### PR TITLE
DALA-5675 Fix Patching metadata for assembled datasets

### DIFF
--- a/dataland-backend/src/main/kotlin/org/dataland/datalandbackend/services/DataMetaInfoAlterationManager.kt
+++ b/dataland-backend/src/main/kotlin/org/dataland/datalandbackend/services/DataMetaInfoAlterationManager.kt
@@ -4,6 +4,7 @@ import org.dataland.datalandbackend.entities.DataMetaInformationEntity
 import org.dataland.datalandbackend.model.DataType
 import org.dataland.datalandbackend.model.StorableDataset
 import org.dataland.datalandbackend.model.metainformation.DataMetaInformationPatch
+import org.dataland.datalandbackend.utils.DataPointUtils
 import org.dataland.datalandbackendutils.exceptions.InvalidInputApiException
 import org.dataland.datalandbackendutils.services.KeycloakUserService
 import org.slf4j.LoggerFactory
@@ -18,15 +19,19 @@ import org.springframework.transaction.annotation.Transactional
 class DataMetaInfoAlterationManager
     @Autowired
     constructor(
-        private val dataMetaInformationManager: DataMetaInformationManager,
         private val dataManager: DataManager,
+        private val dataMetaInformationManager: DataMetaInformationManager,
+        private val dataPointUtils: DataPointUtils,
         private val keycloakUserService: KeycloakUserService,
+        private val messageQueuePublications: MessageQueuePublications,
     ) {
         private val logger = LoggerFactory.getLogger(DataMetaInfoAlterationManager::class.java)
 
         /**
          * Patch dataMetaInformation for dataset with given [dataId]
-         * This function retrieves the full dataset from either temporary or internal storage, patches it, and then sends a
+         * This function retrieves behaves differently for assembled and non-assembled datasets.
+         * For
+         * and  the full dataset from either temporary or internal storage, patches it, and then sends a
          * message to the internal storage to persist the changed dataset.
          * Currently, only public datasets are supported.
          */
@@ -46,27 +51,43 @@ class DataMetaInfoAlterationManager
                 )
             }
 
-            logger.info("Retrieving StorableDataset with dataId $dataId from Storage. CorrelationId: $correlationId.")
-            val updatedStorableDataset: StorableDataset =
-                dataManager
-                    .getPublicDataset(dataId, DataType.valueOf(dataMetaInformation.dataType), correlationId)
-                    .copy(uploaderUserId = dataMetaInformationPatch.uploaderUserId)
+            when (dataPointUtils.getFrameworkSpecificationOrNull(dataMetaInformation.dataType)) {
+                null -> {
+                    logger.info("Retrieving StorableDataset with dataId $dataId from Storage. CorrelationId: $correlationId.")
+                    val updatedStorableDataset: StorableDataset =
+                        dataManager
+                            .getPublicDataset(dataId, DataType.valueOf(dataMetaInformation.dataType), correlationId)
+                            .copy(uploaderUserId = dataMetaInformationPatch.uploaderUserId)
 
-            logger.info(
-                "Updating uploaderUserId to ${dataMetaInformationPatch.uploaderUserId} in metaInformation. " +
-                    "CorrelationId: $correlationId.",
-            )
-            dataMetaInformation.uploaderUserId = dataMetaInformationPatch.uploaderUserId
-            dataMetaInformationManager
-                .storeDataMetaInformation(dataMetaInformation)
+                    logger.info(
+                        "Updating uploaderUserId to ${dataMetaInformationPatch.uploaderUserId} in metaInformation. " +
+                            "CorrelationId: $correlationId.",
+                    )
+                    dataMetaInformation.uploaderUserId = dataMetaInformationPatch.uploaderUserId
 
-            logger.info("Storing updated StorableDataset with dataId $dataId. CorrelationId: $correlationId.")
+                    logger.info("Storing updated StorableDataset with dataId $dataId. CorrelationId: $correlationId.")
 
-            dataManager.storeDatasetInTemporaryStoreAndSendPatchMessage(
-                dataId = dataId,
-                storableDataset = updatedStorableDataset,
-                correlationId = correlationId,
-            )
-            return dataMetaInformation
+                    dataManager.storeDatasetInTemporaryStoreAndSendPatchMessage(
+                        dataId = dataId,
+                        storableDataset = updatedStorableDataset,
+                        correlationId = correlationId,
+                    )
+                }
+
+                else -> {
+                    logger.info(
+                        "Updating uploaderUserId to ${dataMetaInformationPatch.uploaderUserId} in metaInformation. " +
+                            "CorrelationId: $correlationId.",
+                    )
+                    dataMetaInformation.uploaderUserId = dataMetaInformationPatch.uploaderUserId
+                    messageQueuePublications.publishDatasetMetaInfoPatchMessage(
+                        dataId,
+                        dataMetaInformation.uploaderUserId,
+                        correlationId,
+                    )
+                }
+            }
+
+            return dataMetaInformationManager.storeDataMetaInformation(dataMetaInformation)
         }
     }

