### PR TITLE
add missing fields to upload page

### DIFF
--- a/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/tests/InvalidSfdrRequestTests.kt
+++ b/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/tests/InvalidSfdrRequestTests.kt
@@ -5,7 +5,7 @@ import org.dataland.datalandbackend.openApiClient.infrastructure.ClientException
 import org.dataland.datalandbackend.openApiClient.model.SfdrData
 import org.dataland.e2etests.utils.ApiAccessor
 import org.dataland.e2etests.utils.DocumentControllerApiAccessor
-import org.dataland.e2etests.utils.testDataProvivders.FrameworkTestDataProvider
+import org.dataland.e2etests.utils.testDataProviders.FrameworkTestDataProvider
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test

--- a/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/tests/QaReportControllerTest.kt
+++ b/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/tests/QaReportControllerTest.kt
@@ -11,8 +11,8 @@ import org.dataland.e2etests.utils.DocumentControllerApiAccessor
 import org.dataland.e2etests.utils.QaApiAccessor
 import org.dataland.e2etests.utils.UploadConfiguration
 import org.dataland.e2etests.utils.UploadInfo
-import org.dataland.e2etests.utils.testDataProvivders.FrameworkTestDataProvider
-import org.dataland.e2etests.utils.testDataProvivders.QaReportTestDataProvider
+import org.dataland.e2etests.utils.testDataProviders.FrameworkTestDataProvider
+import org.dataland.e2etests.utils.testDataProviders.QaReportTestDataProvider
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test

--- a/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/tests/QaServiceTest.kt
+++ b/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/tests/QaServiceTest.kt
@@ -12,7 +12,7 @@ import org.dataland.e2etests.auth.GlobalAuth.withTechnicalUser
 import org.dataland.e2etests.auth.TechnicalUser
 import org.dataland.e2etests.utils.ApiAccessor
 import org.dataland.e2etests.utils.DocumentControllerApiAccessor
-import org.dataland.e2etests.utils.testDataProvivders.GeneralTestDataProvider
+import org.dataland.e2etests.utils.testDataProviders.GeneralTestDataProvider
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeAll

--- a/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/tests/communityManager/DataRequestUploadListenerTest.kt
+++ b/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/tests/communityManager/DataRequestUploadListenerTest.kt
@@ -25,7 +25,7 @@ import org.dataland.e2etests.utils.communityManager.getUsersStoredRequestWithLat
 import org.dataland.e2etests.utils.communityManager.patchDataRequestAndAssertNewStatusAndLastModifiedUpdated
 import org.dataland.e2etests.utils.communityManager.postStandardSingleDataRequest
 import org.dataland.e2etests.utils.communityManager.retrieveTimeAndWaitOneMillisecond
-import org.dataland.e2etests.utils.testDataProvivders.FrameworkTestDataProvider
+import org.dataland.e2etests.utils.testDataProviders.FrameworkTestDataProvider
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeAll

--- a/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/tests/communityManager/accessRequests/AccessRequestTest.kt
+++ b/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/tests/communityManager/accessRequests/AccessRequestTest.kt
@@ -19,7 +19,7 @@ import org.dataland.e2etests.utils.VsmeTestUtils
 import org.dataland.e2etests.utils.communityManager.assertAccessDeniedResponseBodyInCommunityManagerClientException
 import org.dataland.e2etests.utils.communityManager.getNewlyStoredRequestsAfterTimestamp
 import org.dataland.e2etests.utils.communityManager.retrieveTimeAndWaitOneMillisecond
-import org.dataland.e2etests.utils.testDataProvivders.FrameworkTestDataProvider
+import org.dataland.e2etests.utils.testDataProviders.FrameworkTestDataProvider
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test

--- a/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/tests/dataPoints/AssembledDatasetTest.kt
+++ b/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/tests/dataPoints/AssembledDatasetTest.kt
@@ -16,7 +16,7 @@ import org.dataland.e2etests.utils.DocumentControllerApiAccessor
 import org.dataland.e2etests.utils.api.ApiAwait
 import org.dataland.e2etests.utils.api.Backend
 import org.dataland.e2etests.utils.api.QaService
-import org.dataland.e2etests.utils.testDataProvivders.FrameworkTestDataProvider
+import org.dataland.e2etests.utils.testDataProviders.FrameworkTestDataProvider
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.BeforeAll

--- a/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/tests/dataPoints/DataMigrationTest.kt
+++ b/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/tests/dataPoints/DataMigrationTest.kt
@@ -18,7 +18,7 @@ import org.dataland.e2etests.utils.DocumentControllerApiAccessor
 import org.dataland.e2etests.utils.api.ApiAwait
 import org.dataland.e2etests.utils.api.Backend
 import org.dataland.e2etests.utils.api.QaService
