### PR TITLE
Dala 4864 filter and pagination on admin requests page

### DIFF
--- a/dataland-frontend/src/components/pages/AdminAllRequestsOverview.vue
+++ b/dataland-frontend/src/components/pages/AdminAllRequestsOverview.vue
@@ -67,6 +67,7 @@
                 v-if="currentDataRequests && currentDataRequests.length > 0"
                 v-show="!waitingForData"
                 ref="dataTable"
+                data-test="requests-datatable"
                 :value="currentDataRequests"
                 :paginator="true"
                 :lazy="true"

--- a/dataland-frontend/src/components/pages/AdminAllRequestsOverview.vue
+++ b/dataland-frontend/src/components/pages/AdminAllRequestsOverview.vue
@@ -357,17 +357,11 @@ export default defineComponent({
     /**
      * Navigates to the view dataRequest page
      * @param event contains column that was clicked
-     * @param event.data extended stored data request
-     * @param event.originalEvent needed to get the clicked cell
      * @returns the promise of the router push action
      */
     onRowClick(event: DataTableRowClickEvent) {
-      const clickedElement = event.originalEvent.target as HTMLElement;
-      const isResolveButtonClick = clickedElement.id === 'resolveButton';
-      if (!isResolveButtonClick) {
-        const requestIdOfClickedRow = event.data.dataRequestId;
-        return this.$router.push(`/requests/${requestIdOfClickedRow}`);
-      }
+      const requestIdOfClickedRow = event.data.dataRequestId;
+      return this.$router.push(`/requests/${requestIdOfClickedRow}`);
     },
   },
 });

