### PR TITLE
Dala 4946 manual maintenance sprint 78

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/manual_maintenance.md
+++ b/.github/PULL_REQUEST_TEMPLATE/manual_maintenance.md
@@ -46,6 +46,10 @@ fine, proceed with other servers.
 If the updates require a reboot (for e.g. a kernel update), you can restart the machine with `sudo reboot`.
 However, for dataland.com, you may want to avoid any interruption and schedule the reboot during the night with `sudo shutdown -r 02:00`.
 
+## Cloud maintenance
+
+Check the cloud provider's dashboard for manually created backups and images. Delete them if they are not needed anymore.
+
 ## ssh-keys maintenance
 
 - [ ] Make sure the ssh-keys file reflects the current team composition. Execute the update script as described in the 

--- a/.github/PULL_REQUEST_TEMPLATE/manual_maintenance.md
+++ b/.github/PULL_REQUEST_TEMPLATE/manual_maintenance.md
@@ -23,15 +23,18 @@ consult the internal Dataland Wiki.
   3. Execute the following snippet of code (requires python): `curl http://localhost:8080/api/v1/client-controller/openapi | sed 's/\(example: \)\([^ ]*\)/\1"\2"/g' | python -c 'import sys, yaml, json; print(json.dumps(yaml.safe_load(sys.stdin.read()), indent=2))' > ./eurodatClientOpenApi.json`
   4. If there are changes to `eurodatClientOpenApi.json`, discuss with the team how to proceed
 
-## Server updates
+## Server maintenance
 
 Note: Before applying any update to any server make sure that a backup exists. In case of prod, create a fresh backup just
 before applying any changes and align with the team when to apply them.
 
-Start the update with one of the dev servers (preferably dev2 or dev3) and deploy to it afterwards. If everything was
-fine, proceed with other servers.
+On all servers to the following:
+- Execute `sudo apt-get update && sudo apt-get upgrade` to update the server
+- Execute `sudo docker system prune -a` to clean up unused docker components and liberate disk space
+- Check for new ubuntu releases and install them if available with `sudo do-release-upgrade` (see internal documentation for details) 
 
-Execute `sudo apt-get update && sudo apt-get upgrade` on
+Start the process with one of the dev servers (preferably dev2 or dev3) and deploy to it afterwards. If everything was
+fine, proceed with other servers.
 
 - [ ] dev1.dataland.com
 - [ ] dev2.dataland.com
@@ -41,7 +44,7 @@ Execute `sudo apt-get update && sudo apt-get upgrade` on
 - [ ] dataland.com (align beforehand)
 
 If the updates require a reboot (for e.g. a kernel update), you can restart the machine with `sudo reboot`.
-However, for dataland.com, you may want to avoid any interruption and schedule the reboot at the night with `sudo shutdown -r 02:00`.
+However, for dataland.com, you may want to avoid any interruption and schedule the reboot during the night with `sudo shutdown -r 02:00`.
 
 ## ssh-keys maintenance
 


### PR DESCRIPTION
# Pull Request \<Title>
`<Description here>`
## Things to do during Peer Review
Please check all boxes before the Pull Request is merged. In case you skip a box, describe in the PRs description (that means: here) why the check is skipped.
- [x] The GitHub Actions (including Sonarqube Gateway and Lint Checks) are green. This is enforced by GitHub. 
- [ ] The PR has been peer-reviewed
  - [ ] The code has been manually inspected by someone who did not implement the feature
  - [ ] If this PR includes work on the frontend, at least one `@ts-nocheck` is removed. Additionally, there should not be any `@ts-nocheck` in files modified by this PR. If no `@ts-nocheck` are left: Celebrate :tada: :confetti_ball: type-safety and remove this entry. 
- [ ] The PR actually implements what is described in the JIRA-Issue
- [ ] At least one test exists testing the new feature
  - [ ] If you have created new test files, make sure that they are included in a test container and actually run in the CI
- [ ] At least 3 consecutive CI runs are successfully executed to ensure that there are no flaky tests.
- [ ] Documentation is updated as required
- [ ] The automated deployment is updated if required
- [ ] If there was a database entity class added, there must also be a migration script for creating the corresponding database if flyway is already used by the service
- [ ] IF there are changes done to the framework data models or to a database entity class, the following steps were completed in order
  - [ ] A fresh clone of dataland.com is generated (see Wiki page on "OTC" for details)
  - [ ] The feature branch is deployed to clone with `Reset non-user related Docker Volumes & Re-populate` turned off
  - [ ] It's verified that the CD run is green
  - [ ] The new feature is manually used/tested/observed on the clone server. Testing of the new feature should (also) be done by a second, independent reviewer from the dev team
  - [ ] The feature branch is deployed to dev1 with `Reset non-user related Docker Volumes & Re-populate` turned on, and it's verified that the CD run is green  
- [ ] ELSE, the new version is deployed to the dev server "dev1" using this branch
  - [ ] Run with setting `Reset non-user related Docker Volumes & Re-populate` turned on 
  - [ ] It's verified that this version actually is the one deployed (check gitinfo for branch name and commit id!)
  - [ ] It's verified that the CD run is green
  - [ ] The new feature is manually used/tested/observed on dev server. Testing of the new feature should (also) be done by a second, independent reviewer from the dev team
- [ ] Confirm that the latest version of the feature is deployed to the dev server "dev1" using this branch (no longer enforced by GitHub)