-import org.dataland.e2etests.utils.testDataProvivders.FrameworkTestDataProvider
+import org.dataland.e2etests.utils.testDataProviders.FrameworkTestDataProvider
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test

--- a/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/tests/frameworks/EuTaxonomyFinancials.kt
+++ b/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/tests/frameworks/EuTaxonomyFinancials.kt
@@ -5,7 +5,7 @@ import org.dataland.datalandbackend.openApiClient.infrastructure.ClientException
 import org.dataland.datalandbackend.openApiClient.model.EutaxonomyFinancialsData
 import org.dataland.e2etests.utils.ApiAccessor
 import org.dataland.e2etests.utils.QaApiAccessor
-import org.dataland.e2etests.utils.testDataProvivders.FrameworkTestDataProvider
+import org.dataland.e2etests.utils.testDataProviders.FrameworkTestDataProvider
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test

--- a/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/tests/frameworks/EuTaxonomyNonFinancials.kt
+++ b/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/tests/frameworks/EuTaxonomyNonFinancials.kt
@@ -6,7 +6,7 @@ import org.dataland.datalandbackend.openApiClient.model.EutaxonomyNonFinancialsD
 import org.dataland.e2etests.utils.ApiAccessor
 import org.dataland.e2etests.utils.DocumentControllerApiAccessor
 import org.dataland.e2etests.utils.MetaDataUtils.assertDataMetaInfoMatches
-import org.dataland.e2etests.utils.testDataProvivders.FrameworkTestDataProvider
+import org.dataland.e2etests.utils.testDataProviders.FrameworkTestDataProvider
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test

--- a/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/tests/frameworks/Lksg.kt
+++ b/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/tests/frameworks/Lksg.kt
@@ -8,7 +8,7 @@ import org.dataland.datalandbackend.openApiClient.model.LksgGrievanceAssessmentM
 import org.dataland.datalandbackend.openApiClient.model.LksgProcurementCategory
 import org.dataland.e2etests.utils.ApiAccessor
 import org.dataland.e2etests.utils.DocumentControllerApiAccessor
-import org.dataland.e2etests.utils.testDataProvivders.FrameworkTestDataProvider
+import org.dataland.e2etests.utils.testDataProviders.FrameworkTestDataProvider
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll

--- a/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/tests/frameworks/Sfdr.kt
+++ b/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/tests/frameworks/Sfdr.kt
@@ -7,7 +7,7 @@ import org.dataland.e2etests.utils.ApiAccessor
 import org.dataland.e2etests.utils.DataPointTestUtils
 import org.dataland.e2etests.utils.DocumentControllerApiAccessor
 import org.dataland.e2etests.utils.api.ApiAwait
-import org.dataland.e2etests.utils.testDataProvivders.FrameworkTestDataProvider
+import org.dataland.e2etests.utils.testDataProviders.FrameworkTestDataProvider
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll

--- a/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/tests/frameworks/Vsme.kt
+++ b/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/tests/frameworks/Vsme.kt
@@ -16,7 +16,7 @@ import org.dataland.e2etests.utils.ApiAccessor
 import org.dataland.e2etests.utils.ExceptionUtils.assertAccessDeniedWrapper
 import org.dataland.e2etests.utils.MetaDataUtils.assertDataMetaInfoMatches
 import org.dataland.e2etests.utils.VsmeTestUtils
-import org.dataland.e2etests.utils.testDataProvivders.FrameworkTestDataProvider
+import org.dataland.e2etests.utils.testDataProviders.FrameworkTestDataProvider
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue

--- a/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/utils/ApiAccessor.kt
+++ b/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/utils/ApiAccessor.kt
@@ -34,8 +34,8 @@ import org.dataland.e2etests.auth.TechnicalUser
 import org.dataland.e2etests.customApiControllers.UnauthorizedCompanyDataControllerApi
 import org.dataland.e2etests.customApiControllers.UnauthorizedEuTaxonomyDataNonFinancialsControllerApi
 import org.dataland.e2etests.customApiControllers.UnauthorizedMetaDataControllerApi
