### PR TITLE
Fix the path to health endpoint of backend

### DIFF
--- a/testing/wait_for_backend_and_run_e2etests.sh
+++ b/testing/wait_for_backend_and_run_e2etests.sh
@@ -6,7 +6,7 @@ set -ex
 
 is_infrastructure_up () {
   declare -A services
-  services["backend"]=http://proxy:80/api/actuator/health/ping
+  services["backend"]=http://proxy:80/api/actuator/health
   services["skyminder-dummyserver"]=http://skyminder-dummyserver:8080/actuator/health
   services["edc-dummyserver"]=http://dataland-edc:9191/api/actuator/health
 


### PR DESCRIPTION
# Pull Request \It's impossible that the actual e2etests start because the script which checks all services won't reach the backend health endpoint
`<Description here>`
## Things to do during Peer Review
Please check all boxes before the Pull Request is merged. In case you skip a box, describe in the PRs description (that means: here) why the check is skipped.
- [x] The Github Actions (including Sonarqube Gateway and Lint Checks) are green. This is enforced by Github. 
- [ ] A peer-review has been executed
  - [ ] The code has been manually inspected by someone who did not implement the feature
  - [ ] The new feature was observed "in running software"
- [ ] The PR actually implements what is described in the JIRA-Issue
- [ ] At least one E2E Test exists testing the new feature
- [ ] Documentation is updated as required
- [ ] The automated deployment is updated if required
- [ ] The new version is deployed to the dev server using this branch
  - [ ] It's verified that this version actually is the one deployed (check actuator/info for branch name and commit id!)
  - [ ] The new feature is manually used/tested/observed on dev server
- [ ] There is at least one picture for each story, which was created before coding has started
- [ ] The local Dev stack still works: execute `startDevelopmentStack.sh`, npm serve, npm teste2e and execute Cypress Tests locally
