### PR TITLE
Get rid of all warnings from github

### DIFF
--- a/.github/workflows/CD.yaml
+++ b/.github/workflows/CD.yaml
@@ -128,7 +128,7 @@ jobs:
           name: parameters
           path: ./*.log
       - name: Login to Github Packages
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/CD.yaml
+++ b/.github/workflows/CD.yaml
@@ -48,7 +48,7 @@ jobs:
         with:
           name: parameters
           path: ./*.log
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v3
         with:
           distribution: temurin
           java-version: 17

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -75,7 +75,7 @@ jobs:
         with:
           name: parameters
           path: ./*.log
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v3
         with:
           distribution: temurin
           java-version: 17
@@ -213,23 +213,23 @@ jobs:
         with:
           name: parameters
           path: ./*.log
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v3
         with:
           distribution: temurin
           java-version: 17
           cache: gradle
       - name: Build project
         run: ./gradlew assemble --no-daemon --stacktrace
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: JaCoCoResultsBackendUnitTests
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: JaCoCoResultsCsvConverterUnitTests
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: JaCoCoResultsE2ETest
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: lcovResults
           path: fe-coverage

--- a/.github/workflows/CypressImage.yaml
+++ b/.github/workflows/CypressImage.yaml
@@ -37,14 +37,14 @@ jobs:
           cp -r /home/runner/.gradle ./gradlecache
           cp -r /home/runner/.cache/Cypress ./cypresscache
       - name: Login to Github Packages
-        uses: docker/login-action@v3
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v2
       - name: Build a cypress base image and push it to GitHub Container Registry
         uses: docker/build-push-action@v3
         with:

--- a/.github/workflows/CypressImage.yaml
+++ b/.github/workflows/CypressImage.yaml
@@ -25,7 +25,7 @@ jobs:
         with:
           name: parameters
           path: ./*.log
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v3
         with:
           distribution: temurin
           java-version: 17
@@ -37,14 +37,14 @@ jobs:
           cp -r /home/runner/.gradle ./gradlecache
           cp -r /home/runner/.cache/Cypress ./cypresscache
       - name: Login to Github Packages
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Build a cypress base image and push it to GitHub Container Registry
         uses: docker/build-push-action@v3
         with:

--- a/.github/workflows/TemurinImage.yaml
+++ b/.github/workflows/TemurinImage.yaml
@@ -35,14 +35,14 @@ jobs:
       - name: Copy the gradle cache into the workspace
         run: cp -r /home/runner/.gradle ./gradlecache
       - name: Login to Github Packages
-        uses: docker/login-action@v3
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v2
       - name: Build an eclipse temurin base image and push it to GitHub Container Registry
         uses: docker/build-push-action@v3
         with:

--- a/.github/workflows/TemurinImage.yaml
+++ b/.github/workflows/TemurinImage.yaml
@@ -25,7 +25,7 @@ jobs:
         with:
           name: parameters
           path: ./*.log
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v3
         with:
           distribution: temurin
           java-version: 17
@@ -35,14 +35,14 @@ jobs:
       - name: Copy the gradle cache into the workspace
         run: cp -r /home/runner/.gradle ./gradlecache
       - name: Login to Github Packages
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Build an eclipse temurin base image and push it to GitHub Container Registry
         uses: docker/build-push-action@v3
         with:


### PR DESCRIPTION
# Update github actions
`update actions`
## Things to do during Peer Review
Please check all boxes before the Pull Request is merged. In case you skip a box, describe in the PRs description (that means: here) why the check is skipped.
- [x] The Github Actions (including Sonarqube Gateway and Lint Checks) are green. This is enforced by Github. 
- [x] A peer-review has been executed
  - [x] The code has been manually inspected by someone who did not implement the feature
- [x] The PR actually implements what is described in the JIRA-Issue
- [ ] At least one E2E Test exists testing the new feature
- [ ] Documentation is updated as required
- [ ] The automated deployment is updated if required
- [x] The new version is deployed to a dev server using this branch
  - [x] It's verified that this version actually is the one deployed (check actuator/info for branch name and commit id!)
  - [x] The new feature is manually used/tested/observed on dev server
  - [ ] All implemented Social Logins have been tested manually in the UI
- [ ] If any work on the UI is to be merged, those changes were also documented in the Figma 
- [ ] The local Dev stack still works: execute `startDevelopmentStack.sh`, execute npm run cypress and run Cypress Tests locally
