### PR TITLE
Fix SonarQube issues

### DIFF
--- a/dataland-backend/backendOpenApi.json
+++ b/dataland-backend/backendOpenApi.json
@@ -18115,7 +18115,7 @@
         ],
         "type": "object",
         "properties": {
-          "lei": {
+          "sector": {
             "type": "string",
             "nullable": true
           },
@@ -18131,7 +18131,7 @@
           "companyName": {
             "type": "string"
           },
-          "sector": {
+          "lei": {
             "type": "string",
             "nullable": true
           }

--- a/dataland-backend/src/main/kotlin/org/dataland/datalandbackend/services/PrivateDataManager.kt
+++ b/dataland-backend/src/main/kotlin/org/dataland/datalandbackend/services/PrivateDataManager.kt
@@ -88,11 +88,11 @@ class PrivateDataManager(
         storeJsonInMemory(dataId, storableDataSet, correlationId)
         val metaInfoEntity = buildMetaInfoEntity(dataId, storableDataSet)
         storeMetaInfoEntityInMemory(dataId, metaInfoEntity, correlationId)
-        val documentHashes =
+        val documentHashes : Map<String, String> =
             documents
                 ?.takeIf { it.isNotEmpty() }
                 ?.let { storeDocumentsInMemoryAndReturnTheirHashes(dataId, it, correlationId) }
-                ?: mutableMapOf()
+                ?: mapOf()
         sendReceptionMessage(dataId, storableDataSet, correlationId, documentHashes)
         return metaInfoEntity.toApiModel(userAuthentication)
     }
@@ -226,7 +226,7 @@ class PrivateDataManager(
                 eurodatId = "JSON",
             )
         dataIdAndHashToEurodatIdMappingRepository.save(dataIdToJsonMappingEntity)
-        val documentHashes = documentHashesInMemoryStorage[dataId]
+        val documentHashes : Map<String, String>? = documentHashesInMemoryStorage[dataId]
         if (!documentHashes.isNullOrEmpty()) {
             val dataIdToDocumentHashMappingEntities =
                 documentHashes.map { documentHash ->

--- a/dataland-batch-manager/src/main/kotlin/org/dataland/datalandbatchmanager/service/RelationshipExtractor.kt
+++ b/dataland-batch-manager/src/main/kotlin/org/dataland/datalandbatchmanager/service/RelationshipExtractor.kt
@@ -17,7 +17,7 @@ class RelationshipExtractor {
      *  @return The final mapping of child LEI to parent LEI as MutableMap<String, String>
      */
     fun prepareFinalParentMapping(gleifParser: Iterable<GleifRelationshipInformation>): Map<String, String> {
-        val mappings = parseCsvToGroupedMap(gleifParser)
+        val mappings : Map<GleifRelationshipTypes, MutableMap<String, String>> = parseCsvToGroupedMap(gleifParser)
 
         val localFinalParentMapping = mappings[GleifRelationshipTypes.IS_ULTIMATELY_CONSOLIDATED_BY] ?: mutableMapOf()
         val orderOfImportance =

--- a/dataland-data-exporter/src/main/kotlin/org/dataland/datalanddataexporter/utils/TransformationUtils.kt
+++ b/dataland-data-exporter/src/main/kotlin/org/dataland/datalanddataexporter/utils/TransformationUtils.kt
@@ -67,7 +67,7 @@ object TransformationUtils {
         node: JsonNode,
         transformationRules: Map<String, String>,
     ) {
-        val leafNodesInJsonNode = getNonArrayLeafNodeFieldNames(node, "")
+        val leafNodesInJsonNode : List<String> = getNonArrayLeafNodeFieldNames(node, "")
         val filteredNodes = leafNodesInJsonNode.filter { !it.contains(NODE_FILTER) }
         require(transformationRules.keys.containsAll(filteredNodes)) {
             "Transformation rules do not cover all leaf nodes in the data."

--- a/dataland-specification-lib/src/main/kotlin/org/dataland/datalandspecification/specifications/FrameworkSpecification.kt
+++ b/dataland-specification-lib/src/main/kotlin/org/dataland/datalandspecification/specifications/FrameworkSpecification.kt
@@ -53,7 +53,7 @@ data class FrameworkSpecification(
      */
     fun validateIntegrity(database: SpecificationDatabase) {
         VerificationUtils.assertValidId(id)
-        val dataPointIds = database.dataPointSpecifications.keys
+        val dataPointIds : Set<String> = database.dataPointSpecifications.keys
         val schemaDataPointIds = flattenedSchema.map { it.dataPointId }.toSet()
         val missingDataPointIds = schemaDataPointIds - dataPointIds
         check(missingDataPointIds.isEmpty()) { "The following data point ids are missing in the database: $missingDataPointIds" }


### PR DESCRIPTION
# Pull Request DALA-5189_manual_maintenance (SonarQube)
Adjustments to fix code smells.
## Things to do during Peer Review
Please check all boxes before the Pull Request is merged. In case you skip a box, describe in the PRs description (that means: here) why the check is skipped.
- [x] The GitHub Actions (including Sonarqube Gateway and Lint Checks) are green. This is enforced by GitHub. 
- [ ] The PR has been peer-reviewed
  - [ ] The code has been manually inspected by someone who did not implement the feature
  - [ ] If this PR includes work on the frontend, at least one `@ts-nocheck` is removed. Additionally, there should not be any `@ts-nocheck` in files modified by this PR. If no `@ts-nocheck` are left: Celebrate :tada: :confetti_ball: type-safety and remove this entry. 
- [ ] The PR actually implements what is described in the JIRA-Issue
- [ ] At least one test exists testing the new feature
  - [ ] If you have created new test files, make sure that they are included in a test container and actually run in the CI
- [ ] At least 3 consecutive CI runs are successfully executed to ensure that there are no flaky tests.
- [ ] Documentation is updated as required
- [ ] The automated deployment is updated if required
- [ ] If there was a database entity class added, there must also be a migration script for creating the corresponding database if flyway is already used by the service
- [ ] IF there are changes done to the framework data models or to a database entity class, the following steps were completed in order
  - [ ] A fresh clone of dataland.com is generated (see Wiki page on "OTC" for details)
  - [ ] The feature branch is deployed to clone with `Reset non-user related Docker Volumes & Re-populate` turned off
  - [ ] It's verified that the CD run is green
  - [ ] The new feature is manually used/tested/observed on the clone server. Testing of the new feature should (also) be done by a second, independent reviewer from the dev team
  - [ ] The feature branch is deployed to dev1 with `Reset non-user related Docker Volumes & Re-populate` turned on, and it's verified that the CD run is green  
- [ ] ELSE, the new version is deployed to the dev server "dev1" using this branch
  - [ ] Run with setting `Reset non-user related Docker Volumes & Re-populate` turned on 
  - [ ] It's verified that this version actually is the one deployed (check gitinfo for branch name and commit id!)
  - [ ] It's verified that the CD run is green
  - [ ] The new feature is manually used/tested/observed on dev server. Testing of the new feature should (also) be done by a second, independent reviewer from the dev team
- [ ] Confirm that the latest version of the feature is deployed to the dev server "dev1" using this branch (no longer enforced by GitHub)