### PR TITLE
edc version fixed to 0.0.4

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,7 +69,7 @@ services:
   edc-dummyserver:
     restart: always
     profiles: ["testing", "development"]
-    image: ghcr.io/d-fine/datalandedc/edcdummyserver:latest
+    image: ghcr.io/d-fine/datalandedc/edcdummyserver:RELEASE-0.0.4
     networks:
       internal:
         aliases:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,7 +82,7 @@ services:
   dataland-edc:
     restart: always
     profiles: ["production"]
-    image: ghcr.io/d-fine/datalandedc/edcdummyserver:latest
+    image: ghcr.io/d-fine/datalandedc/edcdummyserver:RELEASE-0.0.4
     networks:
      - internal
     expose:

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -21,7 +21,7 @@ dependencyResolutionManagement {
             library("rs-api", "jakarta.ws.rs:jakarta.ws.rs-api:3.1.0")
 
             library("skyminder-client", "org.dataland:skyminder-client:0.1.3")
-            library("dataland-edc-client", "org.dataland:dataland-edc-client:0.0.2")
+            library("dataland-edc-client", "org.dataland:dataland-edc-client:0.0.4")
 
             library("log4j", "org.apache.logging.log4j:log4j:2.17.2")
             library("log4j-api", "org.apache.logging.log4j:log4j-api:2.17.2")


### PR DESCRIPTION
# Pull Request Fix EDC Versio
`The version of the edc clients and server should be fixed to 0.04 in order to keep main deployable and testable.`
## Things to do during Peer Review
Please check all boxes before the Pull Request is merged. In case you skip a box, describe in the PRs description (that means: here) why the check is skipped.
- [x] The Github Actions (including Sonarqube Gateway and Lint Checks) are green. This is enforced by Github. 
- [x] A peer-review has been executed
  - [x] The code has been manually inspected by someone who did not implement the feature
  - [ ] The new feature was observed "in running software"
- [x] The PR actually implements what is described in the JIRA-Issue
- [x] At least one E2E Test exists testing the new feature
- [x] Documentation is updated as required
- [x] The automated deployment is updated if required
- [ ] The new version is deployed to preview using this branch
  - [ ] It's verified that this version actually is the one deployed (check actuator/info for branch name and commit id!)
  - [ ] The new feature is manually used/tested/observed on preview
- [x] There is at least one picture for each story, which was created before coding has started