### PR TITLE
Dala 97 adapt dod and pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,12 +2,15 @@
 `<Description here>`
 ## Things to do during Peer Review
 Please check all boxes before the Pull Request is merged. In case you skip a box, describe in the PRs description (that means: here) why the check is skipped.
-- [ ] The code has been manually inspected
-- [ ] The new feature was observed "in running software"
-- [ ] The DoD was checked for completeness
+- [x] The Github Actions (including Sonarqube Gateway and Lint Checks) are green. This is enforced by Github. 
+- [ ] A peer-review has been executed
+  - [ ] The code has been manually inspected by someone who did not implement the feature
+  - [ ] The new feature was observed "in running software"
 - [ ] The PR actually implements what is described in the JIRA-Issue
 - [ ] At least one E2E Test exists testing the new feature
 - [ ] Documentation is updated as required
+- [ ] The automated deployment is updated if required
 - [ ] The new version is deployed to preview using this branch
   - [ ] It's verified that this version actually is the one deployed (check actuator/info for branch name and commit id!)
   - [ ] The new feature is manually used/tested/observed on preview
+- [ ] There is at least one picture for each story, which was created before coding has started

--- a/dataland-frontend/tests/e2e/specs/low/pages/DataSearch.ts
+++ b/dataland-frontend/tests/e2e/specs/low/pages/DataSearch.ts
@@ -35,7 +35,7 @@ describe('Data Search Page Skyminder', function () {
     })
 });
 
-describe.only('Data Search Page Company', function () {
+describe('Data Search Page Company', function () {
     it('page should be present', function () {
         cy.visit("/search")
         cy.get('#app').should("exist")


### PR DESCRIPTION
# Pull Request Adapt PR Template and DoD
This PR adapts the PR Template to the changed DoD. The DoD change is implemented under https://github.com/d-fine/DatalandInternal/wiki/DoD and was agreed on in the retrospective.
## Things to do during Peer Review
Please check all boxes before the Pull Request is merged. In case you skip a box, describe in the PRs description (that means: here) why the check is skipped.
- [x] The Github Actions (including Sonarqube Gateway and Lint Checks) are green. This is enforced by Github.
- [ ] A peer-review has been executed
  - [ ] The code has been manually inspected by someone who did not implement the feature
  - [ ] The new feature was observed "in running software"
- [ ] The PR actually implements what is described in the JIRA-Issue
- [ ] At least one E2E Test exists testing the new feature
- [ ] Documentation is updated as required
- [ ] The automated deployment is updated if required
- [ ] The new version is deployed to preview using this branch
  - [ ] It's verified that this version actually is the one deployed (check actuator/info for branch name and commit id!)
  - [ ] The new feature is manually used/tested/observed on preview
- [ ] There is at least one picture for each story, which was created before coding has started