### PR TITLE
DALA-4305 Inform IR about data uploads if no company owner

### DIFF
--- a/dataland-community-manager/src/main/kotlin/org/dataland/datalandcommunitymanager/entities/ElementaryEventEntity.kt
+++ b/dataland-community-manager/src/main/kotlin/org/dataland/datalandcommunitymanager/entities/ElementaryEventEntity.kt
@@ -1,0 +1,28 @@
+package org.dataland.datalandcommunitymanager.entities
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.dataland.datalandbackend.openApiClient.model.DataTypeEnum
+import org.dataland.datalandcommunitymanager.events.EventType
+import java.util.UUID
+
+@Entity
+@Table(name = "elementary_events")
+data class ElementaryEventEntity (
+    @Id
+    val elementaryEventId: String = UUID.randomUUID().toString(),
+
+    @Column(columnDefinition = "TEXT")
+    val eventType: EventType,
+
+    @Column(columnDefinition = "TEXT")
+    val companyId: String,
+
+    @Column(columnDefinition = "TEXT")
+    val framework: DataTypeEnum,
+
+    @Column(columnDefinition = "LONG")
+    val creationTimestamp: Long,
+)

--- a/dataland-community-manager/src/main/kotlin/org/dataland/datalandcommunitymanager/entities/NotificationEventEntity.kt
+++ b/dataland-community-manager/src/main/kotlin/org/dataland/datalandcommunitymanager/entities/NotificationEventEntity.kt
@@ -1,0 +1,24 @@
+package org.dataland.datalandcommunitymanager.entities
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.util.UUID
+
+@Entity
+@Table(name = "notification_event")
+data class NotificationEventEntity(
+    @Id
+    val notificationEventId: String = UUID.randomUUID().toString(),
+
+    @Column(columnDefinition = "TEXT")
+    val elementaryEventIds: String,
+
+    @Column(columnDefinition = "LONG")
+    val creationTimestamp: Long,
+){
+    init {
+        require(elementaryEventIds.isNotEmpty())
+    }
+}

--- a/dataland-community-manager/src/main/kotlin/org/dataland/datalandcommunitymanager/events/EventType.kt
+++ b/dataland-community-manager/src/main/kotlin/org/dataland/datalandcommunitymanager/events/EventType.kt
@@ -1,0 +1,6 @@
+package org.dataland.datalandcommunitymanager.events
+
+enum class EventType {
+    uploadEvent,
+    requestEvent,
+}

--- a/dataland-community-manager/src/main/kotlin/org/dataland/datalandcommunitymanager/repositories/ElementaryEventRepository.kt
+++ b/dataland-community-manager/src/main/kotlin/org/dataland/datalandcommunitymanager/repositories/ElementaryEventRepository.kt
@@ -1,0 +1,7 @@
+package org.dataland.datalandcommunitymanager.repositories
+
+import org.dataland.datalandcommunitymanager.entities.ElementaryEventEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface ElementaryEventRepository : JpaRepository<ElementaryEventEntity, String> {
+}

--- a/dataland-community-manager/src/main/kotlin/org/dataland/datalandcommunitymanager/repositories/NotificationEventRepository.kt
+++ b/dataland-community-manager/src/main/kotlin/org/dataland/datalandcommunitymanager/repositories/NotificationEventRepository.kt
@@ -1,0 +1,7 @@
+package org.dataland.datalandcommunitymanager.repositories
+
+import org.dataland.datalandcommunitymanager.entities.NotificationEventEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface NotificationEventRepository : JpaRepository<NotificationEventEntity, String> {
+}

--- a/dataland-community-manager/src/main/kotlin/org/dataland/datalandcommunitymanager/services/NotificationService.kt
+++ b/dataland-community-manager/src/main/kotlin/org/dataland/datalandcommunitymanager/services/NotificationService.kt
@@ -1,0 +1,18 @@
+package org.dataland.datalandcommunitymanager.services
+
+import org.springframework.stereotype.Service
+
+@Service("NotificationService")
+class NotificationService {
+
+    fun triggerNotificationEvent(): Boolean {
+        //TODO
+        return false
+    }
+
+    fun sendSingleEmailMessageToQueue() {}
+
+    fun sendSummaryEmailMessageToQueue() {}
+
+    fun createNotificationEntry() {}
+}


### PR DESCRIPTION
# Pull Request \<Title>
`<Description here>`
## Things to do during Peer Review
Please check all boxes before the Pull Request is merged. In case you skip a box, describe in the PRs description (that means: here) why the check is skipped.
- [x] The Github Actions (including Sonarqube Gateway and Lint Checks) are green. This is enforced by Github. 
- [ ] A peer-review has been executed
  - [ ] The code has been manually inspected by someone who did not implement the feature
  - [ ] If this PR includes work on the frontend, at least one `@ts-nocheck` is removed. Additionally, there should not be any `@ts-nocheck` in files modified by this PR. If no `@ts-nocheck` are left: Celebrate :tada: :confetti_ball: type-safety and remove this entry. 
- [ ] The PR actually implements what is described in the JIRA-Issue
- [ ] At least one test exists testing the new feature
  - [ ] If you have created new test files, make sure that they are included in a test container and actually run in the CI
- [ ] At least 3 consecutive CI runs are successfully executed to ensure that there are no flaky tests.
- [ ] Documentation is updated as required
- [ ] The automated deployment is updated if required
- [ ] If there was a database entity class added, there must also be a migration script for creating the corresponding database if flyway is already used by the service
- [ ] IF there are changes done to the framework data models or to a database entity class, the following steps were completed in order
  - [ ] A fresh clone of dataland.com is generated (see Wiki page on "OTC" for details)
  - [ ] The feature branch is deployed to clone with `Reset non-user related Docker Volumes & Re-populate` turned off
  - [ ] It's verified that the CD run is green
  - [ ] The new feature is manually used/tested/observed on the clone server. Testing of the new feature should (also) be done by a second, independent reviewer from the dev team
  - [ ] The feature branch is deployed to dev1 with `Reset non-user related Docker Volumes & Re-populate` turned on, and it's verified that the CD run is green  
- [ ] ELSE, the new version is deployed to the dev server "dev1" using this branch
  - [ ] Run with setting `Reset non-user related Docker Volumes & Re-populate` turned on 
  - [ ] It's verified that this version actually is the one deployed (check gitinfo for branch name and commit id!)
  - [ ] It's verified that the CD run is green
  - [ ] The new feature is manually used/tested/observed on dev server. Testing of the new feature should (also) be done by a second, independent reviewer from the dev team