### PR TITLE
cleaner fix for login bug via security headers

### DIFF
--- a/dataland-frontend/.prettierignore
+++ b/dataland-frontend/.prettierignore
@@ -1,2 +1,0 @@
-# Ignore all HTML files:
-**/silent-check-sso.html

--- a/dataland-frontend/public/static/silent-check-sso.html
+++ b/dataland-frontend/public/static/silent-check-sso.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <title>Title</title>
   </head>
-<script>
-    parent.postMessage(location.href, location.origin)
-</script>
+  <script>
+    parent.postMessage(location.href, location.origin);
+  </script>
 </html>

--- a/dataland-frontend/tests/e2e/specs/infrastructure/VerifyHeaders.ts
+++ b/dataland-frontend/tests/e2e/specs/infrastructure/VerifyHeaders.ts
@@ -28,7 +28,7 @@ describe('As a developer, I want to ensure that security relevant headers are se
   }
 
   const cspHeaders =
-    "frame-src 'self' data: https://www.youtube.com https://consentcdn.cookiebot.com; script-src-elem 'self' 'unsafe-eval' 'sha256-/0dJfWlZ9/P1qMKyXvELqM6+ycG3hol3gmKln32el8o=' https://consent.cookiebot.com https://consentcdn.cookiebot.com https://www.youtube.com/; style-src 'self' 'unsafe-inline'; frame-ancestors 'self'; form-action 'self'; font-src 'self' data:; img-src 'self' data: https://*.googleusercontent.com/ https://*.licdn.com/ https://consent.cookiebot.com https://i.ytimg.com/ https://img.youtube.com/";
+    "frame-src 'self' data: https://www.youtube.com https://consentcdn.cookiebot.com; script-src-elem 'self' 'unsafe-eval' 'sha256-Ufh4gFF+3wijVQyJo86U1jiXhiwxTNfKBjPqBWLdvEY=' https://consent.cookiebot.com https://consentcdn.cookiebot.com https://www.youtube.com/; style-src 'self' 'unsafe-inline'; frame-ancestors 'self'; form-action 'self'; font-src 'self' data:; img-src 'self' data: https://*.googleusercontent.com/ https://*.licdn.com/ https://consent.cookiebot.com https://i.ytimg.com/ https://img.youtube.com/";
 
   describeIf(
     'Check CSP headers in the local development environment',

--- a/dataland-inbound-proxy/config/utils/securityHeaderMap.conf
+++ b/dataland-inbound-proxy/config/utils/securityHeaderMap.conf
@@ -1,7 +1,8 @@
 # Default http security headers to be added if not set already
 
+# Warning:
 map $upstream_http_content_security_policy $default_content_security_policy {
-        "" "frame-src 'self' data: https://www.youtube.com https://consentcdn.cookiebot.com; script-src-elem 'self' 'unsafe-eval' 'sha256-/0dJfWlZ9/P1qMKyXvELqM6+ycG3hol3gmKln32el8o=' https://consent.cookiebot.com https://consentcdn.cookiebot.com https://www.youtube.com/; style-src 'self' 'unsafe-inline'; frame-ancestors 'self'; form-action 'self'; font-src 'self' data:; img-src 'self' data: https://*.googleusercontent.com/ https://*.licdn.com/ https://consent.cookiebot.com https://i.ytimg.com/ https://img.youtube.com/";
+        "" "frame-src 'self' data: https://www.youtube.com https://consentcdn.cookiebot.com; script-src-elem 'self' 'unsafe-eval' 'sha256-Ufh4gFF+3wijVQyJo86U1jiXhiwxTNfKBjPqBWLdvEY=' https://consent.cookiebot.com https://consentcdn.cookiebot.com https://www.youtube.com/; style-src 'self' 'unsafe-inline'; frame-ancestors 'self'; form-action 'self'; font-src 'self' data:; img-src 'self' data: https://*.googleusercontent.com/ https://*.licdn.com/ https://consent.cookiebot.com https://i.ytimg.com/ https://img.youtube.com/";
     }
 
 map $upstream_http_referrer_policy $default_referrer_policy {


### PR DESCRIPTION
# Pull Request \<Title>
`<Description here>`
## Things to do during Peer Review
Please check all boxes before the Pull Request is merged. In case you skip a box, describe in the PRs description (that means: here) why the check is skipped.
- [x] The Github Actions (including Sonarqube Gateway and Lint Checks) are green. This is enforced by Github. 
- [x] A peer-review has been executed
  - [x] The code has been manually inspected by someone who did not implement the feature
  - [x] If this PR includes work on the frontend, at least one `@ts-nocheck` is removed. Additionally, there should not be any `@ts-nocheck` in files modified by this PR. If no `@ts-nocheck` are left: Celebrate :tada: :confetti_ball: type-safety and remove this entry. 
- [x] The PR actually implements what is described in the JIRA-Issue
- [x] At least one test exists testing the new feature
  - [x] If you have created new test files, make sure that they are included in a test container and actually run in the CI
- [x] At least 3 consecutive CI runs are successfully executed to ensure that there are no flaky tests.
- [x] Documentation is updated as required
- [x] The automated deployment is updated if required
- [x] If there was a database entity class added, there must also be a migration script for creating the corresponding database if flyway is already used by the service
- [ ] IF there are changes done to the framework data models or to a database entity class, the following steps were completed in order
  - [ ] A fresh clone of dataland.com is generated (see Wiki page on "OTC" for details)
  - [ ] The feature branch is deployed to clone with `Reset non-user related Docker Volumes & Re-populate` turned off
  - [ ] It's verified that the CD run is green
  - [ ] The new feature is manually used/tested/observed on the clone server. Testing of the new feature should (also) be done by a second, independent reviewer from the dev team
  - [ ] The feature branch is deployed to dev1 with `Reset non-user related Docker Volumes & Re-populate` turned on, and it's verified that the CD run is green  
- [x] ELSE, the new version is deployed to the dev server "dev1" using this branch
  - [x] Run with setting `Reset non-user related Docker Volumes & Re-populate` turned on 
  - [x] It's verified that this version actually is the one deployed (check gitinfo for branch name and commit id!)
  - [x] It's verified that the CD run is green
  - [x] The new feature is manually used/tested/observed on dev server. Testing of the new feature should (also) be done by a second, independent reviewer from the dev team