### PR TITLE
Dala 5149 prod crash

### DIFF
--- a/dataland-community-manager/src/main/kotlin/db/migration/V9__DropDataTypeEnumConstraint.kt
+++ b/dataland-community-manager/src/main/kotlin/db/migration/V9__DropDataTypeEnumConstraint.kt
@@ -11,7 +11,7 @@ class V9__DropDataTypeEnumConstraint : BaseJavaMigration() {
     override fun migrate(context: Context) {
         val sql =
             """
-            ALTER TABLE elementary_events
+            ALTER TABLE IF EXISTS elementary_events
                 DROP CONSTRAINT IF EXISTS elementary_events_framework_check;
             """.trimIndent()
 

--- a/dataland-community-manager/src/main/kotlin/db/migration/V9__DropDataTypeEnumConstraint.kt
+++ b/dataland-community-manager/src/main/kotlin/db/migration/V9__DropDataTypeEnumConstraint.kt
@@ -1,0 +1,22 @@
+package db.migration
+
+import org.flywaydb.core.api.migration.BaseJavaMigration
+import org.flywaydb.core.api.migration.Context
+
+/**
+ * Migration that is used to drop the constraint on the framework property of the elementary_events table.
+ */
+@Suppress("ClassName")
+class V9__DropDataTypeEnumConstraint : BaseJavaMigration() {
+    override fun migrate(context: Context) {
+        val sql =
+            """
+            ALTER TABLE elementary_events
+                DROP CONSTRAINT IF EXISTS elementary_events_framework_check;
+            """.trimIndent()
+
+        context.connection.createStatement().use { statement ->
+            statement.execute(sql)
+        }
+    }
+}

--- a/dataland-community-manager/src/main/kotlin/org/dataland/datalandcommunitymanager/converters/DataTypEnumAttributeConverter.kt
+++ b/dataland-community-manager/src/main/kotlin/org/dataland/datalandcommunitymanager/converters/DataTypEnumAttributeConverter.kt
@@ -11,10 +11,10 @@ import org.dataland.datalandbackend.openApiClient.model.DataTypeEnum
  */
 @Converter(autoApply = true)
 class DataTypEnumAttributeConverter : AttributeConverter<DataTypeEnum, String> {
-    override fun convertToDatabaseColumn(dataType: DataTypeEnum?): String? = dataType?.value
+    override fun convertToDatabaseColumn(dataType: DataTypeEnum?): String? = dataType?.name
 
     override fun convertToEntityAttribute(string: String?): DataTypeEnum? =
         string?.let {
-            DataTypeEnum.entries.find { it.value == string } ?: throw IllegalArgumentException("Unknown dataType $string")
+            DataTypeEnum.entries.find { it.name == string } ?: throw IllegalArgumentException("Unknown dataType $string")
         }
 }

--- a/dataland-community-manager/src/main/kotlin/org/dataland/datalandcommunitymanager/converters/DataTypEnumAttributeConverter.kt
+++ b/dataland-community-manager/src/main/kotlin/org/dataland/datalandcommunitymanager/converters/DataTypEnumAttributeConverter.kt
@@ -1,0 +1,20 @@
+package org.dataland.datalandcommunitymanager.converters
+
+import jakarta.persistence.AttributeConverter
+import jakarta.persistence.Converter
+import org.dataland.datalandbackend.openApiClient.model.DataTypeEnum
+
+/**
+ *  This converter is used for database entities to convert the DataType enum to strings when saving to the database.
+ *  and to convert the string to the DataType when loading data from the database.
+ *  As autoApply=true, this should work for all stored DataTypeEnums.
+ */
+@Converter(autoApply = true)
+class DataTypEnumAttributeConverter : AttributeConverter<DataTypeEnum, String> {
+    override fun convertToDatabaseColumn(dataType: DataTypeEnum?): String? = dataType?.value
+
+    override fun convertToEntityAttribute(string: String?): DataTypeEnum? =
+        string?.let {
+            DataTypeEnum.entries.find { it.value == string } ?: throw IllegalArgumentException("Unknown dataType $string")
+        }
+}

--- a/dataland-community-manager/src/main/kotlin/org/dataland/datalandcommunitymanager/entities/ElementaryEventEntity.kt
+++ b/dataland-community-manager/src/main/kotlin/org/dataland/datalandcommunitymanager/entities/ElementaryEventEntity.kt
@@ -22,7 +22,6 @@ data class ElementaryEventEntity(
     @Enumerated(EnumType.STRING)
     val elementaryEventType: ElementaryEventType,
     val companyId: UUID,
-    @Enumerated(EnumType.STRING)
     val framework: DataTypeEnum,
     val reportingPeriod: String,
     val creationTimestamp: Long,

--- a/dataland-community-manager/src/main/kotlin/org/dataland/datalandcommunitymanager/services/elementaryEventProcessing/BaseEventProcessor.kt
+++ b/dataland-community-manager/src/main/kotlin/org/dataland/datalandcommunitymanager/services/elementaryEventProcessing/BaseEventProcessor.kt
@@ -8,7 +8,6 @@ import org.dataland.datalandcommunitymanager.model.elementaryEventProcessing.Ele
 import org.dataland.datalandcommunitymanager.repositories.ElementaryEventRepository
 import org.dataland.datalandcommunitymanager.services.NotificationService
 import org.dataland.datalandmessagequeueutils.constants.MessageType
-import org.dataland.datalandmessagequeueutils.exceptions.MessageQueueRejectException
 import org.dataland.datalandmessagequeueutils.utils.MessageQueueUtils
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
@@ -81,18 +80,6 @@ abstract class BaseEventProcessor(
                 notificationEvent = null,
             ),
         )
-
-    /**
-     * Each EventProcessor listens to a different messageQueue which will contain different message payloads.
-     * Thus, the payload validation needs to be implemented in the child classes.
-     * @param payload: JSON-ish object/string to validate
-     * @throws MessageQueueRejectException if the validation fails
-     */
-    @Throws(MessageQueueRejectException::class)
-    abstract fun validateIncomingPayloadAndReturnDataId(
-        payload: String,
-        messageType: String,
-    ): String
 
     /**
      * Parses a message payload from the rabbit mq as object.

--- a/dataland-community-manager/src/main/kotlin/org/dataland/datalandcommunitymanager/services/elementaryEventProcessing/PrivateDataUploadProcessor.kt
+++ b/dataland-community-manager/src/main/kotlin/org/dataland/datalandcommunitymanager/services/elementaryEventProcessing/PrivateDataUploadProcessor.kt
@@ -70,14 +70,22 @@ class PrivateDataUploadProcessor(
     ) {
         validateIncomingPayloadAndReturnDataId(payload, type)
 
-        super.processEvent(
-            createElementaryEventBasicInfo(payload),
-            correlationId,
-            type,
-        )
+        messageUtils.rejectMessageOnException {
+            super.processEvent(
+                createElementaryEventBasicInfo(payload),
+                correlationId,
+                type,
+            )
+        }
     }
 
-    override fun validateIncomingPayloadAndReturnDataId(
+    /**
+     * Validates the incoming Payloads and returns the dataId
+     * @param payload the Payload as a string
+     * @param messageType the type of the message
+     * @returns the dataId of the dataset
+     */
+    fun validateIncomingPayloadAndReturnDataId(
         payload: String,
         messageType: String,
     ): String {

--- a/dataland-community-manager/src/main/kotlin/org/dataland/datalandcommunitymanager/services/elementaryEventProcessing/PublicDataUploadProcessor.kt
+++ b/dataland-community-manager/src/main/kotlin/org/dataland/datalandcommunitymanager/services/elementaryEventProcessing/PublicDataUploadProcessor.kt
@@ -72,13 +72,14 @@ class PublicDataUploadProcessor(
         @Header(MessageHeaderKey.TYPE) type: String,
     ) {
         messageUtils.validateMessageType(messageType, this.messageType)
-        val qaCompletedMessage = objectMapper.readValue(payload, QaCompletedMessage::class.java)
-
-        if (qaCompletedMessage.validationResult != QaStatus.Accepted) {
-            return
-        }
 
         messageUtils.rejectMessageOnException {
+            val qaCompletedMessage = objectMapper.readValue(payload, QaCompletedMessage::class.java)
+
+            if (qaCompletedMessage.validationResult != QaStatus.Accepted) {
+                return@rejectMessageOnException
+            }
+
             super.processEvent(
                 createElementaryEventBasicInfo(
                     objectMapper.writeValueAsString(metaDataControllerApi.getDataMetaInfo(qaCompletedMessage.identifier)),

--- a/dataland-community-manager/src/main/kotlin/org/dataland/datalandcommunitymanager/services/elementaryEventProcessing/PublicDataUploadProcessor.kt
+++ b/dataland-community-manager/src/main/kotlin/org/dataland/datalandcommunitymanager/services/elementaryEventProcessing/PublicDataUploadProcessor.kt
@@ -2,6 +2,7 @@ package org.dataland.datalandcommunitymanager.services.elementaryEventProcessing
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.dataland.datalandbackend.openApiClient.api.MetaDataControllerApi
+import org.dataland.datalandbackendutils.model.QaStatus
 import org.dataland.datalandcommunitymanager.events.ElementaryEventType
 import org.dataland.datalandcommunitymanager.model.elementaryEventProcessing.ElementaryEventBasicInfo
 import org.dataland.datalandcommunitymanager.repositories.ElementaryEventRepository
@@ -10,7 +11,7 @@ import org.dataland.datalandmessagequeueutils.constants.ExchangeName
 import org.dataland.datalandmessagequeueutils.constants.MessageHeaderKey
 import org.dataland.datalandmessagequeueutils.constants.MessageType
 import org.dataland.datalandmessagequeueutils.constants.RoutingKeyNames
-import org.dataland.datalandmessagequeueutils.exceptions.MessageQueueRejectException
+import org.dataland.datalandmessagequeueutils.messages.QaCompletedMessage
 import org.dataland.datalandmessagequeueutils.utils.MessageQueueUtils
 import org.json.JSONObject
 import org.slf4j.Logger
@@ -70,29 +71,22 @@ class PublicDataUploadProcessor(
         @Header(MessageHeaderKey.CORRELATION_ID) correlationId: String,
         @Header(MessageHeaderKey.TYPE) type: String,
     ) {
-        val dataId = validateIncomingPayloadAndReturnDataId(payload, type)
-
-        super.processEvent(
-            createElementaryEventBasicInfo(
-                objectMapper.writeValueAsString(metaDataControllerApi.getDataMetaInfo(dataId)),
-            ),
-            correlationId,
-            type,
-        )
-    }
-
-    override fun validateIncomingPayloadAndReturnDataId(
-        payload: String,
-        messageType: String,
-    ): String {
         messageUtils.validateMessageType(messageType, this.messageType)
+        val qaCompletedMessage = objectMapper.readValue(payload, QaCompletedMessage::class.java)
 
-        val payloadJsonObject = JSONObject(payload)
+        if (qaCompletedMessage.validationResult != QaStatus.Accepted) {
+            return
+        }
 
-        return payloadJsonObject
-            .getString("identifier")
-            .takeIf { it.isNotEmpty() }
-            ?: throw MessageQueueRejectException("The identifier in the message payload is empty.")
+        messageUtils.rejectMessageOnException {
+            super.processEvent(
+                createElementaryEventBasicInfo(
+                    objectMapper.writeValueAsString(metaDataControllerApi.getDataMetaInfo(qaCompletedMessage.identifier)),
+                ),
+                correlationId,
+                type,
+            )
+        }
     }
 
     override fun createElementaryEventBasicInfo(jsonString: String): ElementaryEventBasicInfo {

--- a/dataland-community-manager/src/test/kotlin/org/dataland/datalandcommunitymanager/services/PublicDataUploadProcessorTest.kt
+++ b/dataland-community-manager/src/test/kotlin/org/dataland/datalandcommunitymanager/services/PublicDataUploadProcessorTest.kt
@@ -2,32 +2,53 @@ package org.dataland.datalandcommunitymanager.services
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.dataland.datalandbackend.openApiClient.api.MetaDataControllerApi
+import org.dataland.datalandbackend.openApiClient.model.DataMetaInformation
 import org.dataland.datalandbackend.openApiClient.model.DataTypeEnum
+import org.dataland.datalandbackendutils.model.QaStatus
 import org.dataland.datalandcommunitymanager.model.elementaryEventProcessing.ElementaryEventBasicInfo
 import org.dataland.datalandcommunitymanager.repositories.ElementaryEventRepository
 import org.dataland.datalandcommunitymanager.services.elementaryEventProcessing.PublicDataUploadProcessor
 import org.dataland.datalandmessagequeueutils.constants.MessageType
-import org.dataland.datalandmessagequeueutils.exceptions.MessageQueueRejectException
+import org.dataland.datalandmessagequeueutils.messages.QaCompletedMessage
 import org.dataland.datalandmessagequeueutils.utils.MessageQueueUtils
 import org.json.JSONObject
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
-import org.junit.jupiter.api.assertThrows
+import org.mockito.Mockito
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
 import java.util.UUID
 
 class PublicDataUploadProcessorTest {
     private lateinit var publicDataUploadProcessor: PublicDataUploadProcessor
 
+    private val objectMapper = jacksonObjectMapper()
+
+    private lateinit var elementaryEventRepositoryMock: ElementaryEventRepository
+
+    private var dataId = UUID.randomUUID()
+    private var companyId = UUID.randomUUID()
+
     @BeforeEach
     fun setup() {
-        val messageUtilsMock = mock(MessageQueueUtils::class.java)
+        val messageUtilsMock = MessageQueueUtils()
         val notificationServiceMock = mock(NotificationService::class.java)
-        val elementaryEventRepositoryMock = mock(ElementaryEventRepository::class.java)
         val metaDataControllerApiMock = mock(MetaDataControllerApi::class.java)
-        val objectMapper = jacksonObjectMapper()
+
+        elementaryEventRepositoryMock = mock(ElementaryEventRepository::class.java)
+        `when`(elementaryEventRepositoryMock.saveAndFlush(any())).then { invocation -> invocation.arguments[0] }
+
+        `when`(metaDataControllerApiMock.getDataMetaInfo(any()))
+            .thenReturn(
+                DataMetaInformation(
+                    dataId.toString(), companyId.toString(), DataTypeEnum.heimathafen, 0, "2022", false,
+                    org.dataland.datalandbackend.openApiClient.model.QaStatus.Pending, null,
+                ),
+            )
 
         publicDataUploadProcessor =
             PublicDataUploadProcessor(
@@ -37,48 +58,18 @@ class PublicDataUploadProcessorTest {
                 objectMapper,
                 metaDataControllerApiMock,
             )
-    }
 
-    @Test
-    fun `empty identifier leads to rejection exception`() {
-        val payload =
-            JSONObject(
-                mapOf("identifier" to ""),
-            ).toString()
-
-        val exception =
-            assertThrows<MessageQueueRejectException> {
-                publicDataUploadProcessor.validateIncomingPayloadAndReturnDataId(payload, MessageType.QA_COMPLETED)
-            }
-
-        assertEquals("Message was rejected: The identifier in the message payload is empty.", exception.message)
-    }
-
-    @Test
-    fun `non empty dataId leads to valid return of dataId`() {
-        val dummyId = "123"
-        val payload =
-            JSONObject(
-                mapOf("identifier" to dummyId),
-            ).toString()
-
-        val dataId =
-            assertDoesNotThrow {
-                publicDataUploadProcessor.validateIncomingPayloadAndReturnDataId(payload, MessageType.QA_COMPLETED)
-            }
-
-        assertEquals(dummyId, dataId)
+        publicDataUploadProcessor.notificationFeatureFlagAsString = "true"
     }
 
     @Test
     fun `create valid elementaryEventBasicInfo`() {
-        val dummyCompanyId = UUID.randomUUID()
         val dummyReportingPeriod = "2022"
         val jsonString =
             JSONObject(
                 mapOf(
-                    "dataId" to "abc",
-                    "companyId" to dummyCompanyId,
+                    "dataId" to dataId,
+                    "companyId" to companyId,
                     "dataType" to DataTypeEnum.heimathafen.toString(),
                     "reportingPeriod" to dummyReportingPeriod,
                 ),
@@ -87,11 +78,31 @@ class PublicDataUploadProcessorTest {
         val actualElementaryEventBasicInfo = publicDataUploadProcessor.createElementaryEventBasicInfo(jsonString)
         val expectedElementaryEventBasicInfo =
             ElementaryEventBasicInfo(
-                companyId = dummyCompanyId,
+                companyId = companyId,
                 framework = DataTypeEnum.heimathafen,
                 reportingPeriod = dummyReportingPeriod,
             )
 
         assertEquals(expectedElementaryEventBasicInfo, actualElementaryEventBasicInfo)
+    }
+
+    @Test
+    fun `do not create an elementary event when the dataset has been rejected`() {
+        val qaCompletedMessage = QaCompletedMessage(dataId.toString(), QaStatus.Rejected, "reviewerId", "message")
+        val payload = objectMapper.writeValueAsString(qaCompletedMessage)
+
+        publicDataUploadProcessor.processEvent(payload, "correlationId", MessageType.QA_COMPLETED)
+
+        Mockito.verifyNoInteractions(elementaryEventRepositoryMock)
+    }
+
+    @Test
+    fun `create an elementary event when the dataset has been approved`() {
+        val qaCompletedMessage = QaCompletedMessage(dataId.toString(), QaStatus.Accepted, "reviewerId", "message")
+        val payload = objectMapper.writeValueAsString(qaCompletedMessage)
+
+        publicDataUploadProcessor.processEvent(payload, "correlationId", MessageType.QA_COMPLETED)
+
+        verify(elementaryEventRepositoryMock, times(1)).saveAndFlush(any())
     }
 }

--- a/dataland-qa-service/src/main/kotlin/org/dataland/datalandqaservice/services/QaEventListenerQaService.kt
+++ b/dataland-qa-service/src/main/kotlin/org/dataland/datalandqaservice/services/QaEventListenerQaService.kt
@@ -100,10 +100,10 @@ class QaEventListenerQaService
                 throw MessageQueueRejectException("Provided data ID is empty")
             }
 
-            val dataMetaInfo = metaDataControllerApi.getDataMetaInfo(dataId)
-            val companyName = companyDataControllerApi.getCompanyById(dataMetaInfo.companyId).companyInformation.companyName
-
             messageUtils.rejectMessageOnException {
+                val dataMetaInfo = metaDataControllerApi.getDataMetaInfo(dataId)
+                val companyName = companyDataControllerApi.getCompanyById(dataMetaInfo.companyId).companyInformation.companyName
+
                 logger.info("Received data with DataId: $dataId on QA message queue with Correlation Id: $correlationId")
                 storeDatasetAsToBeReviewed(
                     dataId,


### PR DESCRIPTION
# Pull Request \<Title>
`<Description here>`
## Things to do during Peer Review
Please check all boxes before the Pull Request is merged. In case you skip a box, describe in the PRs description (that means: here) why the check is skipped.
- [x] The GitHub Actions (including Sonarqube Gateway and Lint Checks) are green. This is enforced by GitHub. 
- [x] The PR has been peer-reviewed
  - [x] The code has been manually inspected by someone who did not implement the feature
  - [ ] If this PR includes work on the frontend, at least one `@ts-nocheck` is removed. Additionally, there should not be any `@ts-nocheck` in files modified by this PR. If no `@ts-nocheck` are left: Celebrate :tada: :confetti_ball: type-safety and remove this entry. 
- [x] The PR actually implements what is described in the JIRA-Issue
- [x] At least one test exists testing the new feature
  - [ ] If you have created new test files, make sure that they are included in a test container and actually run in the CI
- [ ] At least 3 consecutive CI runs are successfully executed to ensure that there are no flaky tests.
- [x] Documentation is updated as required
- [x] The automated deployment is updated if required
- [x] If there was a database entity class added, there must also be a migration script for creating the corresponding database if flyway is already used by the service
- [x] IF there are changes done to the framework data models or to a database entity class, the following steps were completed in order
  - [x] A fresh clone of dataland.com is generated (see Wiki page on "OTC" for details)
  - [x] The feature branch is deployed to clone with `Reset non-user related Docker Volumes & Re-populate` turned off
  - [x] It's verified that the CD run is green
  - [x] The new feature is manually used/tested/observed on the clone server. Testing of the new feature should (also) be done by a second, independent reviewer from the dev team
  - [x] The feature branch is deployed to dev1 with `Reset non-user related Docker Volumes & Re-populate` turned on, and it's verified that the CD run is green  
- [ ] ELSE, the new version is deployed to the dev server "dev1" using this branch
  - [ ] Run with setting `Reset non-user related Docker Volumes & Re-populate` turned on 
  - [ ] It's verified that this version actually is the one deployed (check gitinfo for branch name and commit id!)
  - [ ] It's verified that the CD run is green
  - [ ] The new feature is manually used/tested/observed on dev server. Testing of the new feature should (also) be done by a second, independent reviewer from the dev team
- [x] Confirm that the latest version of the feature is deployed to the dev server "dev1" using this branch (no longer enforced by GitHub)