### PR TITLE
Dala 5391 updates issue

### DIFF
--- a/dataland-batch-manager/src/main/kotlin/org/dataland/datalandbatchmanager/service/ProcessDataUpdates.kt
+++ b/dataland-batch-manager/src/main/kotlin/org/dataland/datalandbatchmanager/service/ProcessDataUpdates.kt
@@ -137,7 +137,7 @@ class ProcessDataUpdates
         }
 
         @Suppress("UnusedPrivateMember") // Detect does not recognise the scheduled execution of this function
-        @Scheduled(cron = "0 0 5 * * *")
+        @Scheduled(cron = "0 */5 * * * *")
         private fun processRequestPriorityUpdates() {
             logger.info("Running scheduled update of request priorities.")
             waitForCommunityManager()

--- a/dataland-batch-manager/src/main/kotlin/org/dataland/datalandbatchmanager/service/RequestPriorityUpdater.kt
+++ b/dataland-batch-manager/src/main/kotlin/org/dataland/datalandbatchmanager/service/RequestPriorityUpdater.kt
@@ -37,6 +37,7 @@ class RequestPriorityUpdater
                     keycloakUserService.getUsersByRole(roleName).map { it.userId },
                 )
             }
+            logger.info("Premium user IDs: $premiumUserIds")
 
             updateRequestPriorities(
                 currentPriority = RequestPriority.Low,
@@ -67,10 +68,12 @@ class RequestPriorityUpdater
                     requestStatus = setOf(RequestStatus.Open),
                     requestPriority = setOf(currentPriority),
                 )
