### PR TITLE
Fix flaky e2e tests

### DIFF
--- a/dataland-frontend/tests/component/components/pages/LandingPage.cy.ts
+++ b/dataland-frontend/tests/component/components/pages/LandingPage.cy.ts
@@ -68,7 +68,7 @@ function validateBrandsSection(): void {
  */
 function checkNewFooter(): void {
   cy.get("footer").should("exist");
-  //move to footer section component test
+
   checkImage("Copyright ©   Dataland", getSingleImageNameInSection("Footer"));
   cy.get(".footer__copyright").should("contain.text", `Copyright © ${new Date().getFullYear()} Dataland`);
 

--- a/dataland-frontend/tests/component/components/pages/LandingPage.cy.ts
+++ b/dataland-frontend/tests/component/components/pages/LandingPage.cy.ts
@@ -68,6 +68,7 @@ function validateBrandsSection(): void {
  */
 function checkNewFooter(): void {
   cy.get("footer").should("exist");
+  //move to footer section component test
   checkImage("Copyright ©   Dataland", getSingleImageNameInSection("Footer"));
   cy.get(".footer__copyright").should("contain.text", `Copyright © ${new Date().getFullYear()} Dataland`);
 

--- a/dataland-frontend/tests/e2e/specs/landing-page/LandingPage.ts
+++ b/dataland-frontend/tests/e2e/specs/landing-page/LandingPage.ts
@@ -3,11 +3,11 @@ describe("Check that the Landing Page to work properly", () => {
     cy.intercept({ url: "https://www.youtube-nocookie.com/**" }, { forceNetworkError: false }).as("youtube");
     cy.visitAndCheckAppMount("/");
     cy.wait("@youtube");
-    //are in register test
+
     cy.get("a:contains('Login')").click();
     cy.url().should("include", "/keycloak/realms/datalandsecurity/protocol/openid-connect/auth");
     cy.get("span:contains('HOME')").click();
-    //are in register test
+
     cy.get(`button[name="signup_dataland_button"]`).click();
     cy.url().should("include", "/keycloak/realms/datalandsecurity/protocol/openid-connect/registrations");
     cy.get("span:contains('HOME')").click();

--- a/dataland-frontend/tests/e2e/specs/landing-page/LandingPage.ts
+++ b/dataland-frontend/tests/e2e/specs/landing-page/LandingPage.ts
@@ -1,11 +1,13 @@
 describe("Check that the Landing Page to work properly", () => {
   it("Check the links and buttons", () => {
+    cy.intercept({ url: "https://www.youtube-nocookie.com/**" }, { forceNetworkError: false }).as("youtube");
     cy.visitAndCheckAppMount("/");
-
+    cy.wait("@youtube");
+    //are in register test
     cy.get("a:contains('Login')").click();
     cy.url().should("include", "/keycloak/realms/datalandsecurity/protocol/openid-connect/auth");
     cy.get("span:contains('HOME')").click();
-
+    //are in register test
     cy.get(`button[name="signup_dataland_button"]`).click();
     cy.url().should("include", "/keycloak/realms/datalandsecurity/protocol/openid-connect/registrations");
     cy.get("span:contains('HOME')").click();

--- a/dataland-frontend/tests/e2e/specs/user-authentication/Register.ts
+++ b/dataland-frontend/tests/e2e/specs/user-authentication/Register.ts
@@ -8,7 +8,7 @@ describe("As a user I want to be able to register for an account and be able to 
   const randomHexPassword = [...passwordBytes].map((x): string => x.toString(16).padStart(2, "0")).join("");
 
   it("Checks that the Dataland password-policy gets respected", () => {
-    cy.intercept({ url: "https://www.youtube.com/**" }, { forceNetworkError: false }).as("youtube");
+    cy.intercept({ url: "https://www.youtube-nocookie.com/**" }, { forceNetworkError: false }).as("youtube");
     cy.visitAndCheckAppMount("/")
       .wait("@youtube")
       .get("button[name='signup_dataland_button']")

--- a/dataland-frontend/tests/e2e/specs/user-authentication/Register.ts
+++ b/dataland-frontend/tests/e2e/specs/user-authentication/Register.ts
@@ -8,7 +8,9 @@ describe("As a user I want to be able to register for an account and be able to 
   const randomHexPassword = [...passwordBytes].map((x): string => x.toString(16).padStart(2, "0")).join("");
 
   it("Checks that the Dataland password-policy gets respected", () => {
+    cy.intercept({ url: "https://www.youtube.com/**" }, { forceNetworkError: false }).as("youtube");
     cy.visitAndCheckAppMount("/")
+      .wait("@youtube")
       .get("button[name='signup_dataland_button']")
       .click()
       .get("#email")


### PR DESCRIPTION
# Pull Request \<Title>
`<Description here>`
## Things to do during Peer Review
Please check all boxes before the Pull Request is merged. In case you skip a box, describe in the PRs description (that means: here) why the check is skipped.
- [x] The Github Actions (including Sonarqube Gateway and Lint Checks) are green. This is enforced by Github. 
- [x] A peer-review has been executed
  - [x] The code has been manually inspected by someone who did not implement the feature
- [x] The PR actually implements what is described in the JIRA-Issue
- [x] At least one test exists testing the new feature
  - [x] If you have created new test files, make sure that they are included in a test container and actually run in the CI
- [x] Documentation is updated as required
- [x] The automated deployment is updated if required
- [x] If there was a database entity class added, there must also be a migration script for creating the corresponding database if flyway is already used by the service
- [x] IF there are changes done to the framework data models or to a database entity class, the following steps were completed in order
  - [x] The version of main currently active on prod is deployed to a dev server with `Reset non-user related Docker Volumes & Re-populate` turned on
  - [x] It's verified that the CD run is green
  - [x] The data from prod is migrated using `./migrateData.sh dataland.com <SOURCE_API_KEY> <TARGET> <TARGET_API_KEY>` 
  - [x] The feature branch is deployed to the same server with `Reset non-user related Docker Volumes & Re-populate` turned off
  - [x] It's verified that the CD run is green
  - [x] The new feature is manually used/tested/observed on the dev server
- [x] ELSE, the new version is deployed to the dev server "dev1" using this branch
  - [x] Run with setting `Reset non-user related Docker Volumes & Re-populate` turned on 
  - [x] It's verified that this version actually is the one deployed (check gitinfo for branch name and commit id!)
  - [x] It's verified that the CD run is green
  - [x] The new feature is manually used/tested/observed on dev server
- [x] Make sure that pull requests in the development tools repository, which are connected to this pull requests, 
are merged