### PR TITLE
Dala 1035 prevent dummy uploads when real data is used

### DIFF
--- a/.github/workflows/CD.yaml
+++ b/.github/workflows/CD.yaml
@@ -157,8 +157,6 @@ jobs:
       - name: Get GitHub real data image on demand
         run: |
           if [[ $REALDATA == true ]]; then
-            echo "Removing fake fixture data"
-            rm ./testing/data/CompanyInformationWith*.json
             echo "Retrieving real data"
             docker run -v $(pwd)/testing/data:/testData:rw ghcr.io/d-fine/dataland/datacontainer:0.0.15
           fi

--- a/.github/workflows/CD.yaml
+++ b/.github/workflows/CD.yaml
@@ -157,6 +157,8 @@ jobs:
       - name: Get GitHub real data image on demand
         run: |
           if [[ $REALDATA == true ]]; then
+            echo "Removing fake fixture data"
+            rm ./testing/data/CompanyInformationWith*.json
             echo "Retrieving real data"
             docker run -v $(pwd)/testing/data:/testData:rw ghcr.io/d-fine/dataland/datacontainer:0.0.15
           fi

--- a/dataland-frontend/tests/e2e/specs/prepopulation/AwaitPrepopulation.ts
+++ b/dataland-frontend/tests/e2e/specs/prepopulation/AwaitPrepopulation.ts
@@ -4,27 +4,24 @@ import { getKeycloakToken } from "@e2e/utils/Auth";
 import { reader_name, reader_pw } from "@e2e/utils/Cypress";
 
 describe("I want to ensure that the prepopulation has finished before executing any further tests", () => {
-  let minimumNumberNonFinancialCompanies = 0;
-  let minimumNumberFinancialCompanies = 0;
-  let minimumNumberLksgCompanies = 0;
-  let minimumNumberSfdrCompanies = 0;
-  let minimumNumberSmeCompanies = 0;
+  let expectedNumberOfCompanies = 0;
 
   before(function () {
-    cy.fixture("CompanyInformationWithEuTaxonomyDataForNonFinancials").then(function (companies: []) {
-      minimumNumberNonFinancialCompanies += companies.length;
-    });
-    cy.fixture("CompanyInformationWithEuTaxonomyDataForFinancials").then(function (companies: []) {
-      minimumNumberFinancialCompanies += companies.length;
-    });
-    cy.fixture("CompanyInformationWithLksgData").then(function (companies: []) {
-      minimumNumberLksgCompanies += companies.length;
-    });
-    cy.fixture("CompanyInformationWithSfdrData").then(function (companies: []) {
-      minimumNumberSfdrCompanies += companies.length;
-    });
-    cy.fixture("CompanyInformationWithSmeData").then(function (companies: []) {
-      minimumNumberSmeCompanies += companies.length;
+    const fixtures = [
+      "CompanyInformationWithEuTaxonomyDataForNonFinancials",
+      "CompanyInformationWithEuTaxonomyDataForFinancials",
+    ];
+    if (Cypress.env("DATA_ENVIRONMENT") === "fakeFixtures") {
+      fixtures.push(
+        "CompanyInformationWithLksgData",
+        "CompanyInformationWithSfdrData",
+        "CompanyInformationWithSmeData"
+      );
+    }
+    fixtures.forEach((fixtureFile) => {
+      cy.fixture(fixtureFile).then(function (companies: []) {
+        expectedNumberOfCompanies += companies.length;
+      });
     });
   });
 
@@ -41,29 +38,18 @@ describe("I want to ensure that the prepopulation has finished before executing 
         .then(() => getKeycloakToken(reader_name, reader_pw))
         .then(async (token) => {
           const financialResponse = await countCompanyAndDataIds(token, DataTypeEnum.EutaxonomyFinancials);
-          assert(
-            financialResponse.matchingCompanies >= minimumNumberFinancialCompanies,
-            `Found ${financialResponse.matchingCompanies} financial companies (Expecting at least ${minimumNumberFinancialCompanies})`
-          );
           const nonFinancialResponse = await countCompanyAndDataIds(token, DataTypeEnum.EutaxonomyNonFinancials);
+          let totalCompanies = financialResponse.matchingCompanies + nonFinancialResponse.matchingCompanies;
+          if (Cypress.env("DATA_ENVIRONMENT") === "fakeFixtures") {
+            const lksgResponse = await countCompanyAndDataIds(token, DataTypeEnum.Lksg);
+            const sfdrResponse = await countCompanyAndDataIds(token, DataTypeEnum.Sfdr);
+            const smeResponse = await countCompanyAndDataIds(token, DataTypeEnum.Sme);
+            totalCompanies +=
+              lksgResponse.matchingCompanies + sfdrResponse.matchingCompanies + smeResponse.matchingCompanies;
+          }
           assert(
-            nonFinancialResponse.matchingCompanies >= minimumNumberNonFinancialCompanies,
-            `Found ${nonFinancialResponse.matchingCompanies} non-financial companies (Expecting at least ${minimumNumberNonFinancialCompanies})`
-          );
-          const lksgResponse = await countCompanyAndDataIds(token, DataTypeEnum.Lksg);
-          assert(
-            lksgResponse.matchingCompanies >= minimumNumberLksgCompanies,
-            `Found ${lksgResponse.matchingCompanies} LKSG companies (Expecting at least ${minimumNumberLksgCompanies})`
-          );
-          const sfdrResponse = await countCompanyAndDataIds(token, DataTypeEnum.Sfdr);
-          assert(
-            sfdrResponse.matchingCompanies >= minimumNumberSfdrCompanies,
-            `Found ${sfdrResponse.matchingCompanies} SFDR companies (Expecting at least ${minimumNumberSfdrCompanies})`
-          );
-          const smeResponse = await countCompanyAndDataIds(token, DataTypeEnum.Sme);
-          assert(
-            smeResponse.matchingCompanies >= minimumNumberSmeCompanies,
-            `Found ${smeResponse.matchingCompanies} SME companies (Expecting at least ${minimumNumberSmeCompanies})`
+            totalCompanies >= expectedNumberOfCompanies,
+            `Found ${totalCompanies} companies (Expecting at least ${expectedNumberOfCompanies})`
           );
         });
     }

--- a/dataland-frontend/tests/e2e/specs/prepopulation/Prepopulation.ts
+++ b/dataland-frontend/tests/e2e/specs/prepopulation/Prepopulation.ts
@@ -15,6 +15,7 @@ import { uploadOneEuTaxonomyNonFinancialsDatasetViaApi } from "@e2e/utils/EuTaxo
 import { uploadOneLksgDatasetViaApi } from "@e2e/utils/LksgUpload";
 import { uploadOneSfdrDataset } from "@e2e/utils/SfdrUpload";
 import { uploadOneSmeDataset } from "@e2e/utils/SmeUpload";
+import { describeIf } from "../../support/TestUtility";
 const chunkSize = 15;
 
 describe(
@@ -92,58 +93,79 @@ describe(
       });
     });
 
-    describe("Upload and validate Lksg data", () => {
-      let companiesWithLksgData: Array<FixtureData<LksgData>>;
+    describeIf(
+      "Upload and validate Lksg data",
+      {
+        executionEnvironments: ["developmentLocal", "ci", "developmentCd", "previewCd"],
+        dataEnvironments: ["fakeFixtures"],
+      },
+      () => {
+        let companiesWithLksgData: Array<FixtureData<LksgData>>;
 
-      before(function () {
-        cy.fixture("CompanyInformationWithLksgData").then(function (jsonContent) {
-          companiesWithLksgData = jsonContent as Array<FixtureData<LksgData>>;
+        before(function () {
+          cy.fixture("CompanyInformationWithLksgData").then(function (jsonContent) {
+            companiesWithLksgData = jsonContent as Array<FixtureData<LksgData>>;
+          });
         });
-      });
 
-      it("Upload Lksg fake-fixtures", () => {
-        prepopulate(companiesWithLksgData, uploadOneLksgDatasetViaApi);
-      });
-
-      it("Checks that all the uploaded company ids and data ids can be retrieved", () => {
-        checkMatchingIds(DataTypeEnum.Lksg, companiesWithLksgData.length);
-      });
-    });
-
-    describe("Upload and validate Sfdr data", () => {
-      let companiesWithSfdrData: Array<FixtureData<SfdrData>>;
-
-      before(function () {
-        cy.fixture("CompanyInformationWithSfdrData").then(function (jsonContent) {
-          companiesWithSfdrData = jsonContent as Array<FixtureData<SfdrData>>;
+        it("Upload Lksg fake-fixtures", () => {
+          prepopulate(companiesWithLksgData, uploadOneLksgDatasetViaApi);
         });
-      });
 
-      it("Upload Sfdr fake-fixtures", () => {
-        prepopulate(companiesWithSfdrData, uploadOneSfdrDataset);
-      });
-
-      it("Checks that all the uploaded company ids and data ids can be retrieved", () => {
-        checkMatchingIds(DataTypeEnum.Sfdr, companiesWithSfdrData.length);
-      });
-    });
-
-    describe("Upload and validate Sme data", () => {
-      let companiesWithSmeData: Array<FixtureData<SmeData>>;
-
-      before(function () {
-        cy.fixture("CompanyInformationWithSmeData").then(function (jsonContent) {
-          companiesWithSmeData = jsonContent as Array<FixtureData<SmeData>>;
+        it("Checks that all the uploaded company ids and data ids can be retrieved", () => {
+          checkMatchingIds(DataTypeEnum.Lksg, companiesWithLksgData.length);
         });
-      });
+      }
+    );
 
-      it("Upload Sme fake-fixtures", () => {
-        prepopulate(companiesWithSmeData, uploadOneSmeDataset);
-      });
+    describeIf(
+      "Upload and validate Sfdr data",
+      {
+        executionEnvironments: ["developmentLocal", "ci", "developmentCd", "previewCd"],
+        dataEnvironments: ["fakeFixtures"],
+      },
+      () => {
+        let companiesWithSfdrData: Array<FixtureData<SfdrData>>;
 
-      it("Checks that all the uploaded company ids and data ids can be retrieved", () => {
-        checkMatchingIds(DataTypeEnum.Sme, companiesWithSmeData.length);
-      });
-    });
+        before(function () {
+          cy.fixture("CompanyInformationWithSfdrData").then(function (jsonContent) {
+            companiesWithSfdrData = jsonContent as Array<FixtureData<SfdrData>>;
+          });
+        });
+
+        it("Upload Sfdr fake-fixtures", () => {
+          prepopulate(companiesWithSfdrData, uploadOneSfdrDataset);
+        });
+
+        it("Checks that all the uploaded company ids and data ids can be retrieved", () => {
+          checkMatchingIds(DataTypeEnum.Sfdr, companiesWithSfdrData.length);
+        });
+      }
+    );
+
+    describeIf(
+      "Upload and validate Sme data",
+      {
+        executionEnvironments: ["developmentLocal", "ci", "developmentCd", "previewCd"],
+        dataEnvironments: ["fakeFixtures"],
+      },
+      () => {
+        let companiesWithSmeData: Array<FixtureData<SmeData>>;
+
+        before(function () {
+          cy.fixture("CompanyInformationWithSmeData").then(function (jsonContent) {
+            companiesWithSmeData = jsonContent as Array<FixtureData<SmeData>>;
+          });
+        });
+
+        it("Upload Sme fake-fixtures", () => {
+          prepopulate(companiesWithSmeData, uploadOneSmeDataset);
+        });
+
+        it("Checks that all the uploaded company ids and data ids can be retrieved", () => {
+          checkMatchingIds(DataTypeEnum.Sme, companiesWithSmeData.length);
+        });
+      }
+    );
   }
 );

--- a/dataland-frontend/tests/e2e/specs/prepopulation/Prepopulation.ts
+++ b/dataland-frontend/tests/e2e/specs/prepopulation/Prepopulation.ts
@@ -14,7 +14,7 @@ import { uploadOneEuTaxonomyFinancialsDatasetViaApi } from "@e2e/utils/EuTaxonom
 import { uploadOneEuTaxonomyNonFinancialsDatasetViaApi } from "@e2e/utils/EuTaxonomyNonFinancialsUpload";
 import { uploadOneLksgDatasetViaApi } from "@e2e/utils/LksgUpload";
 import { uploadOneSfdrDataset } from "@e2e/utils/SfdrUpload";
-import { uploadOneSmeDataset } from "../../utils/SmeUpload";
+import { uploadOneSmeDataset } from "@e2e/utils/SmeUpload";
 const chunkSize = 15;
 
 describe(


### PR DESCRIPTION
# DALA 1035
`disable upload of data for frameworks that do not have real data`
## Things to do during Peer Review
Please check all boxes before the Pull Request is merged. In case you skip a box, describe in the PRs description (that means: here) why the check is skipped.
- [x] The Github Actions (including Sonarqube Gateway and Lint Checks) are green. This is enforced by Github. 
- [x] A peer-review has been executed
  - [x] The code has been manually inspected by someone who did not implement the feature
- [x] The PR actually implements what is described in the JIRA-Issue
- [x] At least one E2E Test exists testing the new feature
- [x] Documentation is updated as required
- [x] The automated deployment is updated if required
- [x] The new version is deployed to the dev server "dev1" using this branch
  - [x] It's verified that this version actually is the one deployed (check gitinfo for branch name and commit id!)
  - [x] The new feature is manually used/tested/observed on dev server
  - [x] All implemented Social Logins have been tested manually in the UI
- [x] If any work on the UI is to be merged, those changes were also documented in the Figma 
