### PR TITLE
Dala 2757 fix technical user handling

### DIFF
--- a/deployment/initialize_keycloak.sh
+++ b/deployment/initialize_keycloak.sh
@@ -30,7 +30,7 @@ docker logs "$keycloak_initializer_container_name"
 if ls "$keycloak_user_dir"/*-users-*.json &>/dev/null; then
   echo "Testing if the number of current users matches the number of exported users"
   exported_users=$(sudo docker exec "$keycloak_initializer_container_name" bash -c 'grep -l username /keycloak_users/datalandsecurity-users-*.json | wc -l')
-  exported_expected_technical_users=$(sudo docker exec --env USER_PATTERN='"username" : "((data_(reader|uploader|reviewer|admin))|service-account-dataland-batch-manager)"' "$keycloak_initializer_container_name" bash -c 'grep -E -l "$USER_PATTERN" /keycloak_users/datalandsecurity-users-*.json | wc -l')
+  exported_expected_technical_users=$(sudo docker exec --env USER_PATTERN='"username" : "(data_(reader|uploader|reviewer|admin)|service-account-dataland-batch-manager)"' "$keycloak_initializer_container_name" bash -c 'grep -E -l "$USER_PATTERN" /keycloak_users/datalandsecurity-users-*.json | wc -l')
   exported_test_users=$(sudo docker exec "$keycloak_initializer_container_name" bash -c 'grep -E -l \"test_user.*@dataland.com\" /keycloak_users/datalandsecurity-users-*.json | wc -l')
   exported_actual_users=$((exported_users-exported_test_users-exported_expected_technical_users))
 

--- a/deployment/initialize_keycloak.sh
+++ b/deployment/initialize_keycloak.sh
@@ -30,7 +30,7 @@ docker logs "$keycloak_initializer_container_name"
 if ls "$keycloak_user_dir"/*-users-*.json &>/dev/null; then
   echo "Testing if the number of current users matches the number of exported users"
   exported_users=$(sudo docker exec "$keycloak_initializer_container_name" bash -c 'grep -l username /keycloak_users/datalandsecurity-users-*.json | wc -l')
-  exported_expected_technical_users=$(sudo docker exec --env USER_PATTERN='"username" : "(data_(reader|uploader|reviewer|admin))|service-account-dataland-batch-manager"' "$keycloak_initializer_container_name" bash -c 'grep -E -l "$USER_PATTERN" /keycloak_users/datalandsecurity-users-*.json | wc -l')
+  exported_expected_technical_users=$(sudo docker exec --env USER_PATTERN='"username" : "((data_(reader|uploader|reviewer|admin))|service-account-dataland-batch-manager)"' "$keycloak_initializer_container_name" bash -c 'grep -E -l "$USER_PATTERN" /keycloak_users/datalandsecurity-users-*.json | wc -l')
   exported_test_users=$(sudo docker exec "$keycloak_initializer_container_name" bash -c 'grep -E -l \"test_user.*@dataland.com\" /keycloak_users/datalandsecurity-users-*.json | wc -l')
   exported_actual_users=$((exported_users-exported_test_users-exported_expected_technical_users))
 


### PR DESCRIPTION
# Pull Request \<Title>
`<Description here>`
## Things to do during Peer Review
Please check all boxes before the Pull Request is merged. In case you skip a box, describe in the PRs description (that means: here) why the check is skipped.
- [x] The Github Actions (including Sonarqube Gateway and Lint Checks) are green. This is enforced by Github. 
- [x] A peer-review has been executed
  - [x] The code has been manually inspected by someone who did not implement the feature
- [x] The PR actually implements what is described in the JIRA-Issue
- [x] At least one test exists testing the new feature
  - [x] If you have created new test files, make sure that they are included in a test container and actually run in the CI
- [x] Documentation is updated as required
- [x] The automated deployment is updated if required
- [x] If there was a database entity class added, there must also be a migration script for creating the corresponding database if flyway is already used by the service
- [ ] IF there are changes done to the framework data models or to a database entity class, the following steps were completed in order
  - [ ] The version of main currently active on prod is deployed to a dev server with `Reset non-user related Docker Volumes & Re-populate` turned on
  - [ ] It's verified that the CD run is green
  - [ ] The data from prod is migrated using `./migrateData.sh dataland.com <SOURCE_API_KEY> <TARGET> <TARGET_API_KEY>` 
  - [ ] The feature branch is deployed to the same server with `Reset non-user related Docker Volumes & Re-populate` turned off
  - [ ] It's verified that the CD run is green
  - [ ] The new feature is manually used/tested/observed on the dev server
- [x] ELSE, the new version is deployed to the dev server "dev1" using this branch
  - [x] Run with setting `Reset non-user related Docker Volumes & Re-populate` turned on 
  - [x] It's verified that this version actually is the one deployed (check gitinfo for branch name and commit id!)
  - [x] It's verified that the CD run is green
  - [x] The new feature is manually used/tested/observed on dev server
- [x] Make sure that pull requests in the development tools repository, which are connected to this pull requests, 
are merged