### PR TITLE
fix bug 4856 (no review buttons rendered)

### DIFF
--- a/dataland-frontend/src/components/pages/CompanyInformation.vue
+++ b/dataland-frontend/src/components/pages/CompanyInformation.vue
@@ -157,23 +157,28 @@ export default defineComponent({
     },
   },
   mounted() {
-    void this.getCompanyInformation();
-    void this.setCompanyOwnershipStatus();
-    void this.updateHasCompanyOwner();
+    this.updateBanner();
   },
   watch: {
-    async companyId(newCompanyId) {
+    async companyId() {
+      await this.updateBanner();
+    },
+  },
+  methods: {
+    /**
+     * A complete update of all data-based UI elements of the banner
+     */
+    async updateBanner() {
       try {
-        void this.setCompanyOwnershipStatus();
         void this.getCompanyInformation();
-        this.hasCompanyOwner = await hasCompanyAtLeastOneCompanyOwner(newCompanyId as string, this.getKeycloakPromise);
+        void this.setCompanyOwnershipStatus();
+        void this.updateHasCompanyOwner();
         this.claimIsSubmitted = false;
       } catch (error) {
         console.error('Error fetching data for new company:', error);
       }
     },
-  },
-  methods: {
+
     /**
      * triggers route push to parent company if the parent company exists
      * @returns route push

--- a/dataland-frontend/src/components/pages/CompanyInformation.vue
+++ b/dataland-frontend/src/components/pages/CompanyInformation.vue
@@ -157,18 +157,18 @@ export default defineComponent({
     },
   },
   mounted() {
-    this.updateBanner();
+    this.fetchDataForThisPage();
   },
   watch: {
     async companyId() {
-      await this.updateBanner();
+      await this.fetchDataForThisPage();
     },
   },
   methods: {
     /**
-     * A complete update of all data-based UI elements of the banner
+     * A complete fetch of all data that is relevant for UI elements of this page
      */
-    async updateBanner() {
+    async fetchDataForThisPage() {
       try {
         void this.getCompanyInformation();
         void this.setCompanyOwnershipStatus();

--- a/dataland-frontend/src/components/resources/dataRequest/ReviewRequestButtons.vue
+++ b/dataland-frontend/src/components/resources/dataRequest/ReviewRequestButtons.vue
@@ -182,6 +182,9 @@ export default defineComponent({
         this.fetchMessageHistory().catch((error) => console.error(error));
       },
     },
+    mapOfReportingPeriodToActiveDataset() {
+      void this.updateAnsweredDataRequestsForViewPage();
+    },
   },
   data() {
     return {
@@ -198,6 +201,7 @@ export default defineComponent({
       actionOnClick: ReportingPeriodTableActions.ReopenRequest,
       currentChosenDataRequestId: '',
       messageHistory: [] as StoredDataRequestMessageObject[],
+      currentRunId: 0,
     };
   },
   mounted() {
@@ -251,12 +255,16 @@ export default defineComponent({
      * Makes the api call and updates the list of answered data requests.
      */
     async updateAnsweredDataRequestsForViewPage() {
-      this.answeredDataRequestsForViewPage = await getAnsweredDataRequestsForViewPage(
+      const runId = ++this.currentRunId;
+      const response = await getAnsweredDataRequestsForViewPage(
         this.companyId,
         this.framework,
         Array.from(this.mapOfReportingPeriodToActiveDataset.keys()),
         this.getKeycloakPromise
       );
+      if (runId === this.currentRunId) {
+        this.answeredDataRequestsForViewPage = response;
+      }
     },
     /**
      * Method to close the request or provide dropdown for that when the button is clicked


### PR DESCRIPTION
# Pull Request \<Title>
`<Description here>`
## Things to do during Peer Review
Please check all boxes before the Pull Request is merged. In case you skip a box, describe in the PRs description (that means: here) why the check is skipped.
- [x] The Github Actions (including Sonarqube Gateway and Lint Checks) are green. This is enforced by Github. 
- [x] A peer-review has been executed
  - [x] The code has been manually inspected by someone who did not implement the feature
  - [ ] If this PR includes work on the frontend, at least one `@ts-nocheck` is removed. Additionally, there should not be any `@ts-nocheck` in files modified by this PR. If no `@ts-nocheck` are left: Celebrate :tada: :confetti_ball: type-safety and remove this entry. 
- [ ] The PR actually implements what is described in the JIRA-Issue
- [ ] At least one test exists testing the new feature
  - [ ] If you have created new test files, make sure that they are included in a test container and actually run in the CI
- [x] At least 3 consecutive CI runs are successfully executed to ensure that there are no flaky tests.
- [ ] Documentation is updated as required
- [ ] The automated deployment is updated if required
- [ ] If there was a database entity class added, there must also be a migration script for creating the corresponding database if flyway is already used by the service
- [ ] IF there are changes done to the framework data models or to a database entity class, the following steps were completed in order
  - [ ] A fresh clone of dataland.com is generated (see Wiki page on "OTC" for details)
  - [ ] The feature branch is deployed to clone with `Reset non-user related Docker Volumes & Re-populate` turned off
  - [ ] It's verified that the CD run is green
  - [ ] The new feature is manually used/tested/observed on the clone server. Testing of the new feature should (also) be done by a second, independent reviewer from the dev team
  - [ ] The feature branch is deployed to dev1 with `Reset non-user related Docker Volumes & Re-populate` turned on, and it's verified that the CD run is green  
- [x] ELSE, the new version is deployed to the dev server "dev1" using this branch
  - [x] Run with setting `Reset non-user related Docker Volumes & Re-populate` turned on 
  - [x] It's verified that this version actually is the one deployed (check gitinfo for branch name and commit id!)
  - [x] It's verified that the CD run is green
  - [x] The new feature is manually used/tested/observed on dev server. Testing of the new feature should (also) be done by a second, independent reviewer from the dev team