### PR TITLE
Dala 5264 fix get requests endpoint

### DIFF
--- a/dataland-community-manager/src/main/kotlin/org/dataland/datalandcommunitymanager/services/DataRequestQueryManager.kt
+++ b/dataland-community-manager/src/main/kotlin/org/dataland/datalandcommunitymanager/services/DataRequestQueryManager.kt
@@ -144,6 +144,8 @@ class DataRequestQueryManager
         ): List<ExtendedStoredDataRequest>? {
             val offset = (chunkIndex ?: 0) * (chunkSize ?: 0)
 
+            filter.setupEmailAddressFilter(keycloakUserControllerApiService)
+
             val extendedStoredDataRequests =
                 dataRequestRepository
                     .searchDataRequestEntity(

--- a/dataland-community-manager/src/test/kotlin/org/dataland/datalandcommunitymanager/services/DataRequestQueryManagerTest.kt
+++ b/dataland-community-manager/src/test/kotlin/org/dataland/datalandcommunitymanager/services/DataRequestQueryManagerTest.kt
@@ -201,7 +201,7 @@ class DataRequestQueryManagerTest {
                 null,
             )
 
-        verify(mockKeycloakUserService, times(1)).searchUsers(emailAddressSubstring)
+        verify(mockKeycloakUserService, times(2)).searchUsers(emailAddressSubstring)
         verify(mockKeycloakUserService, times(0)).getUser(anyString())
         assertEquals(1, queryResults!!.size)
         assertEquals(keycloakUserBeta.email, queryResults[0].userEmailAddress)

--- a/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/tests/communityManager/QueryDataRequestsTest.kt
+++ b/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/tests/communityManager/QueryDataRequestsTest.kt
@@ -324,7 +324,7 @@ class QueryDataRequestsTest {
     }
 
     @Test
-    fun `test that querying by e-mail does not throw an error due to the setupEmailAddressFilter not being called`() {
+    fun `test that querying by email does not throw an error due to the setupEmailAddressFilter not being called`() {
         assertDoesNotThrow {
             api.getDataRequests(emailAddress = "test@test.com", chunkSize = chunkSize)
         }

--- a/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/tests/communityManager/QueryDataRequestsTest.kt
+++ b/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/tests/communityManager/QueryDataRequestsTest.kt
@@ -324,7 +324,7 @@ class QueryDataRequestsTest {
     }
 
     @Test
-    fun `test that querying by e-mail doesn't throw an error due to the setupEmailAddressFilter not being called`() {
+    fun `test that querying by e-mail does not throw an error due to the setupEmailAddressFilter not being called`() {
         assertDoesNotThrow {
             api.getDataRequests(emailAddress = "test@test.com", chunkSize = chunkSize)
         }

--- a/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/tests/communityManager/QueryDataRequestsTest.kt
+++ b/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/tests/communityManager/QueryDataRequestsTest.kt
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import java.util.UUID
 
@@ -320,5 +321,12 @@ class QueryDataRequestsTest {
                     chunkSize = chunkSize,
                 ).filter { it.creationTimestamp > timestampBeforePost }
         assertEquals(1, combinedQueryResults.size)
+    }
+
+    @Test
+    fun `test that querying by e-mail doesn't throw an error due to the setupEmailAddressFilter not being called`() {
+        assertDoesNotThrow {
+            api.getDataRequests(emailAddress = "test@test.com", chunkSize = chunkSize)
+        }
     }
 }


### PR DESCRIPTION
# Pull Request \<Title>
`<Description here>`
## Things to do during Peer Review
Please check all boxes before the Pull Request is merged. In case you skip a box, describe in the PRs description (that means: here) why the check is skipped.
- [x] The GitHub Actions (including Sonarqube Gateway and Lint Checks) are green. This is enforced by GitHub. 
- [x] The PR has been peer-reviewed
  - [x] The code has been manually inspected by someone who did not implement the feature
  - [ ] If this PR includes work on the frontend, at least one `@ts-nocheck` is removed. Additionally, there should not be any `@ts-nocheck` in files modified by this PR. If no `@ts-nocheck` are left: Celebrate :tada: :confetti_ball: type-safety and remove this entry. 
- [x] The PR actually implements what is described in the JIRA-Issue
- [x] At least one test exists testing the new feature
  - [x] If you have created new test files, make sure that they are included in a test container and actually run in the CI
- [x] At least 3 consecutive CI runs are successfully executed to ensure that there are no flaky tests.
- [ ] Documentation is updated as required
- [ ] The automated deployment is updated if required
- [ ] If there was a database entity class added, there must also be a migration script for creating the corresponding database if flyway is already used by the service
- [ ] IF there are changes done to the framework data models or to a database entity class, the following steps were completed in order
  - [ ] A fresh clone of dataland.com is generated (see Wiki page on "OTC" for details)
  - [ ] The feature branch is deployed to clone with `Reset non-user related Docker Volumes & Re-populate` turned off
  - [ ] It's verified that the CD run is green
  - [ ] The new feature is manually used/tested/observed on the clone server. Testing of the new feature should (also) be done by a second, independent reviewer from the dev team
  - [ ] The feature branch is deployed to dev1 with `Reset non-user related Docker Volumes & Re-populate` turned on, and it's verified that the CD run is green  
- [ ] ELSE, the new version is deployed to the dev server "dev1" using this branch
  - [x] Run with setting `Reset non-user related Docker Volumes & Re-populate` turned on 
  - [ ] It's verified that this version actually is the one deployed (check gitinfo for branch name and commit id!)
  - [x] It's verified that the CD run is green
  - [x] The new feature is manually used/tested/observed on dev server. Testing of the new feature should (also) be done by a second, independent reviewer from the dev team
- [ ] Confirm that the latest version of the feature is deployed to the dev server "dev1" using this branch (no longer enforced by GitHub)