-import org.dataland.e2etests.utils.testDataProvivders.FrameworkTestDataProvider
-import org.dataland.e2etests.utils.testDataProvivders.GeneralTestDataProvider
+import org.dataland.e2etests.utils.testDataProviders.FrameworkTestDataProvider
+import org.dataland.e2etests.utils.testDataProviders.GeneralTestDataProvider
 
 class ApiAccessor {
     val companyDataControllerApi = CompanyDataControllerApi(BASE_PATH_TO_DATALAND_BACKEND)

--- a/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/utils/testDataProviders/FrameworkTestDataProvider.kt
+++ b/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/utils/testDataProviders/FrameworkTestDataProvider.kt
@@ -1,4 +1,4 @@
-package org.dataland.e2etests.utils.testDataProvivders
+package org.dataland.e2etests.utils.testDataProviders
 
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi

--- a/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/utils/testDataProviders/GeneralTestDataProvider.kt
+++ b/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/utils/testDataProviders/GeneralTestDataProvider.kt
@@ -1,4 +1,4 @@
-package org.dataland.e2etests.utils.testDataProvivders
+package org.dataland.e2etests.utils.testDataProviders
 
 import org.dataland.datalandbackend.openApiClient.model.CompanyInformation
 import org.dataland.datalandbackend.openApiClient.model.IdentifierType

--- a/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/utils/testDataProviders/QaReportTestDataProvider.kt
+++ b/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/utils/testDataProviders/QaReportTestDataProvider.kt
@@ -1,4 +1,4 @@
-package org.dataland.e2etests.utils.testDataProvivders
+package org.dataland.e2etests.utils.testDataProviders
 
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi

--- a/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/utils/testDataProviders/TestDataProviderUtils.kt
+++ b/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/utils/testDataProviders/TestDataProviderUtils.kt
@@ -1,4 +1,4 @@
-package org.dataland.e2etests.utils.testDataProvivders
+package org.dataland.e2etests.utils.testDataProviders
 
 import com.squareup.moshi.FromJson
 import com.squareup.moshi.Json

--- a/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/utils/testDataProvivders/FrameworkTestDataProvider.kt
+++ b/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/utils/testDataProvivders/FrameworkTestDataProvider.kt
@@ -66,10 +66,10 @@ class FrameworkTestDataProvider<T>(
             )
 
         fun <T> forFrameworkFixtures(clazz: Class<T>): FrameworkTestDataProvider<T> =
-            FrameworkTestDataProvider(clazz, jsonFilesForTesting[clazz]!!.fakeFixtureFile)
+            FrameworkTestDataProvider(clazz, (jsonFilesForTesting[clazz] ?: throw NoSuchElementException()).fakeFixtureFile)
 
         fun <T> forFrameworkPreparedFixtures(clazz: Class<T>): FrameworkTestDataProvider<T> =
-            FrameworkTestDataProvider(clazz, jsonFilesForTesting[clazz]!!.preparedFixtureFile)
+            FrameworkTestDataProvider(clazz, (jsonFilesForTesting[clazz] ?: throw NoSuchElementException()).preparedFixtureFile)
     }
 
     private val moshi: Moshi =

--- a/dataland-frontend/src/frameworks/custom/EuTaxoNonFinancialsStaticUploadConfig.ts
+++ b/dataland-frontend/src/frameworks/custom/EuTaxoNonFinancialsStaticUploadConfig.ts
@@ -97,6 +97,46 @@ export const eutaxonomyNonFinancialsDataModel = [
             required: false,
             showIf: (): boolean => true,
           },
+          {
+            name: 'unGlobalCompactPrinciplesCompliancePolicy',
+            label: 'UN Global Compact Principles Compliance Policy',
+            description:
+                'Existence of a policy to monitor compliance with the UNGC principles.',
+            unit: '',
+            component: 'YesNoExtendedDataPointFormField',
+            required: false,
+            showIf: (): boolean => true,
+          },
+          {
+            name: 'oecdGuidelinesForMultinationalEnterprisesCompliancePolicy',
+            label: 'OECD Guidelines for Multinational Enterprises Compliance Policy',
+            description:
+                'Existence of a policy to monitor compliance with the OECD Guidelines for Multinational Enterprises.',
+            unit: '',
+            component: 'YesNoExtendedDataPointFormField',
+            required: false,
+            showIf: (): boolean => true,
+          },
+          {
+            name: 'iloCoreLabourStandards',
+            label: 'ILO Core Labour Standards',
+            description:
+                'Abidance by the ILO Core Labour Standards.',
+            unit: '',
+            component: 'YesNoExtendedDataPointFormField',
+            required: false,
+            showIf: (): boolean => true,
+          },
+          {
+            name: 'humanRightsDueDiligence',
+            label: 'Human Rights Due Diligence',
+            description:
+                'Existence of due diligence processes to identify, prevent, mitigate and address adverse human rights impacts.',
+            unit: '',
+            component: 'YesNoExtendedDataPointFormField',
+            required: false,
+            showIf: (): boolean => true,
+          },
         ],
       },
     ],

