### PR TITLE
Bug fix email service

### DIFF
--- a/dataland-email-service/src/main/kotlin/org/dataland/datalandemailservice/repositories/EmailSubscriptionRepository.kt
+++ b/dataland-email-service/src/main/kotlin/org/dataland/datalandemailservice/repositories/EmailSubscriptionRepository.kt
@@ -7,6 +7,8 @@ import java.util.UUID
 
 /**
  * Repository interface for accessing and managing EmailSubscriptionEntity data.
+ * Note that this repository represents a blacklist, i.e. only email addresses that have an entity
+ * with is_subscribed=false will not receive any other email from the email service.
  */
 @Repository
 interface EmailSubscriptionRepository : JpaRepository<EmailSubscriptionEntity, UUID> {

--- a/dataland-email-service/src/main/kotlin/org/dataland/datalandemailservice/services/EmailSubscriptionTracker.kt
+++ b/dataland-email-service/src/main/kotlin/org/dataland/datalandemailservice/services/EmailSubscriptionTracker.kt
@@ -27,7 +27,7 @@ class EmailSubscriptionTracker(
      * or the UUID of the newly created entity if no subscription existed.
      */
     @Transactional
-    fun addSubscription(emailAddress: String): UUID {
+    fun addSubscriptionIfNeededAndReturnUuid(emailAddress: String): UUID {
         val entity =
             emailSubscriptionRepository.findByEmailAddress(emailAddress)
                 ?: emailSubscriptionRepository.save(
@@ -41,19 +41,20 @@ class EmailSubscriptionTracker(
     }
 
     /**
-     * This function queries the email subscription repository to determine whether the
-     * provided email address is currently subscribed.
+     * This function queries the email subscription repository for the email address and checks the subscription status.
+     * If there is an entity, the value of isSubscribed is returned. Otherwise, true is returned.
+     * Since the repository acts as a blacklist, no subscription entity for the email address indicates that the email should be sent.
      *
      * @param emailAddress that should be checked
-     * @return Boolean which is `true` if the email is subscribed,
-     * `false` if it is not subscribed or if the email address
-     *  does not exist in the repository.
+     * @return `true` if the email is subscribed or no entity is found, false otherwise.
      */
     fun isEmailSubscribed(emailAddress: String): Boolean =
         emailSubscriptionRepository.findByEmailAddress(emailAddress)?.isSubscribed ?: true
 
     /**
-     * This functions checks whether an email contact should be filtered or not.
+     * This function checks whether an email should be sent to an email contact.
+     * The email should be sent if the email address is subscribed and the email does not have the @example.com domain.
+     *
      * @param emailContact that should be checked
      * @return Boolean which is 'true' if the contact should be filtered and 'false' otherwise.
      */

--- a/dataland-email-service/src/main/kotlin/org/dataland/datalandemailservice/services/EmailSubscriptionTracker.kt
+++ b/dataland-email-service/src/main/kotlin/org/dataland/datalandemailservice/services/EmailSubscriptionTracker.kt
@@ -50,7 +50,7 @@ class EmailSubscriptionTracker(
      *  does not exist in the repository.
      */
     fun isEmailSubscribed(emailAddress: String): Boolean =
-        emailSubscriptionRepository.findByEmailAddress(emailAddress)?.isSubscribed ?: false
+        emailSubscriptionRepository.findByEmailAddress(emailAddress)?.isSubscribed ?: true
 
     /**
      * This functions checks whether an email contact should be filtered or not.

--- a/dataland-email-service/src/main/kotlin/org/dataland/datalandemailservice/services/templateemail/DataRequestedClaimOwnershipEmailFactory.kt
+++ b/dataland-email-service/src/main/kotlin/org/dataland/datalandemailservice/services/templateemail/DataRequestedClaimOwnershipEmailFactory.kt
@@ -47,7 +47,7 @@ class DataRequestedClaimOwnershipEmailFactory(
         receiverEmail: String,
         properties: Map<String, String?>,
     ): Email {
-        val subscriptionUuid = emailSubscriptionTracker.addSubscription(receiverEmail).toString()
+        val subscriptionUuid = emailSubscriptionTracker.addSubscriptionIfNeededAndReturnUuid(receiverEmail).toString()
         val subscriptionProperty = mapOf(keys.subscriptionUuid to subscriptionUuid)
         return super.buildEmail(receiverEmail, properties + subscriptionProperty)
     }

--- a/dataland-email-service/src/main/kotlin/org/dataland/datalandemailservice/services/templateemail/SingleNotificationEmailFactory.kt
+++ b/dataland-email-service/src/main/kotlin/org/dataland/datalandemailservice/services/templateemail/SingleNotificationEmailFactory.kt
@@ -48,7 +48,7 @@ class SingleNotificationEmailFactory(
         receiverEmail: String,
         properties: Map<String, String?>,
     ): Email {
-        val subscriptionUuid = emailSubscriptionTracker.addSubscription(receiverEmail).toString()
+        val subscriptionUuid = emailSubscriptionTracker.addSubscriptionIfNeededAndReturnUuid(receiverEmail).toString()
         val subscriptionProperty = mapOf(keys.subscriptionUuid to subscriptionUuid)
         return super.buildEmail(receiverEmail, properties + subscriptionProperty)
     }

--- a/dataland-email-service/src/main/kotlin/org/dataland/datalandemailservice/services/templateemail/SummaryNotificationEmailFactory.kt
+++ b/dataland-email-service/src/main/kotlin/org/dataland/datalandemailservice/services/templateemail/SummaryNotificationEmailFactory.kt
@@ -48,7 +48,7 @@ class SummaryNotificationEmailFactory(
         receiverEmail: String,
         properties: Map<String, String?>,
     ): Email {
-        val subscriptionUuid = emailSubscriptionTracker.addSubscription(receiverEmail).toString()
+        val subscriptionUuid = emailSubscriptionTracker.addSubscriptionIfNeededAndReturnUuid(receiverEmail).toString()
         val subscriptionProperty = mapOf(keys.subscriptionUuid to subscriptionUuid)
         return super.buildEmail(receiverEmail, properties + subscriptionProperty)
     }

--- a/dataland-email-service/src/test/kotlin/org/dataland/datalandemailservice/services/DataRequestedClaimOwnershipEmailFactoryTest.kt
+++ b/dataland-email-service/src/test/kotlin/org/dataland/datalandemailservice/services/DataRequestedClaimOwnershipEmailFactoryTest.kt
@@ -35,7 +35,7 @@ class DataRequestedClaimOwnershipEmailFactoryTest {
     @BeforeEach
     fun setup() {
         emailSubscriptionTracker = mock(EmailSubscriptionTracker::class.java)
-        `when`(emailSubscriptionTracker.addSubscription(any())).thenReturn(subscriptionUuid)
+        `when`(emailSubscriptionTracker.addSubscriptionIfNeededAndReturnUuid(any())).thenReturn(subscriptionUuid)
         dataRequestedClaimOwnershipEmailFactory =
             DataRequestedClaimOwnershipEmailFactory(
                 proxyPrimaryUrl = proxyPrimaryUrl,

--- a/dataland-email-service/src/test/kotlin/org/dataland/datalandemailservice/services/EmailSubscriptionTrackerTest.kt
+++ b/dataland-email-service/src/test/kotlin/org/dataland/datalandemailservice/services/EmailSubscriptionTrackerTest.kt
@@ -97,7 +97,7 @@ class EmailSubscriptionTrackerTest(
     }
 
     @Test
-    fun `validate that a unknown email address is not identified as subscribed`() {
-        assertFalse(emailSubscriptionTracker.isEmailSubscribed(unknownEmail))
+    fun `validate that an unknown email address is not identified as subscribed`() {
+        assertTrue(emailSubscriptionTracker.isEmailSubscribed(unknownEmail))
     }
 }

--- a/dataland-email-service/src/test/kotlin/org/dataland/datalandemailservice/services/EmailSubscriptionTrackerTest.kt
+++ b/dataland-email-service/src/test/kotlin/org/dataland/datalandemailservice/services/EmailSubscriptionTrackerTest.kt
@@ -54,7 +54,7 @@ class EmailSubscriptionTrackerTest(
 
     @Test
     fun `validate if a new subscription entity is created for an unknown email`() {
-        val uuid = emailSubscriptionTracker.addSubscription(unknownEmail)
+        val uuid = emailSubscriptionTracker.addSubscriptionIfNeededAndReturnUuid(unknownEmail)
         val newEntity = emailSubscriptionRepository.findByEmailAddress(unknownEmail)
         if (newEntity != null) {
             assertTrue(newEntity.isSubscribed, "The email subscription should be unsubscribed.")
@@ -67,19 +67,19 @@ class EmailSubscriptionTrackerTest(
 
     @Test
     fun `validate that the uuid is returned for a subscribed email`() {
-        val uuid = emailSubscriptionTracker.addSubscription(subscribedEmail)
+        val uuid = emailSubscriptionTracker.addSubscriptionIfNeededAndReturnUuid(subscribedEmail)
         assertEquals(subscribedUuid, uuid)
     }
 
     @Test
     fun `validate that a uuid is returned for an unsubscribed email address`() {
-        val uuid = emailSubscriptionTracker.addSubscription(unsubscribedEmail)
+        val uuid = emailSubscriptionTracker.addSubscriptionIfNeededAndReturnUuid(unsubscribedEmail)
         assertEquals(unsubscribedUuid, uuid)
     }
 
     @Test
     fun `validate that a uuid is returned for a unknown email address`() {
-        val uuid = emailSubscriptionTracker.addSubscription(unknownEmail)
+        val uuid = emailSubscriptionTracker.addSubscriptionIfNeededAndReturnUuid(unknownEmail)
         val uuidString = uuid.toString()
         val convertedUuid = UUID.fromString(uuidString)
 

--- a/dataland-email-service/src/test/kotlin/org/dataland/datalandemailservice/services/NotificationEmailFactoriesTest.kt
+++ b/dataland-email-service/src/test/kotlin/org/dataland/datalandemailservice/services/NotificationEmailFactoriesTest.kt
@@ -26,7 +26,7 @@ class NotificationEmailFactoriesTest {
     @BeforeEach
     fun setup() {
         Mockito
-            .`when`(emailSubscriptionTrackerMock.addSubscription(receiverEmail))
+            .`when`(emailSubscriptionTrackerMock.addSubscriptionIfNeededAndReturnUuid(receiverEmail))
             .thenReturn(mockUuid)
     }
 

--- a/deployment/start_and_deploy_to_server.sh
+++ b/deployment/start_and_deploy_to_server.sh
@@ -55,6 +55,7 @@ if [[ $RESET_STACK_AND_REPOPULATE == true ]]; then
   delete_docker_volume_if_existent_remotely "rabbitmq_data" "$target_server_url" "$location"
   delete_docker_volume_if_existent_remotely "community_manager_data" "$target_server_url" "$location"
   delete_docker_volume_if_existent_remotely "batch_manager_data" "$target_server_url" "$location"
+  delete_docker_volume_if_existent_remotely "email_service_data" "$target_server_url" "$location"
 fi
 
 if [[ $LOAD_GLEIF_GOLDEN_COPY == true ]]; then


### PR DESCRIPTION
# Pull Request \<Title>
`<Description here>`
## Things to do during Peer Review
Please check all boxes before the Pull Request is merged. In case you skip a box, describe in the PRs description (that means: here) why the check is skipped.
- [x] The GitHub Actions (including Sonarqube Gateway and Lint Checks) are green. This is enforced by GitHub. 
- [x] The PR has been peer-reviewed
  - [x] The code has been manually inspected by someone who did not implement the feature
  - [ ] If this PR includes work on the frontend, at least one `@ts-nocheck` is removed. Additionally, there should not be any `@ts-nocheck` in files modified by this PR. If no `@ts-nocheck` are left: Celebrate :tada: :confetti_ball: type-safety and remove this entry. 
- [x] The PR actually implements what is described in the JIRA-Issue
- [x] At least one test exists testing the new feature
  - [x] If you have created new test files, make sure that they are included in a test container and actually run in the CI
- [ ] At least 3 consecutive CI runs are successfully executed to ensure that there are no flaky tests.
- [ ] Documentation is updated as required
- [ ] The automated deployment is updated if required
- [ ] If there was a database entity class added, there must also be a migration script for creating the corresponding database if flyway is already used by the service
- [ ] IF there are changes done to the framework data models or to a database entity class, the following steps were completed in order
  - [ ] A fresh clone of dataland.com is generated (see Wiki page on "OTC" for details)
  - [ ] The feature branch is deployed to clone with `Reset non-user related Docker Volumes & Re-populate` turned off
  - [ ] It's verified that the CD run is green
  - [ ] The new feature is manually used/tested/observed on the clone server. Testing of the new feature should (also) be done by a second, independent reviewer from the dev team
  - [ ] The feature branch is deployed to dev1 with `Reset non-user related Docker Volumes & Re-populate` turned on, and it's verified that the CD run is green  
- [ ] ELSE, the new version is deployed to the dev server "dev1" using this branch
  - [ ] Run with setting `Reset non-user related Docker Volumes & Re-populate` turned on 
  - [ ] It's verified that this version actually is the one deployed (check gitinfo for branch name and commit id!)
  - [ ] It's verified that the CD run is green
  - [ ] The new feature is manually used/tested/observed on dev server. Testing of the new feature should (also) be done by a second, independent reviewer from the dev team
- [ ] Confirm that the latest version of the feature is deployed to the dev server "dev1" using this branch (no longer enforced by GitHub)