### PR TITLE
make start script more verbose

### DIFF
--- a/startDevelopmentStack.sh
+++ b/startDevelopmentStack.sh
@@ -17,7 +17,7 @@ source ./*github_env.log
 source ./environments/.env.uncritical
 set +o allexport
 
-log_folder="./log/build/$(date '+%Y%m%d_%H%M')"
+log_folder="./log/build/"
 mkdir -p "$log_folder"
 
 for rebuild_script in ./build-utils/rebuild*.sh; do
@@ -29,7 +29,9 @@ for rebuild_script in ./build-utils/rebuild*.sh; do
   $rebuild_script &> "./$log_folder/$(basename "$rebuild_script").log" &
 done
 
-echo "Waiting for all processes to terminate."
+sleep 5
+echo "Waiting for all build processes to terminate."
+echo "Progress may be monitored using the logs in $log_folder"
 wait
 
 set -o allexport


### PR DESCRIPTION
# Pull Request \<Title>
`<Description here>`
## Things to do during Peer Review
Please check all boxes before the Pull Request is merged. In case you skip a box, describe in the PRs description (that means: here) why the check is skipped.
- [x] The Github Actions (including Sonarqube Gateway and Lint Checks) are green. This is enforced by Github. 
- [x] A peer-review has been executed
  - [x] The code has been manually inspected by someone who did not implement the feature
- [ ] The PR actually implements what is described in the JIRA-Issue
- [ ] At least one test exists testing the new feature
  - [ ] If you have created new test files, make sure that they are included in a test container and actually run in the CI
- [x] At least 3 consecutive CI runs are successfully executed to ensure that there are no flaky tests.
- [x] Documentation is updated as required
- [x] The automated deployment is updated if required
- [ ] If there was a database entity class added, there must also be a migration script for creating the corresponding database if flyway is already used by the service
- [ ] IF there are changes done to the framework data models or to a database entity class, the following steps were completed in order
  - [ ] A fresh clone of dataland.com is generated (see Wiki page on "OTC" for details)
  - [ ] The feature branch is deployed to clone with `Reset non-user related Docker Volumes & Re-populate` turned off
  - [ ] It's verified that the CD run is green
  - [ ] The new feature is manually used/tested/observed on the clone server
  - [ ] The feature branch is deployed to dev1 with `Reset non-user related Docker Volumes & Re-populate` turned on, and it's verified that the CD run is green  
- [x] ELSE, the new version is deployed to the dev server "dev1" using this branch
  - [x] Run with setting `Reset non-user related Docker Volumes & Re-populate` turned on 
  - [x] It's verified that this version actually is the one deployed (check gitinfo for branch name and commit id!)
  - [x] It's verified that the CD run is green
  - [x] The new feature is manually used/tested/observed on dev server