### PR TITLE
fix spring CVE by updating spring version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,10 +47,10 @@ java.sourceCompatibility = JavaVersion.VERSION_17
 
 plugins {
     id("io.gitlab.arturbosch.detekt").version("1.19.0")
-    id("org.springframework.boot") version "2.6.4" apply false
+    id("org.springframework.boot") version "2.6.6" apply false
     id("org.jlleitschuh.gradle.ktlint") version "10.2.1"
     kotlin("jvm") version "1.6.10"
-    kotlin("plugin.spring") version "1.6.10" apply false
+    kotlin("plugin.spring") version "1.6.20" apply false
     id("org.sonarqube") version "3.3"
     jacoco
 }

--- a/dataland-backend/build.gradle.kts
+++ b/dataland-backend/build.gradle.kts
@@ -15,7 +15,7 @@ plugins {
     kotlin("plugin.spring")
     jacoco
     id("com.github.johnrengelman.processes") version "0.5.0"
-    id("org.springdoc.openapi-gradle-plugin") version "1.3.3"
+    id("org.springdoc.openapi-gradle-plugin") version "1.3.4"
     id("com.gorylenko.gradle-git-properties") version "2.4.0"
     id("org.springframework.boot")
     kotlin("kapt")


### PR DESCRIPTION
# Pull Request Fix CVE in Spring
This Pull Request fixes a CVE in Spring by updating the spring boot version to 2.6.6
see https://www.dfn-cert.de/aktuell/0day-schwachstelle-spring-framework-apache-tomcat-CVE-2022-22965.html
## Things to do during Peer Review
Please check all boxes before the Pull Request is merged. In case you skip a box, describe in the PRs description (that means: here) why the check is skipped.
- [ ] The code has been manually inspected
- [ ] The new feature was observed "in running software"
- [ ] The DoD was checked for completeness
- [ ] The PR actually implements what is described in the JIRA-Issue
- [ ] At least one E2E Test exists testing the new feature
- [ ] Documentation is updated as required
- [ ] The new version is deployed to preview using this branch
  - [ ] It's verified that this version actually is the one deployed (check actuator/info for branch name and commit id!)
  - [ ] The new feature is manually used/tested/observed on preview