--- a/dataland-frontend/src/components/pages/AdminAllRequestsOverview.vue
+++ b/dataland-frontend/src/components/pages/AdminAllRequestsOverview.vue
@@ -251,13 +251,16 @@ export default defineComponent({
 
   watch: {
     selectedFrameworks() {
+      this.currentPage = 0;
       this.getAllRequestsForFilters();
     },
     selectedRequestStatus() {
+      this.currentPage = 0;
       this.getAllRequestsForFilters();
     },
     searchBarInput(newSearch: string) {
       this.searchBarInput = newSearch;
+      this.currentPage = 0;
       if (this.timerId) {
         clearTimeout(this.timerId);
       }
@@ -325,10 +328,11 @@ export default defineComponent({
       this.selectedFrameworks = [];
       this.selectedRequestStatus = [];
       this.searchBarInput = '';
+      this.currentPage = 0;
     },
 
     /**
-     * Updates the current Page in the parent component
+     * Updates the current Page
      * @param event DataTablePageEvent
      */
     onPage(event: DataTablePageEvent) {

--- a/dataland-frontend/src/components/pages/AdminAllRequestsOverview.vue
+++ b/dataland-frontend/src/components/pages/AdminAllRequestsOverview.vue
@@ -349,7 +349,6 @@ export default defineComponent({
       if (event.page != this.currentChunkIndex) {
         this.currentChunkIndex = event.page;
         this.firstRowIndex = this.currentChunkIndex * this.rowsPerPage;
-        console.log(event.first);
         this.getAllRequestsForFilters();
       }
     },

--- a/dataland-frontend/tests/component/components/pages/AdminAllRequestsOverview.cy.ts
+++ b/dataland-frontend/tests/component/components/pages/AdminAllRequestsOverview.cy.ts
@@ -6,11 +6,12 @@ import { getMountingFunction } from '@ct/testUtils/Mount';
 import { AccessStatus, type ExtendedStoredDataRequest, RequestStatus } from '@clients/communitymanager';
 import { faker } from '@faker-js/faker';
 import { humanizeStringOrNumber } from '@/utils/StringFormatter';
+import { chunk } from 'node_modules/cypress/types/lodash';
 
 describe('Component test for the admin-requests-overview page', () => {
   let mockRequests: ExtendedStoredDataRequest[];
   let mockRequestsLarge: ExtendedStoredDataRequest[];
-  const maxRows = 100;
+  const chunkSize = 100;
 
   /**
    * Generates one ExtendedStoredDataRequest type object
@@ -73,7 +74,9 @@ describe('Component test for the admin-requests-overview page', () => {
    */
   function mountAdminAllRequestsPageWithMocks(): Cypress.Chainable {
     const expectedNumberOfRequests = mockRequests.length;
-    cy.intercept('**/community/requests?chunkSize=100&chunkIndex=0', mockRequests).as('fetchInitialUnfilteredRequests');
+    cy.intercept(`**/community/requests?chunkSize=${chunkSize}&chunkIndex=0`, mockRequests).as(
+      'fetchInitialUnfilteredRequests'
+    );
     cy.intercept('**/community/requests/numberOfRequests', expectedNumberOfRequests.toString()).as(
       'fetchInitialUnfilteredNumberOfRequests'
     );
@@ -99,7 +102,7 @@ describe('Component test for the admin-requests-overview page', () => {
    */
   function mountAdminAllRequestsPageWithManyMocks(): void {
     const expectedNumberOfRequests = mockRequestsLarge.length;
-    cy.intercept('**/community/requests?chunkSize=100&chunkIndex=0', mockRequestsLarge.slice(0, 100));
+    cy.intercept(`**/community/requests?chunkSize=${chunkSize}&chunkIndex=0`, mockRequestsLarge.slice(0, chunkSize));
     cy.intercept('**/community/requests/numberOfRequests', expectedNumberOfRequests.toString());
 
     getMountingFunction({
@@ -109,7 +112,7 @@ describe('Component test for the admin-requests-overview page', () => {
         userId: crypto.randomUUID(),
       }),
     })(AdminAllRequestsOverview);
-    assertNumberOfSearchResults(maxRows);
+    assertNumberOfSearchResults(chunkSize);
   }
 
   /**
@@ -134,9 +137,10 @@ describe('Component test for the admin-requests-overview page', () => {
   function validateEmailAddressFilter(): void {
     const mockResponse = [mockRequests[0], mockRequests[3]];
     const expectedNumberOfRequests = mockResponse.length;
-    cy.intercept(`**/community/requests?emailAddress=${mailSearchTerm}&chunkSize=100&chunkIndex=0`, mockResponse).as(
-      'fetchEmailFilteredRequests'
-    );
+    cy.intercept(
+      `**/community/requests?emailAddress=${mailSearchTerm}&chunkSize=${chunkSize}&chunkIndex=0`,
+      mockResponse
+    ).as('fetchEmailFilteredRequests');
     cy.intercept(`**/community/requests/numberOfRequests?emailAddress=ste`, expectedNumberOfRequests.toString()).as(
       'fetchEmailFilteredNumberOfRequests'
     );
@@ -155,9 +159,10 @@ describe('Component test for the admin-requests-overview page', () => {
     const frameworkHumanReadableName = humanizeStringOrNumber(frameworkToFilterFor);
     const mockResponse = [mockRequests[1]];
     const expectedNumberOfRequests = mockResponse.length;
-    cy.intercept(`**/community/requests?dataType=${frameworkToFilterFor}&chunkSize=100&chunkIndex=0`, mockResponse).as(
-      'fetchFrameworkFilteredRequests'
-    );
+    cy.intercept(
+      `**/community/requests?dataType=${frameworkToFilterFor}&chunkSize=${chunkSize}&chunkIndex=0`,
+      mockResponse
+    ).as('fetchFrameworkFilteredRequests');
     cy.intercept(
       `**/community/requests/numberOfRequests?dataType=${frameworkToFilterFor}`,
       expectedNumberOfRequests.toString()
@@ -178,7 +183,7 @@ describe('Component test for the admin-requests-overview page', () => {
     const mockResponse = [mockRequests[0]];
     const expectedNumberOfRequests = mockResponse.length;
     cy.intercept(
-      `**/community/requests?requestStatus=${requestStatusToFilterFor}&chunkSize=100&chunkIndex=0`,
+      `**/community/requests?requestStatus=${requestStatusToFilterFor}&chunkSize=${chunkSize}&chunkIndex=0`,
       mockResponse
     ).as('fetchRequestStatusFilteredRequests');
     cy.intercept(
@@ -202,7 +207,7 @@ describe('Component test for the admin-requests-overview page', () => {
     const mockResponse = [mockRequests[3]];
     const expectedNumberOfRequests = mockResponse.length;
     cy.intercept(
-      `**/community/requests?dataType=${frameworkToFilterFor}&emailAddress=${mailSearchTerm}&chunkSize=100&chunkIndex=0`,
+      `**/community/requests?dataType=${frameworkToFilterFor}&emailAddress=${mailSearchTerm}&chunkSize=${chunkSize}&chunkIndex=0`,
       mockResponse
     ).as('fetchCombinedFilteredRequests');
     cy.intercept(
@@ -221,7 +226,9 @@ describe('Component test for the admin-requests-overview page', () => {
    */
   function validateDeselectingCombinedFilter(): void {
     const expectedNumberOfRequests = mockRequests.length;
-    cy.intercept('**/community/requests?chunkSize=100&chunkIndex=0', mockRequests).as('fetchInitialUnfilteredRequests');
+    cy.intercept(`**/community/requests?chunkSize=${chunkSize}&chunkIndex=0`, mockRequests).as(
+      'fetchInitialUnfilteredRequests'
+    );
     cy.intercept('**/community/requests/numberOfRequests', expectedNumberOfRequests.toString()).as(
       'fetchInitialUnfilteredNumberOfRequests'
     );
@@ -238,10 +245,12 @@ describe('Component test for the admin-requests-overview page', () => {
    * Validates onPage Event
    */
   function validateOnPageEvent(): void {
-    const secondPageMockResponse = mockRequestsLarge.slice(100);
+    const secondPageMockResponse = mockRequestsLarge.slice(chunkSize);
     const expectedNumberOfRequests = mockRequestsLarge.length;
     const expectedNumberOfRows = secondPageMockResponse.length;
-    cy.intercept(`**/community/requests?chunkSize=100&chunkIndex=1`, secondPageMockResponse).as('fetchRequests');
+    cy.intercept(`**/community/requests?chunkSize=${chunkSize}&chunkIndex=1`, secondPageMockResponse).as(
+      'fetchRequests'
+    );
     cy.intercept(`**/community/requests/numberOfRequests`, expectedNumberOfRequests.toString());
 
     cy.get(`button[aria-label="Page 2"]`).click();
@@ -255,7 +264,9 @@ describe('Component test for the admin-requests-overview page', () => {
    */
   function validateResetButton(): void {
     const expectedNumberOfRequests = mockRequests.length;
-    cy.intercept('**/community/requests?chunkSize=100&chunkIndex=0', mockRequests).as('fetchInitialUnfilteredRequests');
+    cy.intercept(`**/community/requests?chunkSize=${chunkSize}&chunkIndex=0`, mockRequests).as(
+      'fetchInitialUnfilteredRequests'
+    );
     cy.intercept('**/community/requests/numberOfRequests', expectedNumberOfRequests.toString()).as(
       'fetchInitialUnfilteredNumberOfRequests'
     );

--- a/dataland-frontend/tests/component/components/pages/AdminAllRequestsOverview.cy.ts
+++ b/dataland-frontend/tests/component/components/pages/AdminAllRequestsOverview.cy.ts
@@ -234,7 +234,7 @@ describe('Component test for the admin-requests-overview page', () => {
     cy.get('[data-test=requests-datatable]').within(() => {
       cy.get('tr:last').click();
     });
-    cy.wrap(mounted.component).its('$route.path').should('eq', '/bulkdatarequest');
+    cy.wrap(mounted.component).its('$route.path').should('eq', `/requests/${dataRequestIdOfLastElement}/`);
   }
 
   it('Filtering for an email address works as expected', () => {

--- a/dataland-frontend/tests/component/components/pages/AdminAllRequestsOverview.cy.ts
+++ b/dataland-frontend/tests/component/components/pages/AdminAllRequestsOverview.cy.ts
@@ -56,6 +56,7 @@ describe('Component test for the admin-requests-overview page', () => {
 
   /**
    * Mounts the page and asserts that the unfiltered list of all data requests is displayed
+   * @returns mounted component as Chainable
    */
   function mountAdminAllRequestsPageWithMocks(): Cypress.Chainable {
     const expectedNumberOfRequests = mockRequests.length;
@@ -218,20 +219,6 @@ describe('Component test for the admin-requests-overview page', () => {
     assertEmailAddressExistsInSearchResults(mailDelta);
   }
 
-  /**
-   * Validate the rowClick event
-   * @param mounted
-   */
-  function validateRowClickEvent(mounted: Cypress.Chainable): void {
-    const dataRequestIdOfLastElement = mockRequests[mockRequests.length - 1].dataRequestId;
-
-    cy.get('[data-test=requests-datatable]').within(() => {
-      cy.get('tr:last').click();
-    });
-    //@ts-ignore
-    cy.wrap(mounted.component).its('$route.path').should('eq', `/requests/${dataRequestIdOfLastElement}`);
-  }
-
   it('Filtering for an email address works as expected', () => {
     mountAdminAllRequestsPageWithMocks();
     validateEmailAddressFilter();
@@ -259,9 +246,15 @@ describe('Component test for the admin-requests-overview page', () => {
     validateResetButton();
   });
 
-  it.only('Check the functionality of the rowClick event', () => {
-    mountAdminAllRequestsPageWithMocks().then((mounted) => {
-      validateRowClickEvent(mounted);
+  it('Check the functionality of the rowClick event', () => {
+    mountAdminAllRequestsPageWithMocks().then((chainable) => {
+      const dataRequestIdOfLastElement = mockRequests[mockRequests.length - 1].dataRequestId;
+
+      cy.get('[data-test=requests-datatable]').within(() => {
+        cy.get('tr:last').click();
+      });
+
+      cy.wrap(chainable.component).its('$route.path').should('eq', `/requests/${dataRequestIdOfLastElement}`);
     });
   });
 });

--- a/dataland-frontend/tests/component/components/pages/AdminAllRequestsOverview.cy.ts
+++ b/dataland-frontend/tests/component/components/pages/AdminAllRequestsOverview.cy.ts
@@ -6,8 +6,8 @@ import { getMountingFunction } from '@ct/testUtils/Mount';
 import { AccessStatus, type ExtendedStoredDataRequest, RequestStatus } from '@clients/communitymanager';
 import { faker } from '@faker-js/faker';
 import { humanizeStringOrNumber } from '@/utils/StringFormatter';
-import {VueWrapper} from "@vue/test-utils";
-import {CreateComponentPublicInstance, ExtractPropTypes} from "vue";
+import { VueWrapper } from '@vue/test-utils';
+import { CreateComponentPublicInstance, ExtractPropTypes } from 'vue';
 
 describe('Component test for the admin-requests-overview page', () => {
   let mockRequests: ExtendedStoredDataRequest[];
@@ -71,16 +71,15 @@ describe('Component test for the admin-requests-overview page', () => {
         roles: [KEYCLOAK_ROLE_ADMIN],
         userId: crypto.randomUUID(),
       }),
-    })(AdminAllRequestsOverview).then((mounted) => {
-        assertNumberOfSearchResults(expectedNumberOfRequests);
-        mockRequests.forEach((extendedStoredDataRequest) => {
-          if (extendedStoredDataRequest.userEmailAddress) {
-            assertEmailAddressExistsInSearchResults(extendedStoredDataRequest.userEmailAddress);
-          }
-        });
-        return mounted
-    })
-    return mountedComponent
+    })(AdminAllRequestsOverview);
+
+    assertNumberOfSearchResults(expectedNumberOfRequests);
+    mockRequests.forEach((extendedStoredDataRequest) => {
+      if (extendedStoredDataRequest.userEmailAddress) {
+        assertEmailAddressExistsInSearchResults(extendedStoredDataRequest.userEmailAddress);
+      }
+    });
+    return mountedComponent;
   }
 
   /**
@@ -227,14 +226,11 @@ describe('Component test for the admin-requests-overview page', () => {
   function validateRowClickEvent(mounted: Cypress.Chainable): void {
     const dataRequestIdOfLastElement = mockRequests[mockRequests.length - 1].dataRequestId;
 
-    cy.intercept('**/requests/' + dataRequestIdOfLastElement).as('fetchDetailsOfRequest');
-
-    cy.wait(2000);
-
     cy.get('[data-test=requests-datatable]').within(() => {
       cy.get('tr:last').click();
     });
-    cy.wrap(mounted.component).its('$route.path').should('eq', `/requests/${dataRequestIdOfLastElement}/`);
+    // eslint-disable-next-line
+    cy.wrap(mounted.component).its('$route.path').should('eq', `/requests/${dataRequestIdOfLastElement}`);
   }
 
   it('Filtering for an email address works as expected', () => {
@@ -268,6 +264,5 @@ describe('Component test for the admin-requests-overview page', () => {
     mountAdminAllRequestsPageWithMocks().then((mounted) => {
       validateRowClickEvent(mounted);
     });
-
   });
 });

--- a/dataland-frontend/tests/component/components/pages/AdminAllRequestsOverview.cy.ts
+++ b/dataland-frontend/tests/component/components/pages/AdminAllRequestsOverview.cy.ts
@@ -6,7 +6,6 @@ import { getMountingFunction } from '@ct/testUtils/Mount';
 import { AccessStatus, type ExtendedStoredDataRequest, RequestStatus } from '@clients/communitymanager';
 import { faker } from '@faker-js/faker';
 import { humanizeStringOrNumber } from '@/utils/StringFormatter';
-import { chunk } from 'node_modules/cypress/types/lodash';
 
 describe('Component test for the admin-requests-overview page', () => {
   let mockRequests: ExtendedStoredDataRequest[];

--- a/dataland-frontend/tests/component/components/pages/AdminAllRequestsOverview.cy.ts
+++ b/dataland-frontend/tests/component/components/pages/AdminAllRequestsOverview.cy.ts
@@ -200,6 +200,22 @@ describe('Component test for the admin-requests-overview page', () => {
     assertEmailAddressExistsInSearchResults(mailDelta);
   }
 
+  /**
+   * Removes the combined filter via resetButton and checks if all requests are shown again
+   */
+  function validateResetButton(): void {
+    const expectedNumberOfRequests = mockRequests.length;
+    cy.intercept('**/community/requests?chunkSize=100&chunkIndex=0', mockRequests).as('fetchInitialUnfilteredRequests');
+    cy.intercept('**/community/requests/numberOfRequests', expectedNumberOfRequests.toString()).as(
+      'fetchInitialUnfilteredNumberOfRequests'
+    );
+    cy.get('[data-test=reset-filter]').click();
+
+    assertNumberOfSearchResults(expectedNumberOfRequests);
+    assertEmailAddressExistsInSearchResults(mailAlpha);
+    assertEmailAddressExistsInSearchResults(mailDelta);
+  }
+
   it('Filtering for an email address works as expected', () => {
     mountAdminAllRequestsPageWithMocks();
     validateEmailAddressFilter();
@@ -219,5 +235,11 @@ describe('Component test for the admin-requests-overview page', () => {
     mountAdminAllRequestsPageWithMocks();
     validateCombinedFilter();
     validateDeselectingCombinedFilter();
+  });
+
+  it('A combined filter works as expected and reset Button works as expected', () => {
+    mountAdminAllRequestsPageWithMocks();
+    validateCombinedFilter();
+    validateResetButton();
   });
 });

--- a/dataland-frontend/tests/component/components/pages/AdminAllRequestsOverview.cy.ts
+++ b/dataland-frontend/tests/component/components/pages/AdminAllRequestsOverview.cy.ts
@@ -9,6 +9,7 @@ import { humanizeStringOrNumber } from '@/utils/StringFormatter';
 
 describe('Component test for the admin-requests-overview page', () => {
   let mockRequests: ExtendedStoredDataRequest[];
+  let mockRequestsLarge: ExtendedStoredDataRequest[];
   const maxRows = 100;
 
   /**
@@ -53,6 +54,17 @@ describe('Component test for the admin-requests-overview page', () => {
       generateExtendedStoredDataRequest(mailGamma, DataTypeEnum.Vsme, RequestStatus.Answered, AccessStatus.Declined),
       generateExtendedStoredDataRequest(mailDelta, DataTypeEnum.Sfdr, RequestStatus.Resolved, AccessStatus.Public),
     ];
+    mockRequestsLarge = [];
+    for (let num = 1; num <= 104; num++) {
+      const dataType = faker.helpers.arrayElement([DataTypeEnum.Lksg, DataTypeEnum.P2p, DataTypeEnum.Vsme]);
+      const email = faker.helpers.arrayElement([mailAlpha, mailBeta, mailGamma, mailDelta]);
+      const requestStatus = faker.helpers.arrayElement([
+        RequestStatus.Open,
+        RequestStatus.Answered,
+        RequestStatus.Withdrawn,
+      ]);
+      mockRequestsLarge.push(generateExtendedStoredDataRequest(email, dataType, requestStatus, AccessStatus.Public));
+    }
   });
 
   /**
@@ -86,19 +98,8 @@ describe('Component test for the admin-requests-overview page', () => {
    *
    */
   function mountAdminAllRequestsPageWithManyMocks(): void {
-    for (let num = 1; num <= 100; num++) {
-      const dataType = faker.helpers.arrayElement([DataTypeEnum.Lksg, DataTypeEnum.P2p, DataTypeEnum.Vsme]);
-      const email = faker.helpers.arrayElement([mailAlpha, mailBeta, mailGamma, mailDelta]);
-      const requestStatus = faker.helpers.arrayElement([
-        RequestStatus.Open,
-        RequestStatus.Answered,
-        RequestStatus.Withdrawn,
-      ]);
-      mockRequests.push(generateExtendedStoredDataRequest(email, dataType, requestStatus, AccessStatus.Public));
-    }
-
-    const expectedNumberOfRequests = mockRequests.length;
-    cy.intercept('**/community/requests?chunkSize=100&chunkIndex=0', mockRequests.slice(0, 100));
+    const expectedNumberOfRequests = mockRequestsLarge.length;
+    cy.intercept('**/community/requests?chunkSize=100&chunkIndex=0', mockRequestsLarge.slice(0, 100));
     cy.intercept('**/community/requests/numberOfRequests', expectedNumberOfRequests.toString());
 
     getMountingFunction({
@@ -237,8 +238,8 @@ describe('Component test for the admin-requests-overview page', () => {
    * Validates onPage Event
    */
   function validateOnPageEvent(): void {
-    const secondPageMockResponse = mockRequests.slice(100);
-    const expectedNumberOfRequests = mockRequests.length;
+    const secondPageMockResponse = mockRequestsLarge.slice(100);
+    const expectedNumberOfRequests = mockRequestsLarge.length;
     const expectedNumberOfRows = secondPageMockResponse.length;
     cy.intercept(`**/community/requests?chunkSize=100&chunkIndex=1`, secondPageMockResponse).as('fetchRequests');
     cy.intercept(`**/community/requests/numberOfRequests`, expectedNumberOfRequests.toString());

--- a/dataland-frontend/tests/component/components/pages/AdminAllRequestsOverview.cy.ts
+++ b/dataland-frontend/tests/component/components/pages/AdminAllRequestsOverview.cy.ts
@@ -6,8 +6,6 @@ import { getMountingFunction } from '@ct/testUtils/Mount';
 import { AccessStatus, type ExtendedStoredDataRequest, RequestStatus } from '@clients/communitymanager';
 import { faker } from '@faker-js/faker';
 import { humanizeStringOrNumber } from '@/utils/StringFormatter';
-import { VueWrapper } from '@vue/test-utils';
-import { CreateComponentPublicInstance, ExtractPropTypes } from 'vue';
 
 describe('Component test for the admin-requests-overview page', () => {
   let mockRequests: ExtendedStoredDataRequest[];
@@ -222,6 +220,7 @@ describe('Component test for the admin-requests-overview page', () => {
 
   /**
    * Validate the rowClick event
+   * @param mounted
    */
   function validateRowClickEvent(mounted: Cypress.Chainable): void {
     const dataRequestIdOfLastElement = mockRequests[mockRequests.length - 1].dataRequestId;
@@ -229,7 +228,7 @@ describe('Component test for the admin-requests-overview page', () => {
     cy.get('[data-test=requests-datatable]').within(() => {
       cy.get('tr:last').click();
     });
-    // eslint-disable-next-line
+    //@ts-ignore
     cy.wrap(mounted.component).its('$route.path').should('eq', `/requests/${dataRequestIdOfLastElement}`);
   }
 

--- a/dataland-frontend/tests/component/components/pages/AdminAllRequestsOverview.cy.ts
+++ b/dataland-frontend/tests/component/components/pages/AdminAllRequestsOverview.cy.ts
@@ -292,7 +292,7 @@ describe('Component test for the admin-requests-overview page', () => {
     validateResetButton();
   });
 
-  it.only('Check the functionality of the onPage event', () => {
+  it('Check the functionality of the onPage event', () => {
     mountAdminAllRequestsPageWithManyMocks();
     validateOnPageEvent();
   });

--- a/dataland-frontend/tests/component/components/pages/AdminAllRequestsOverview.cy.ts
+++ b/dataland-frontend/tests/component/components/pages/AdminAllRequestsOverview.cy.ts
@@ -209,7 +209,7 @@ describe('Component test for the admin-requests-overview page', () => {
     cy.intercept('**/community/requests/numberOfRequests', expectedNumberOfRequests.toString()).as(
       'fetchInitialUnfilteredNumberOfRequests'
     );
-    cy.get('[data-test=reset-filter]').click();
+    cy.get(`[data-test=reset-filter]`).click();
 
     assertNumberOfSearchResults(expectedNumberOfRequests);
     assertEmailAddressExistsInSearchResults(mailAlpha);


### PR DESCRIPTION
# Pull Request \<Title>
Please also functional test on clone
## Things to do during Peer Review
Please check all boxes before the Pull Request is merged. In case you skip a box, describe in the PRs description (that means: here) why the check is skipped.
- [x] The Github Actions (including Sonarqube Gateway and Lint Checks) are green. This is enforced by Github. 
- [x] A peer-review has been executed
  - [x] The code has been manually inspected by someone who did not implement the feature
  - [x] If this PR includes work on the frontend, at least one `@ts-nocheck` is removed. Additionally, there should not be any `@ts-nocheck` in files modified by this PR. If no `@ts-nocheck` are left: Celebrate :tada: :confetti_ball: type-safety and remove this entry. 
- [x] The PR actually implements what is described in the JIRA-Issue
- [x] At least one test exists testing the new feature
  - [x] If you have created new test files, make sure that they are included in a test container and actually run in the CI
- [x] At least 3 consecutive CI runs are successfully executed to ensure that there are no flaky tests.
- [x] Documentation is updated as required
- [x] The automated deployment is updated if required
- [ ] If there was a database entity class added, there must also be a migration script for creating the corresponding database if flyway is already used by the service
- [ ] IF there are changes done to the framework data models or to a database entity class, the following steps were completed in order
  - [ ] A fresh clone of dataland.com is generated (see Wiki page on "OTC" for details)
  - [ ] The feature branch is deployed to clone with `Reset non-user related Docker Volumes & Re-populate` turned off
  - [ ] It's verified that the CD run is green
  - [ ] The new feature is manually used/tested/observed on the clone server. Testing of the new feature should (also) be done by a second, independent reviewer from the dev team
  - [ ] The feature branch is deployed to dev1 with `Reset non-user related Docker Volumes & Re-populate` turned on, and it's verified that the CD run is green  
- [x] ELSE, the new version is deployed to the dev server "dev1" using this branch
  - [x] Run with setting `Reset non-user related Docker Volumes & Re-populate` turned on 
  - [x] It's verified that this version actually is the one deployed (check gitinfo for branch name and commit id!)
  - [x] It's verified that the CD run is green
  - [x] The new feature is manually used/tested/observed on dev server. Testing of the new feature should (also) be done by a second, independent reviewer from the dev team