+            logger.info("Found ${requests.size} requests with priority $currentPriority.")
             requests
                 .filter(filterCondition)
                 .forEach { (dataRequestId) ->
                     runCatching {
+                        logger.info("Updating request priority of request $dataRequestId to $newPriority.")
                         requestControllerApi.patchDataRequest(
                             dataRequestId = UUID.fromString(dataRequestId),
                             dataRequestPatch =

--- a/dataland-batch-manager/src/main/kotlin/org/dataland/datalandbatchmanager/service/RequestPriorityUpdater.kt
+++ b/dataland-batch-manager/src/main/kotlin/org/dataland/datalandbatchmanager/service/RequestPriorityUpdater.kt
@@ -37,15 +37,15 @@ class RequestPriorityUpdater
                     keycloakUserService.getUsersByRole(roleName).map { it.userId },
                 )
             }
-            logger.info("Premium user IDs: $premiumUserIds")
+            logger.info("Found ${premiumUserIds.size} premium users and administrators.")
 
-            logger.info("Updating request priorities based on user roles Premium user.")
+            logger.info("Upgrading request priorities from Low to High for premium users.")
             updateRequestPriorities(
                 currentPriority = RequestPriority.Low,
                 newPriority = RequestPriority.High,
             ) { request -> request.userId in premiumUserIds }
 
-            logger.info("Updating request priorities based on user roles non-Premium user.")
+            logger.info("Downgrading request priorities from High to Low for regular users.")
             updateRequestPriorities(
                 currentPriority = RequestPriority.High,
                 newPriority = RequestPriority.Low,
@@ -76,12 +76,10 @@ class RequestPriorityUpdater
                     requestPriority = setOf(currentPriority),
                     chunkSize = expectedRequests,
                 )
-            logger.info("Found ${requests.size} requests with priority $currentPriority.")
             requests
                 .filter(filterCondition)
                 .forEach { (dataRequestId) ->
                     runCatching {
-                        logger.info("Updating request priority of request $dataRequestId to $newPriority.")
                         requestControllerApi.patchDataRequest(
                             dataRequestId = UUID.fromString(dataRequestId),
                             dataRequestPatch =

--- a/dataland-batch-manager/src/main/kotlin/org/dataland/datalandbatchmanager/service/RequestPriorityUpdater.kt
+++ b/dataland-batch-manager/src/main/kotlin/org/dataland/datalandbatchmanager/service/RequestPriorityUpdater.kt
@@ -39,11 +39,13 @@ class RequestPriorityUpdater
             }
             logger.info("Premium user IDs: $premiumUserIds")
 
+            logger.info("Updating request priorities based on user roles Premium user.")
             updateRequestPriorities(
                 currentPriority = RequestPriority.Low,
                 newPriority = RequestPriority.High,
             ) { request -> request.userId in premiumUserIds }
 
+            logger.info("Updating request priorities based on user roles non-Premium user.")
             updateRequestPriorities(
                 currentPriority = RequestPriority.High,
                 newPriority = RequestPriority.Low,

--- a/dataland-batch-manager/src/main/kotlin/org/dataland/datalandbatchmanager/service/RequestPriorityUpdater.kt
+++ b/dataland-batch-manager/src/main/kotlin/org/dataland/datalandbatchmanager/service/RequestPriorityUpdater.kt
@@ -65,10 +65,16 @@ class RequestPriorityUpdater
             newPriority: RequestPriority,
             filterCondition: (ExtendedStoredDataRequest) -> Boolean,
         ) {
+            val expectedRequests = requestControllerApi.getNumberOfRequests(
+                requestStatus = setOf(RequestStatus.Open),
+                requestPriority = setOf(currentPriority),
+            )
+            logger.info("Found $expectedRequests requests with priority $currentPriority to be considered for updating.")
             val requests =
                 requestControllerApi.getDataRequests(
                     requestStatus = setOf(RequestStatus.Open),
                     requestPriority = setOf(currentPriority),
+                    chunkSize = expectedRequests,
                 )
             logger.info("Found ${requests.size} requests with priority $currentPriority.")
             requests


### PR DESCRIPTION
# Pull Request \<Title>
`<Description here>`
## Things to do during Peer Review
Please check all boxes before the Pull Request is merged. In case you skip a box, describe in the PRs description (that means: here) why the check is skipped.
- [x] The GitHub Actions for the CI are green. This is enforced by GitHub. 
- [ ] The PR has been peer-reviewed
  - [ ] The code has been manually inspected by someone who did not implement the feature
  - [ ] If this PR includes work on the frontend, at least one `@ts-nocheck` is removed. Additionally, there should not be any `@ts-nocheck` in files modified by this PR. If no `@ts-nocheck` are left: Celebrate :tada: :confetti_ball: type-safety and remove this entry. 
- [ ] The PR actually implements what is described in the JIRA-Issue
- [ ] At least one test exists testing the new feature
  - [ ] Make sure all newly added functionality (especially user facing) is tested
  - [ ] Make sure that new test files are included in a test container and actually run in the CI
- [ ] At least 3 consecutive CI runs are successfully executed to ensure that there are no flaky tests.
- [ ] Documentation is updated as required. If unsure whether or what to update, ask a fellow developer.
- [ ] If there was a database entity class added, there must also be a migration script for creating the corresponding database if flyway is already used by the service
- [ ] IF there are changes done to the framework data models or to a database entity class, the following steps were completed in order
  - [ ] A fresh clone of dataland.com is generated (see Wiki page on "OTC" for details)
  - [ ] The feature branch is deployed to clone with `Reset non-user related Docker Volumes & Re-populate` turned off
  - [ ] It's verified that the CD run is green
  - [ ] The new feature is manually used/tested/observed on the clone server. Testing of the new feature should (also) be done by a second, independent reviewer from the dev team
  - [ ] The feature branch is deployed to one of the dev servers with `Reset non-user related Docker Volumes & Re-populate` turned on, and it's verified that the CD run is green
- [ ] ELSE, the new version is deployed to one of the dev servers using this branch
  - [ ] Run with setting `Reset non-user related Docker Volumes & Re-populate` turned on 
  - [ ] It's verified that this version actually is the one deployed (check gitinfo for branch name and commit id!)
  - [ ] It's verified that the CD run is green
  - [ ] The new feature is manually used/tested/observed on dev server. Testing of the new feature should (also) be done by a second, independent reviewer from the dev team
- [ ] Confirm that the latest version (use the /gitinfo endpoint) of the feature branch is deployed to one of the dev servers (no longer enforced by GitHub)