--- a/dataland-frontend/src/frameworks/custom/EuTaxoNonFinancialsStaticUploadConfig.ts
+++ b/dataland-frontend/src/frameworks/custom/EuTaxoNonFinancialsStaticUploadConfig.ts
@@ -100,8 +100,7 @@ export const eutaxonomyNonFinancialsDataModel = [
           {
             name: 'unGlobalCompactPrinciplesCompliancePolicy',
             label: 'UN Global Compact Principles Compliance Policy',
-            description:
-                'Existence of a policy to monitor compliance with the UNGC principles.',
+            description: 'Existence of a policy to monitor compliance with the UNGC principles.',
             unit: '',
             component: 'YesNoExtendedDataPointFormField',
             required: false,
@@ -111,7 +110,7 @@ export const eutaxonomyNonFinancialsDataModel = [
             name: 'oecdGuidelinesForMultinationalEnterprisesCompliancePolicy',
             label: 'OECD Guidelines for Multinational Enterprises Compliance Policy',
             description:
-                'Existence of a policy to monitor compliance with the OECD Guidelines for Multinational Enterprises.',
+              'Existence of a policy to monitor compliance with the OECD Guidelines for Multinational Enterprises.',
             unit: '',
             component: 'YesNoExtendedDataPointFormField',
             required: false,
@@ -120,8 +119,7 @@ export const eutaxonomyNonFinancialsDataModel = [
           {
             name: 'iloCoreLabourStandards',
             label: 'ILO Core Labour Standards',
-            description:
-                'Abidance by the ILO Core Labour Standards.',
+            description: 'Abidance by the ILO Core Labour Standards.',
             unit: '',
             component: 'YesNoExtendedDataPointFormField',
             required: false,
@@ -131,7 +129,7 @@ export const eutaxonomyNonFinancialsDataModel = [
             name: 'humanRightsDueDiligence',
             label: 'Human Rights Due Diligence',
             description:
-                'Existence of due diligence processes to identify, prevent, mitigate and address adverse human rights impacts.',
+              'Existence of due diligence processes to identify, prevent, mitigate and address adverse human rights impacts.',
             unit: '',
             component: 'YesNoExtendedDataPointFormField',
             required: false,


### PR DESCRIPTION
# Pull Request \<Title>
`<Description here>`
## Things to do during Peer Review
Please check all boxes before the Pull Request is merged. In case you skip a box, describe in the PRs description (that means: here) why the check is skipped.
- [x] The GitHub Actions for the CI are green. This is enforced by GitHub. 
- [x] The PR has been peer-reviewed
  - [x] The code has been manually inspected by someone who did not implement the feature
  - [x] If this PR includes work on the frontend, at least one `@ts-nocheck` is removed. Additionally, there should not be any `@ts-nocheck` in files modified by this PR. If no `@ts-nocheck` are left: Celebrate :tada: :confetti_ball: type-safety and remove this entry. 
- [x] The PR actually implements what is described in the JIRA-Issue
- [ ] At least one test exists testing the new feature
  - [ ] Make sure all newly added functionality (especially user facing) is tested
  - [ ] Make sure that new test files are included in a test container and actually run in the CI
- [ ] At least 3 consecutive CI runs are successfully executed to ensure that there are no flaky tests.
- [x] Documentation is updated as required. If unsure whether or what to update, ask a fellow developer.
- [ ] If there was a database entity class added, there must also be a migration script for creating the corresponding database if flyway is already used by the service
- [ ] IF there are changes done to the framework data models or to a database entity class, the following steps were completed in order
  - [ ] A fresh clone of dataland.com is generated (see Wiki page on "OTC" for details)
  - [ ] The feature branch is deployed to clone with `Reset non-user related Docker Volumes & Re-populate` turned off
  - [ ] It's verified that the CD run is green
  - [ ] The new feature is manually used/tested/observed on the clone server. Testing of the new feature should (also) be done by a second, independent reviewer from the dev team
  - [ ] The feature branch is deployed to one of the dev servers with `Reset non-user related Docker Volumes & Re-populate` turned on, and it's verified that the CD run is green
- [ ] ELSE, the new version is deployed to one of the dev servers using this branch
  - [ ] Run with setting `Reset non-user related Docker Volumes & Re-populate` turned on 
  - [ ] It's verified that this version actually is the one deployed (check gitinfo for branch name and commit id!)
  - [ ] It's verified that the CD run is green
  - [ ] The new feature is manually used/tested/observed on dev server. Testing of the new feature should (also) be done by a second, independent reviewer from the dev team
- [x] Confirm that the latest version (use the /gitinfo endpoint) of the feature branch is deployed to one of the dev servers (no longer enforced by GitHub)