--- a/dataland-backend/src/main/kotlin/org/dataland/datalandbackend/services/datapoints/AssembledDataManager.kt
+++ b/dataland-backend/src/main/kotlin/org/dataland/datalandbackend/services/datapoints/AssembledDataManager.kt
@@ -289,7 +289,7 @@ class AssembledDataManager
         /**
          * Retrieves a key value map containing the IDs of the data points contained in a dataset mapped to their technical IDs
          * @param datasetId the ID of the dataset
-         * @return a map of data point IDs to the corresponding technical IDs that are contained in the dataset
+         * @return a map of data point IDs to the corresponding technical UUIDs that are contained in the dataset
          */
         @Transactional(readOnly = true)
         fun getDataPointIdsForDataset(datasetId: String): Map<String, String> {


### PR DESCRIPTION
# Pull Request \<Title>
`<Description here>`
## Things to do during Peer Review
Please check all boxes before the Pull Request is merged. In case you skip a box, describe in the PRs description (that means: here) why the check is skipped.
- [x] The GitHub Actions for the CI are green. This is enforced by GitHub. 
- [ ] The PR has been peer-reviewed
  - [ ] The code has been manually inspected by someone who did not implement the feature
  - [ ] If this PR includes work on the frontend, at least one `@ts-nocheck` is removed. Additionally, there should not be any `@ts-nocheck` in files modified by this PR. If no `@ts-nocheck` are left: Celebrate :tada: :confetti_ball: type-safety and remove this entry. 
- [ ] The PR actually implements what is described in the JIRA-Issue
- [ ] At least one test exists testing the new feature
  - [ ] Make sure all newly added functionality (especially user facing) is tested
  - [ ] Make sure that new test files are included in a test container and actually run in the CI
- [ ] At least 3 consecutive CI runs are successfully executed to ensure that there are no flaky tests.
- [ ] Documentation is updated as required. If unsure whether or what to update, ask a fellow developer.
- [ ] If there was a database entity class added, there must also be a migration script for creating the corresponding database if flyway is already used by the service
- [ ] IF there are changes done to the framework data models or to a database entity class, the following steps were completed in order
  - [ ] A fresh clone of dataland.com is generated (see Wiki page on "OTC" for details)
  - [ ] The feature branch is deployed to clone with `Reset non-user related Docker Volumes & Re-populate` turned off
  - [ ] It's verified that the CD run is green
  - [ ] The new feature is manually used/tested/observed on the clone server. Testing of the new feature should (also) be done by a second, independent reviewer from the dev team
  - [ ] The feature branch is deployed to one of the dev servers with `Reset non-user related Docker Volumes & Re-populate` turned on, and it's verified that the CD run is green
- [ ] ELSE, the new version is deployed to one of the dev servers using this branch
  - [ ] Run with setting `Reset non-user related Docker Volumes & Re-populate` turned on 
  - [ ] It's verified that this version actually is the one deployed (check gitinfo for branch name and commit id!)
  - [ ] It's verified that the CD run is green
  - [ ] The new feature is manually used/tested/observed on dev server. Testing of the new feature should (also) be done by a second, independent reviewer from the dev team
- [ ] Confirm that the latest version (use the /gitinfo endpoint) of the feature branch is deployed to one of the dev servers (no longer enforced by GitHub)
