### PR TITLE
Dala-4583 page null bug and DALA-4220 make document links left aligned

### DIFF
--- a/dataland-frontend/src/components/general/DataPointDataTable.vue
+++ b/dataland-frontend/src/components/general/DataPointDataTable.vue
@@ -77,7 +77,7 @@ export default defineComponent({
       const dataSource = this.dialogData.dataPointDisplay.dataSource;
       if (!dataSource) return '';
       if ('page' in dataSource) {
-        return `${dataSource.fileName}, page ${dataSource.page}`;
+        return dataSource.page === null ? `${dataSource.fileName}` : `${dataSource.fileName}, page ${dataSource.page}`;
       } else {
         return dataSource.fileName ?? '';
       }

--- a/dataland-frontend/src/components/resources/frameworkDataSearch/DocumentLink.vue
+++ b/dataland-frontend/src/components/resources/frameworkDataSearch/DocumentLink.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    style="position: relative; display: flex; align-items: center; justify-content: center"
+    style="position: relative; display: flex; align-items: center; justify-content: flex-start"
     data-test="download-link"
   >
     <span @click="downloadDocument()" class="text-primary cursor-pointer" :class="fontStyle" style="flex: 0 0 auto">

--- a/dataland-frontend/tests/component/components/resources/frameworkDataSearch/DocumentLink.cy.ts
+++ b/dataland-frontend/tests/component/components/resources/frameworkDataSearch/DocumentLink.cy.ts
@@ -19,7 +19,7 @@ describe('check that the progress spinner works correctly for the document link 
       },
     }).then(() => {
       validateNoIcons();
-      cy.get("[data-test='download-link']").should('exist').click();
+      cy.get("[data-test='Report-Download-Test']").should('exist').click();
       cy.wait('@downloadComplete').then(() => {
         validateNoIcons();
       });

--- a/dataland-frontend/tests/component/components/resources/frameworkDataSearch/DocumentLink.cy.ts
+++ b/dataland-frontend/tests/component/components/resources/frameworkDataSearch/DocumentLink.cy.ts
@@ -1,9 +1,10 @@
 // @ts-nocheck
 import DocumentLink from '@/components/resources/frameworkDataSearch/DocumentLink.vue';
+import DataPointDataTable from '@/components/general/DataPointDataTable.vue';
 import { minimalKeycloakMock } from '@ct/testUtils/Keycloak';
 import { DataTypeEnum } from '@clients/backend';
 
-describe('check that the progress spinner works correctly for the document link component', function (): void {
+describe('check that the document link component works and is displayed correctly', function (): void {
   it('Check that there are no icons before and after triggering a download', function (): void {
     cy.intercept('**/documents/dummyFile**', {
       statusCode: 200,
@@ -106,6 +107,34 @@ describe('check that the progress spinner works correctly for the document link 
         .then(() => {
           validateNoIcons();
         });
+    });
+  });
+  it('Check that the label does not display "page" when page number is null', function (): void {
+    cy.mountWithPlugins(DataPointDataTable, {
+      keycloak: minimalKeycloakMock({}),
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      props: {},
+      data() {
+        return {
+          dialogData: {
+            dataPointDisplay: {
+              value: 'Some Value',
+              quality: 'Some quality',
+              dataSource: {
+                fileName: 'FileName',
+                page: null,
+              },
+              comment: 'Some comment',
+            },
+            dataId: '12345',
+            dataType: DataTypeEnum.Heimathafen,
+          },
+        };
+      },
+    }).then(() => {
+      cy.get("[data-test='Report-Download-FileName']").should('contain', 'FileName');
+      cy.get("[data-test='Report-Download-FileName']").should('not.contain', 'page null');
     });
   });
 });


### PR DESCRIPTION
# Pull Request \<Title>
`<Description here>`
## Things to do during Peer Review
Please check all boxes before the Pull Request is merged. In case you skip a box, describe in the PRs description (that means: here) why the check is skipped.
- [x] The Github Actions (including Sonarqube Gateway and Lint Checks) are green. This is enforced by Github. 
- [x] A peer-review has been executed
  - [x] The code has been manually inspected by someone who did not implement the feature
  - [x] If this PR includes work on the frontend, at least one `@ts-nocheck` is removed. Additionally, there should not be any `@ts-nocheck` in files modified by this PR. If no `@ts-nocheck` are left: Celebrate :tada: :confetti_ball: type-safety and remove this entry. 
- [x] The PR actually implements what is described in the JIRA-Issue
- [x] At least one test exists testing the new feature
  - [x] If you have created new test files, make sure that they are included in a test container and actually run in the CI
- [x] At least 3 consecutive CI runs are successfully executed to ensure that there are no flaky tests.
- [x] Documentation is updated as required
- [x] The automated deployment is updated if required
- [x] If there was a database entity class added, there must also be a migration script for creating the corresponding database if flyway is already used by the service
- [ ] IF there are changes done to the framework data models or to a database entity class, the following steps were completed in order
  - [ ] A fresh clone of dataland.com is generated (see Wiki page on "OTC" for details)
  - [ ] The feature branch is deployed to clone with `Reset non-user related Docker Volumes & Re-populate` turned off
  - [ ] It's verified that the CD run is green
  - [ ] The new feature is manually used/tested/observed on the clone server. Testing of the new feature should (also) be done by a second, independent reviewer from the dev team
  - [ ] The feature branch is deployed to dev1 with `Reset non-user related Docker Volumes & Re-populate` turned on, and it's verified that the CD run is green  
- [x] ELSE, the new version is deployed to the dev server "dev1" using this branch
  - [x] Run with setting `Reset non-user related Docker Volumes & Re-populate` turned on 
  - [x] It's verified that this version actually is the one deployed (check gitinfo for branch name and commit id!)
  - [x] It's verified that the CD run is green
  - [x] The new feature is manually used/tested/observed on dev server. Testing of the new feature should (also) be done by a second, independent reviewer from the dev team