### PR TITLE
Dala 4379 login bug

### DIFF
--- a/dataland-frontend/.prettierignore
+++ b/dataland-frontend/.prettierignore
@@ -1,0 +1,2 @@
+# Ignore all HTML files:
+**/silent-check-sso.html

--- a/dataland-frontend/public/static/silent-check-sso.html
+++ b/dataland-frontend/public/static/silent-check-sso.html
@@ -1,10 +1,10 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
+<head>
+    <meta charset="UTF-8">
     <title>Title</title>
-  </head>
-  <script>
-    parent.postMessage(location.href, location.origin);
-  </script>
+</head>
+<script>
+    parent.postMessage(location.href, location.origin)
+</script>
 </html>

--- a/dataland-frontend/public/static/silent-check-sso.html
+++ b/dataland-frontend/public/static/silent-check-sso.html
@@ -1,9 +1,9 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
+  <head>
+    <meta charset="UTF-8" />
     <title>Title</title>
-</head>
+  </head>
 <script>
     parent.postMessage(location.href, location.origin)
 </script>

--- a/dataland-frontend/src/components/pages/NewLandingPage.vue
+++ b/dataland-frontend/src/components/pages/NewLandingPage.vue
@@ -1,5 +1,5 @@
 <template>
-  <TheHeader :landingPage="landingPage" />
+  <TheNewHeader :landingPage="landingPage" />
   <main role="main">
     <TheIntro :sections="landingPage?.sections" />
     <TheQuotes :sections="landingPage?.sections" />
@@ -19,7 +19,7 @@ import { useDialog } from 'primevue/usedialog';
 import SessionDialog from '@/components/general/SessionDialog.vue';
 import { SessionDialogMode } from '@/utils/SessionTimeoutUtils';
 
-import TheHeader from '@/components/generics/TheNewHeader.vue';
+import TheNewHeader from '@/components/generics/TheNewHeader.vue';
 import TheIntro from '@/components/resources/newLandingPage/TheIntro.vue';
 import TheQuotes from '@/components/resources/newLandingPage/TheQuotes.vue';
 import TheBrands from '@/components/resources/newLandingPage/TheBrands.vue';


### PR DESCRIPTION
# Pull Request \<Title>
`<Description here>`
## Things to do during Peer Review
Please check all boxes before the Pull Request is merged. In case you skip a box, describe in the PRs description (that means: here) why the check is skipped.
- [x] The Github Actions (including Sonarqube Gateway and Lint Checks) are green. This is enforced by Github. 
- [x] A peer-review has been executed
  - [x] The code has been manually inspected by someone who did not implement the feature
  - [x] If this PR includes work on the frontend, at least one `@ts-nocheck` is removed. Additionally, there should not be any `@ts-nocheck` in files modified by this PR. If no `@ts-nocheck` are left: Celebrate :tada: :confetti_ball: type-safety and remove this entry. 
- [x] The PR actually implements what is described in the JIRA-Issue
- [ ] At least one test exists testing the new feature
  - [ ] If you have created new test files, make sure that they are included in a test container and actually run in the CI
- [ ] At least 3 consecutive CI runs are successfully executed to ensure that there are no flaky tests.
- [x] Documentation is updated as required
- [x] The automated deployment is updated if required
- [ ] If there was a database entity class added, there must also be a migration script for creating the corresponding database if flyway is already used by the service
- [ ] IF there are changes done to the framework data models or to a database entity class, the following steps were completed in order
  - [ ] A fresh clone of dataland.com is generated (see Wiki page on "OTC" for details)
  - [ ] The feature branch is deployed to clone with `Reset non-user related Docker Volumes & Re-populate` turned off
  - [ ] It's verified that the CD run is green
  - [ ] The new feature is manually used/tested/observed on the clone server. Testing of the new feature should (also) be done by a second, independent reviewer from the dev team
  - [ ] The feature branch is deployed to dev1 with `Reset non-user related Docker Volumes & Re-populate` turned on, and it's verified that the CD run is green  
- [x] ELSE, the new version is deployed to the dev server "dev1" using this branch
  - [x] Run with setting `Reset non-user related Docker Volumes & Re-populate` turned on 
  - [x] It's verified that this version actually is the one deployed (check gitinfo for branch name and commit id!)
  - [x] It's verified that the CD run is green
  - [x] The new feature is manually used/tested/observed on dev server. Testing of the new feature should (also) be done by a second, independent reviewer from the dev team