### PR TITLE
DALA-5452 Fix Data Migration for Additional-Company-Information

### DIFF
--- a/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/tests/InvalidSfdrRequestTests.kt
+++ b/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/tests/InvalidSfdrRequestTests.kt
@@ -2,8 +2,10 @@ package org.dataland.e2etests.tests
 
 import org.dataland.datalandbackend.openApiClient.infrastructure.ClientError
 import org.dataland.datalandbackend.openApiClient.infrastructure.ClientException
+import org.dataland.datalandbackend.openApiClient.model.SfdrData
 import org.dataland.e2etests.utils.ApiAccessor
 import org.dataland.e2etests.utils.DocumentManagerAccessor
+import org.dataland.e2etests.utils.testDataProvivders.FrameworkTestDataProvider
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
@@ -23,9 +25,7 @@ class InvalidSfdrRequestTests {
     }
 
     fun getErrorFromApi(companyName: String): ClientException {
-        val oneInvalidSfdrDataset =
-            apiAccessor.testDataProviderForSfdrData
-                .getSpecificCompanyByNameFromSfdrPreparedFixtures(companyName)
+        val oneInvalidSfdrDataset = FrameworkTestDataProvider.forFrameworkPreparedFixtures(SfdrData::class.java).getByCompanyName(companyName)
         Assertions.assertNotNull(oneInvalidSfdrDataset)
         val companyInformation = apiAccessor.uploadOneCompanyWithRandomIdentifier()
         val errorForInvalidInput =

--- a/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/tests/InvalidSfdrRequestTests.kt
+++ b/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/tests/InvalidSfdrRequestTests.kt
@@ -25,7 +25,10 @@ class InvalidSfdrRequestTests {
     }
 
     fun getErrorFromApi(companyName: String): ClientException {
-        val oneInvalidSfdrDataset = FrameworkTestDataProvider.forFrameworkPreparedFixtures(SfdrData::class.java).getByCompanyName(companyName)
+        val oneInvalidSfdrDataset =
+            FrameworkTestDataProvider
+                .forFrameworkPreparedFixtures(SfdrData::class.java)
+                .getByCompanyName(companyName)
         Assertions.assertNotNull(oneInvalidSfdrDataset)
         val companyInformation = apiAccessor.uploadOneCompanyWithRandomIdentifier()
         val errorForInvalidInput =

--- a/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/tests/communityManager/accessRequests/AccessRequestTest.kt
+++ b/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/tests/communityManager/accessRequests/AccessRequestTest.kt
@@ -34,7 +34,7 @@ class AccessRequestTest {
     private val requestControllerApi = RequestControllerApi(BASE_PATH_TO_COMMUNITY_MANAGER)
     val jwtHelper = JwtAuthenticationHelper()
 
-    private val testVsmeData = FrameworkTestDataProvider(VsmeData::class.java).getTData(1).first()
+    private val testVsmeData = FrameworkTestDataProvider.forFrameworkFixtures(VsmeData::class.java).getTData(1).first()
     private lateinit var dummyFileAlpha: File
     private val fileNameAlpha = "Report-Alpha"
     private lateinit var hashAlpha: String

--- a/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/tests/dataPoints/AssembledDatasetTest.kt
+++ b/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/tests/dataPoints/AssembledDatasetTest.kt
@@ -26,7 +26,7 @@ import java.util.UUID
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class AssembledDatasetTest {
-    private val testDataProvider = FrameworkTestDataProvider(AdditionalCompanyInformationData::class.java)
+    private val testDataProvider = FrameworkTestDataProvider.forFrameworkFixtures(AdditionalCompanyInformationData::class.java)
     private val dummyDataset = testDataProvider.getTData(1)[0]
     private val apiAccessor = ApiAccessor()
     private val linkedQaReportDataFile = File("./build/resources/test/AdditionalCompanyInformationQaReportPreparedFixtures.json")

--- a/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/tests/frameworks/EuTaxonomyFinancials.kt
+++ b/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/tests/frameworks/EuTaxonomyFinancials.kt
@@ -2,8 +2,12 @@ package org.dataland.e2etests.tests.frameworks
 
 import org.dataland.datalandbackend.openApiClient.infrastructure.ClientError
 import org.dataland.datalandbackend.openApiClient.infrastructure.ClientException
+import org.dataland.datalandbackend.openApiClient.model.EutaxonomyFinancialsData
+import org.dataland.datalandbackend.openApiClient.model.EutaxonomyNonFinancialsData
+import org.dataland.datalandbackend.openApiClient.model.SfdrData
 import org.dataland.e2etests.utils.ApiAccessor
 import org.dataland.e2etests.utils.QaApiAccessor
+import org.dataland.e2etests.utils.testDataProvivders.FrameworkTestDataProvider
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -45,8 +49,7 @@ class EuTaxonomyFinancials {
         val companyName = "TestForIncompleteReferencedReport"
 
         val companyInformation =
-            apiAccessor.testDataProviderEuTaxonomyForFinancials
-                .getSpecificCompanyByNameFromEuTaxonomyFinancialsPreparedFixtures(companyName)
+            FrameworkTestDataProvider.forFrameworkPreparedFixtures(EutaxonomyFinancialsData::class.java).getByCompanyName(companyName)
         val dataSet = companyInformation!!.t
 
         val uploadPair = Pair(dataSet, "2023")

--- a/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/tests/frameworks/EuTaxonomyFinancials.kt
+++ b/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/tests/frameworks/EuTaxonomyFinancials.kt
@@ -3,8 +3,6 @@ package org.dataland.e2etests.tests.frameworks
 import org.dataland.datalandbackend.openApiClient.infrastructure.ClientError
 import org.dataland.datalandbackend.openApiClient.infrastructure.ClientException
 import org.dataland.datalandbackend.openApiClient.model.EutaxonomyFinancialsData
-import org.dataland.datalandbackend.openApiClient.model.EutaxonomyNonFinancialsData
-import org.dataland.datalandbackend.openApiClient.model.SfdrData
 import org.dataland.e2etests.utils.ApiAccessor
 import org.dataland.e2etests.utils.QaApiAccessor
 import org.dataland.e2etests.utils.testDataProvivders.FrameworkTestDataProvider

--- a/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/tests/frameworks/EuTaxonomyNonFinancials.kt
+++ b/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/tests/frameworks/EuTaxonomyNonFinancials.kt
@@ -3,7 +3,6 @@ package org.dataland.e2etests.tests.frameworks
 import org.dataland.datalandbackend.openApiClient.infrastructure.ClientError
 import org.dataland.datalandbackend.openApiClient.infrastructure.ClientException
 import org.dataland.datalandbackend.openApiClient.model.EutaxonomyNonFinancialsData
-import org.dataland.datalandbackend.openApiClient.model.SfdrData
 import org.dataland.e2etests.utils.ApiAccessor
 import org.dataland.e2etests.utils.DocumentManagerAccessor
 import org.dataland.e2etests.utils.testDataProvivders.FrameworkTestDataProvider

--- a/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/tests/frameworks/EuTaxonomyNonFinancials.kt
+++ b/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/tests/frameworks/EuTaxonomyNonFinancials.kt
@@ -2,8 +2,11 @@ package org.dataland.e2etests.tests.frameworks
 
 import org.dataland.datalandbackend.openApiClient.infrastructure.ClientError
 import org.dataland.datalandbackend.openApiClient.infrastructure.ClientException
+import org.dataland.datalandbackend.openApiClient.model.EutaxonomyNonFinancialsData
+import org.dataland.datalandbackend.openApiClient.model.SfdrData
 import org.dataland.e2etests.utils.ApiAccessor
 import org.dataland.e2etests.utils.DocumentManagerAccessor
+import org.dataland.e2etests.utils.testDataProvivders.FrameworkTestDataProvider
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
@@ -74,8 +77,7 @@ class EuTaxonomyNonFinancials {
         val companyName = "TestForIncompleteReferencedReport"
 
         val companyInformation =
-            apiAccessor.testDataProviderForEuTaxonomyDataForNonFinancials
-                .getSpecificCompanyByNameFromEuTaxonomyNonFinancialsPreparedFixtures(companyName)
+            FrameworkTestDataProvider.forFrameworkPreparedFixtures(EutaxonomyNonFinancialsData::class.java).getByCompanyName(companyName)
 
         val dataSet = companyInformation!!.t
 

--- a/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/tests/frameworks/Lksg.kt
+++ b/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/tests/frameworks/Lksg.kt
@@ -6,8 +6,10 @@ import org.dataland.datalandbackend.openApiClient.model.DataAndMetaInformationLk
 import org.dataland.datalandbackend.openApiClient.model.LksgData
 import org.dataland.datalandbackend.openApiClient.model.LksgGrievanceAssessmentMechanism
 import org.dataland.datalandbackend.openApiClient.model.LksgProcurementCategory
+import org.dataland.datalandbackend.openApiClient.model.SfdrData
 import org.dataland.e2etests.utils.ApiAccessor
 import org.dataland.e2etests.utils.DocumentManagerAccessor
+import org.dataland.e2etests.utils.testDataProvivders.FrameworkTestDataProvider
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
@@ -118,8 +120,7 @@ class Lksg {
         val companyId = "1908273127903192839781293898312983"
         val companyName = "TestForBrokenFileReference"
         val companyInformation =
-            apiAccessor.testDataProviderForLksgData
-                .getSpecificCompanyByNameFromLksgPreparedFixtures(companyName)
+            FrameworkTestDataProvider.forFrameworkPreparedFixtures(LksgData::class.java).getByCompanyName(companyName)
         val lksgData = companyInformation!!.t
 
         val dataSet = removeNullMapEntriesFromSupplierCountryCountAndSortAllRiskPositions(lksgData)

--- a/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/tests/frameworks/Lksg.kt
+++ b/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/tests/frameworks/Lksg.kt
@@ -6,7 +6,6 @@ import org.dataland.datalandbackend.openApiClient.model.DataAndMetaInformationLk
 import org.dataland.datalandbackend.openApiClient.model.LksgData
 import org.dataland.datalandbackend.openApiClient.model.LksgGrievanceAssessmentMechanism
 import org.dataland.datalandbackend.openApiClient.model.LksgProcurementCategory
-import org.dataland.datalandbackend.openApiClient.model.SfdrData
 import org.dataland.e2etests.utils.ApiAccessor
 import org.dataland.e2etests.utils.DocumentManagerAccessor
 import org.dataland.e2etests.utils.testDataProvivders.FrameworkTestDataProvider

--- a/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/tests/frameworks/Sfdr.kt
+++ b/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/tests/frameworks/Sfdr.kt
@@ -2,8 +2,10 @@ package org.dataland.e2etests.tests.frameworks
 
 import org.dataland.datalandbackend.openApiClient.infrastructure.ClientError
 import org.dataland.datalandbackend.openApiClient.infrastructure.ClientException
+import org.dataland.datalandbackend.openApiClient.model.SfdrData
 import org.dataland.e2etests.utils.ApiAccessor
 import org.dataland.e2etests.utils.DocumentManagerAccessor
+import org.dataland.e2etests.utils.testDataProvivders.FrameworkTestDataProvider
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
@@ -89,8 +91,7 @@ class Sfdr {
         val companyId = apiAccessor.uploadOneCompanyWithRandomIdentifier().actualStoredCompany.companyId
 
         val companyInformation =
-            apiAccessor.testDataProviderForSfdrData
-                .getSpecificCompanyByNameFromSfdrPreparedFixtures(companyName)
+            FrameworkTestDataProvider.forFrameworkPreparedFixtures(SfdrData::class.java).getByCompanyName(companyName)
 
         val dataSet = companyInformation!!.t
 

--- a/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/tests/frameworks/Vsme.kt
+++ b/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/tests/frameworks/Vsme.kt
@@ -37,7 +37,7 @@ class Vsme {
 
     private val requestControllerApi = RequestControllerApi(BASE_PATH_TO_COMMUNITY_MANAGER)
 
-    private val testVsmeData = FrameworkTestDataProvider(VsmeData::class.java).getTData(1).first()
+    private val testVsmeData = FrameworkTestDataProvider.forFrameworkFixtures(VsmeData::class.java).getTData(1).first()
 
     private val dataAdminUserId = UUID.fromString(TechnicalUser.Admin.technicalUserId)
 

--- a/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/utils/ApiAccessor.kt
+++ b/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/utils/ApiAccessor.kt
@@ -58,7 +58,7 @@ class ApiAccessor {
         EutaxonomyNonFinancialsDataControllerApi(BASE_PATH_TO_DATALAND_BACKEND)
     val unauthorizedEuTaxonomyDataNonFinancialsControllerApi = UnauthorizedEuTaxonomyDataNonFinancialsControllerApi()
     val testDataProviderForEuTaxonomyDataForNonFinancials =
-        FrameworkTestDataProvider(EutaxonomyNonFinancialsData::class.java)
+        FrameworkTestDataProvider.forFrameworkFixtures(EutaxonomyNonFinancialsData::class.java)
     val dataDeletionControllerApi = DataDeletionControllerApi(BASE_PATH_TO_DATALAND_BACKEND)
 
     fun euTaxonomyNonFinancialsUploaderFunction(
@@ -81,7 +81,7 @@ class ApiAccessor {
     val dataControllerApiForEuTaxonomyFinancials =
         EutaxonomyFinancialsDataControllerApi(BASE_PATH_TO_DATALAND_BACKEND)
     val testDataProviderEuTaxonomyForFinancials =
-        FrameworkTestDataProvider(EutaxonomyFinancialsData::class.java)
+        FrameworkTestDataProvider.forFrameworkFixtures(EutaxonomyFinancialsData::class.java)
 
     fun euTaxonomyFinancialsUploaderFunction(
         companyId: String,
@@ -97,7 +97,7 @@ class ApiAccessor {
     }
 
     val dataControllerApiForLksgData = LksgDataControllerApi(BASE_PATH_TO_DATALAND_BACKEND)
-    val testDataProviderForLksgData = FrameworkTestDataProvider(LksgData::class.java)
+    val testDataProviderForLksgData = FrameworkTestDataProvider.forFrameworkFixtures(LksgData::class.java)
 
     fun lksgUploaderFunction(
         companyId: String,
@@ -112,7 +112,7 @@ class ApiAccessor {
     }
 
     val dataControllerApiForP2pData = P2pDataControllerApi(BASE_PATH_TO_DATALAND_BACKEND)
-    val testDataProviderForP2pData = FrameworkTestDataProvider(PathwaysToParisData::class.java)
+    val testDataProviderForP2pData = FrameworkTestDataProvider.forFrameworkFixtures(PathwaysToParisData::class.java)
 
     fun p2pUploaderFunction(
         companyId: String,
@@ -127,7 +127,7 @@ class ApiAccessor {
     }
 
     val dataControllerApiForSfdrData = SfdrDataControllerApi(BASE_PATH_TO_DATALAND_BACKEND)
-    val testDataProviderForSfdrData = FrameworkTestDataProvider(SfdrData::class.java)
+    val testDataProviderForSfdrData = FrameworkTestDataProvider.forFrameworkFixtures(SfdrData::class.java)
 
     fun sfdrUploaderFunction(
         companyId: String,

--- a/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/utils/testDataProvivders/FrameworkTestDataProvider.kt
+++ b/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/utils/testDataProvivders/FrameworkTestDataProvider.kt
@@ -18,24 +18,59 @@ import java.util.UUID
 
 class FrameworkTestDataProvider<T>(
     private val clazz: Class<T>,
+    private val dataFile: File,
 ) {
-    private val jsonFilesForTesting =
-        mapOf(
-            EutaxonomyNonFinancialsData::class.java to
-                File("./build/resources/test/CompanyInformationWithEutaxonomyNonFinancialsData.json"),
-            EutaxonomyFinancialsData::class.java to
-                File("./build/resources/test/CompanyInformationWithEutaxonomyFinancialsData.json"),
-            LksgData::class.java to
-                File("./build/resources/test/CompanyInformationWithLksgData.json"),
-            SfdrData::class.java to
-                File("./build/resources/test/CompanyInformationWithSfdrData.json"),
-            VsmeData::class.java to
-                File("./build/resources/test/CompanyInformationWithVsmeData.json"),
-            PathwaysToParisData::class.java to
-                File("./build/resources/test/CompanyInformationWithP2pData.json"),
-            AdditionalCompanyInformationData::class.java to
-                File("./build/resources/test/CompanyInformationWithAdditionalCompanyInformationData.json"),
-        )
+    data class FrameworkTestDataConfiguration(
+        val fakeFixtureFile: File,
+        val preparedFixtureFile: File,
+    )
+
+    companion object {
+        private val jsonFilesForTesting =
+            mapOf(
+                EutaxonomyNonFinancialsData::class.java to
+                    FrameworkTestDataConfiguration(
+                        File("./build/resources/test/CompanyInformationWithEutaxonomyNonFinancialsData.json"),
+                        File("./build/resources/test/CompanyInformationWithEutaxonomyNonFinancialsPreparedFixtures.json"),
+                    ),
+                EutaxonomyFinancialsData::class.java to
+                    FrameworkTestDataConfiguration(
+                        File("./build/resources/test/CompanyInformationWithEutaxonomyFinancialsData.json"),
+                        File("./build/resources/test/CompanyInformationWithEutaxonomyFinancialsPreparedFixtures.json"),
+                    ),
+                LksgData::class.java to
+                    FrameworkTestDataConfiguration(
+                        File("./build/resources/test/CompanyInformationWithLksgData.json"),
+                        File("./build/resources/test/CompanyInformationWithLksgPreparedFixtures.json"),
+                    ),
+                SfdrData::class.java to
+                    FrameworkTestDataConfiguration(
+                        File("./build/resources/test/CompanyInformationWithSfdrData.json"),
+                        File("./build/resources/test/CompanyInformationWithSfdrPreparedFixtures.json"),
+                    ),
+                VsmeData::class.java to
+                    FrameworkTestDataConfiguration(
+                        File("./build/resources/test/CompanyInformationWithVsmeData.json"),
+                        File("./build/resources/test/CompanyInformationWithVsmePreparedFixtures.json"),
+                    ),
+                PathwaysToParisData::class.java to
+                    FrameworkTestDataConfiguration(
+                        File("./build/resources/test/CompanyInformationWithP2pData.json"),
+                        File("./build/resources/test/CompanyInformationWithP2pPreparedFixtures.json"),
+                    ),
+                AdditionalCompanyInformationData::class.java to
+                    FrameworkTestDataConfiguration(
+                        File("./build/resources/test/CompanyInformationWithAdditionalCompanyInformationData.json"),
+                        File("./build/resources/test/CompanyInformationWithAdditionalCompanyInformationPreparedFixtures.json"),
+                    ),
+            )
+
+        fun <T> forFrameworkFixtures(clazz: Class<T>): FrameworkTestDataProvider<T> =
+            FrameworkTestDataProvider(clazz, jsonFilesForTesting[clazz]!!.fakeFixtureFile)
+
+        fun <T> forFrameworkPreparedFixtures(clazz: Class<T>): FrameworkTestDataProvider<T> =
+            FrameworkTestDataProvider(clazz, jsonFilesForTesting[clazz]!!.preparedFixtureFile)
+    }
 
     private val moshi: Moshi =
         Moshi
@@ -44,8 +79,6 @@ class FrameworkTestDataProvider<T>(
             .add(BigDecimalAdapter)
             .add(LocalDateAdapter)
             .build()
-
-    private fun getJsonFileForTesting(): File = jsonFilesForTesting[clazz]!!
 
     private fun convertJsonToList(jsonFile: File): List<CompanyInformationWithT<T>> {
         val jsonFileAsString = jsonFile.inputStream().bufferedReader().readText()
@@ -60,7 +93,7 @@ class FrameworkTestDataProvider<T>(
         return jsonAdapter.fromJson(jsonFileAsString)!!
     }
 
-    private val testCompanyInformationWithTData = convertJsonToList(getJsonFileForTesting())
+    private val testCompanyInformationWithTData = convertJsonToList(dataFile)
 
     fun getCompanyInformationWithoutIdentifiers(requiredQuantity: Int): List<CompanyInformation> =
         testCompanyInformationWithTData
@@ -71,42 +104,6 @@ class FrameworkTestDataProvider<T>(
                     companyContactDetails = emptyList(),
                 )
             }
-
-    private fun companyListForTestingLksgSpecificValidation(): List<CompanyInformationWithT<T>> =
-        convertJsonToList(File("./build/resources/test/CompanyInformationWithLksgPreparedFixtures.json"))
-
-    private fun companyListForTestingSfdrSpecificValidation(): List<CompanyInformationWithT<T>> =
-        convertJsonToList(File("./build/resources/test/CompanyInformationWithSfdrPreparedFixtures.json"))
-
-    private fun companyListForTestingEuTaxonomyNonFinancialsSpecificValidation(): List<CompanyInformationWithT<T>> =
-        convertJsonToList(
-            File("./build/resources/test/CompanyInformationWithEutaxonomyNonFinancialsPreparedFixtures.json"),
-        )
-
-    private fun companyListForTestingEuTaxonomyFinancialsSpecificValidation(): List<CompanyInformationWithT<T>> =
-        convertJsonToList(
-            File("./build/resources/test/CompanyInformationWithEutaxonomyFinancialsPreparedFixtures.json"),
-        )
-
-    fun getSpecificCompanyByNameFromLksgPreparedFixtures(companyName: String): CompanyInformationWithT<T>? =
-        companyListForTestingLksgSpecificValidation().find {
-            it.companyInformation.companyName == companyName
-        }
-
-    fun getSpecificCompanyByNameFromSfdrPreparedFixtures(companyName: String): CompanyInformationWithT<T>? =
-        companyListForTestingSfdrSpecificValidation().find {
-            it.companyInformation.companyName == companyName
-        }
-
-    fun getSpecificCompanyByNameFromEuTaxonomyNonFinancialsPreparedFixtures(companyName: String): CompanyInformationWithT<T>? =
-        companyListForTestingEuTaxonomyNonFinancialsSpecificValidation().find {
-            it.companyInformation.companyName == companyName
-        }
-
-    fun getSpecificCompanyByNameFromEuTaxonomyFinancialsPreparedFixtures(companyName: String): CompanyInformationWithT<T>? =
-        companyListForTestingEuTaxonomyFinancialsSpecificValidation().find {
-            it.companyInformation.companyName == companyName
-        }
 
     fun getCompanyInformationWithRandomIdentifiers(requiredQuantity: Int): List<CompanyInformation> =
         testCompanyInformationWithTData
@@ -119,6 +116,10 @@ class FrameworkTestDataProvider<T>(
                         ),
                 )
             }
+
+    fun getByCompanyName(companyName: String): CompanyInformationWithT<T> =
+        testCompanyInformationWithTData
+            .first { it.companyInformation.companyName == companyName }
 
     fun getTData(numberOfDataSets: Int): List<T> =
         testCompanyInformationWithTData

--- a/dataland-frontend/tests/e2e/fixtures/frameworks/additional-company-information/AdditionalCompanyInformationPreparedFixtures.ts
+++ b/dataland-frontend/tests/e2e/fixtures/frameworks/additional-company-information/AdditionalCompanyInformationPreparedFixtures.ts
@@ -1,6 +1,7 @@
 import { type FixtureData } from '@sharedUtils/Fixtures';
 import { type AdditionalCompanyInformationData } from '@clients/backend';
 import { generateAdditionalCompanyInformationFixtures } from './AdditionalCompanyInformationDataFixtures';
+import { getAllFakeFixtureDocumentIds } from '@e2e/utils/DocumentReference.ts';
 
 /**
  * Generates additional-company-information prepared fixtures by generating random additional-company-information datasets and
@@ -12,6 +13,7 @@ export function generateAdditionalCompanyInformationPreparedFixtures(): Array<
 > {
   const preparedFixtures = [];
   preparedFixtures.push(generateFixturesWithNoNullFields());
+  preparedFixtures.push(generateFixtureWithNullishFields());
   return preparedFixtures;
 }
 
@@ -22,5 +24,47 @@ export function generateAdditionalCompanyInformationPreparedFixtures(): Array<
 function generateFixturesWithNoNullFields(): FixtureData<AdditionalCompanyInformationData> {
   const newFixture = generateAdditionalCompanyInformationFixtures(1, 0)[0];
   newFixture.companyInformation.companyName = 'additional-company-information-dataset-with-no-null-fields';
+  return newFixture;
+}
+
+/**
+ * Generate a prepared Fixture with nullish entries like the VOEB dataset that caused the migration to fail
+ * @returns the fixture
+ */
+function generateFixtureWithNullishFields(): FixtureData<AdditionalCompanyInformationData> {
+  const newFixture = generateAdditionalCompanyInformationFixtures(1, 0)[0];
+  const allDocumentRefs = getAllFakeFixtureDocumentIds()[0];
+  newFixture.companyInformation.companyName = 'additional-company-information-dataset-with-nullish-fields';
+  newFixture.t = {
+    general: {
+      general: {
+        fiscalYearDeviation: {
+          value: 'NoDeviation',
+          quality: null,
+          comment: '',
+          dataSource: {
+            page: '58',
+            tagName: null,
+            fileName: '2024_VOEBS_Jahresbericht_2024_web',
+            fileReference: allDocumentRefs[0],
+          },
+        },
+        fiscalYearEnd: null,
+        referencedReports: {
+          '2024_VOEBS_Jahresbericht_2024_web': {
+            fileReference: allDocumentRefs[0],
+            fileName: null,
+            publicationDate: null,
+          },
+        },
+      },
+      financialInformation: {
+        equity: null,
+        debt: null,
+        balanceSheetTotal: null,
+        evic: null,
+      },
+    },
+  };
   return newFixture;
 }

--- a/testing/data/CompanyInformationWithAdditionalCompanyInformationPreparedFixtures.json
+++ b/testing/data/CompanyInformationWithAdditionalCompanyInformationPreparedFixtures.json
@@ -127,5 +127,71 @@
 			}
 		},
 		"reportingPeriod": "2022"
+	},
+	{
+		"companyInformation": {
+			"companyName": "additional-company-information-dataset-with-nullish-fields",
+			"headquarters": "Santa Monica",
+			"headquartersPostalCode": "24874-7765",
+			"sector": "architectures",
+			"identifiers": {
+				"Lei": [
+					"fObQRs66XVrci4Ek4xcX"
+				],
+				"Isin": [
+					"V4KusqRjvD2V",
+					"GFoj3pYKkBRB"
+				],
+				"PermId": [],
+				"Ticker": [
+					"kXRn7jz"
+				],
+				"Duns": [],
+				"VatNumber": [],
+				"CompanyRegistrationNumber": []
+			},
+			"countryCode": "HM",
+			"companyContactDetails": [],
+			"companyAlternativeNames": [
+				"Beahan - Stoltenberg",
+				"Marquardt, Ferry and Mayer",
+				"Wisoky LLC"
+			],
+			"companyLegalForm": "AG",
+			"website": "https://oily-wriggler.info/",
+			"isTeaserCompany": false
+		},
+		"t": {
+			"general": {
+				"general": {
+					"fiscalYearDeviation": {
+						"value": "NoDeviation",
+						"quality": null,
+						"comment": "",
+						"dataSource": {
+							"page": "58",
+							"tagName": null,
+							"fileName": "2024_VOEBS_Jahresbericht_2024_web",
+							"fileReference": "1"
+						}
+					},
+					"fiscalYearEnd": null,
+					"referencedReports": {
+						"2024_VOEBS_Jahresbericht_2024_web": {
+							"fileReference": "1",
+							"fileName": null,
+							"publicationDate": null
+						}
+					}
+				},
+				"financialInformation": {
+					"equity": null,
+					"debt": null,
+					"balanceSheetTotal": null,
+					"evic": null
+				}
+			}
+		},
+		"reportingPeriod": "2020"
 	}
 ]


### PR DESCRIPTION
# Pull Request \<Title>
`<Description here>`
## Things to do during Peer Review
Please check all boxes before the Pull Request is merged. In case you skip a box, describe in the PRs description (that means: here) why the check is skipped.
- [x] The GitHub Actions for the CI are green. This is enforced by GitHub. 
- [ ] The PR has been peer-reviewed
  - [ ] The code has been manually inspected by someone who did not implement the feature
  - [ ] If this PR includes work on the frontend, at least one `@ts-nocheck` is removed. Additionally, there should not be any `@ts-nocheck` in files modified by this PR. If no `@ts-nocheck` are left: Celebrate :tada: :confetti_ball: type-safety and remove this entry. 
- [ ] The PR actually implements what is described in the JIRA-Issue
- [ ] At least one test exists testing the new feature
  - [ ] Make sure all newly added functionality (especially user facing) is tested
  - [ ] Make sure that new test files are included in a test container and actually run in the CI
- [ ] At least 3 consecutive CI runs are successfully executed to ensure that there are no flaky tests.
- [ ] Documentation is updated as required. If unsure whether or what to update, ask a fellow developer.
- [ ] If there was a database entity class added, there must also be a migration script for creating the corresponding database if flyway is already used by the service
- [ ] IF there are changes done to the framework data models or to a database entity class, the following steps were completed in order
  - [ ] A fresh clone of dataland.com is generated (see Wiki page on "OTC" for details)
  - [ ] The feature branch is deployed to clone with `Reset non-user related Docker Volumes & Re-populate` turned off
  - [ ] It's verified that the CD run is green
  - [ ] The new feature is manually used/tested/observed on the clone server. Testing of the new feature should (also) be done by a second, independent reviewer from the dev team
  - [ ] The feature branch is deployed to one of the dev servers with `Reset non-user related Docker Volumes & Re-populate` turned on, and it's verified that the CD run is green
- [ ] ELSE, the new version is deployed to one of the dev servers using this branch
  - [ ] Run with setting `Reset non-user related Docker Volumes & Re-populate` turned on 
  - [ ] It's verified that this version actually is the one deployed (check gitinfo for branch name and commit id!)
  - [ ] It's verified that the CD run is green
  - [ ] The new feature is manually used/tested/observed on dev server. Testing of the new feature should (also) be done by a second, independent reviewer from the dev team
- [ ] Confirm that the latest version (use the /gitinfo endpoint) of the feature branch is deployed to one of the dev servers (no longer enforced by GitHub)
