### PR TITLE
DALA-5709_Fix-for-Deployment-EU-Taxonomy-Financials

### DIFF
--- a/dataland-frontend/cypress.config.ts
+++ b/dataland-frontend/cypress.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
     commit_id: require('git-commit-id')({ cwd: '../' }),
     prepopulate_timeout_s: 180,
     short_timeout_in_ms: 10000,
-    medium_timeout_in_ms: 30000,
+    medium_timeout_in_ms: 60000,
     long_timeout_in_ms: 60000,
     mobile_device_viewport_height: 667,
     mobile_device_viewport_width: 300,

--- a/dataland-frontend/tests/e2e/specs/eu-taxonomy-financials/DataIntegrity.ts
+++ b/dataland-frontend/tests/e2e/specs/eu-taxonomy-financials/DataIntegrity.ts
@@ -65,14 +65,14 @@ describeIf(
                     '/upload?templateDataId=' +
                     dataMetaInformation.dataId
                 );
-                cy.wait('@fetchDataForPrefill', { timeout: Cypress.env('medium_timeout_in_ms') as number });
+                cy.wait('@fetchDataForPrefill', { timeout: Cypress.env('long_timeout_in_ms') as number });
                 cy.get('h1').should('contain', testCompanyName);
                 cy.intercept({
                   url: `**/api/data/${DataTypeEnum.EutaxonomyFinancials}?bypassQa=true`,
                   times: 1,
                 }).as('postCompanyAssociatedData');
                 submitButton.clickButton();
-                cy.wait('@postCompanyAssociatedData', { timeout: Cypress.env('medium_timeout_in_ms') as number }).then(
+                cy.wait('@postCompanyAssociatedData', { timeout: Cypress.env('long_timeout_in_ms') as number }).then(
                   (postInterception) => {
                     cy.url().should('eq', getBaseUrl() + '/datasets');
                     isDatasetApproved();

--- a/dataland-frontend/tests/e2e/specs/eu-taxonomy-financials/DataIntegrity.ts
+++ b/dataland-frontend/tests/e2e/specs/eu-taxonomy-financials/DataIntegrity.ts
@@ -65,14 +65,14 @@ describeIf(
                     '/upload?templateDataId=' +
                     dataMetaInformation.dataId
                 );
-                cy.wait('@fetchDataForPrefill', { timeout: Cypress.env('long_timeout_in_ms') as number });
+                cy.wait('@fetchDataForPrefill', { timeout: Cypress.env('medium_timeout_in_ms') as number });
                 cy.get('h1').should('contain', testCompanyName);
                 cy.intercept({
                   url: `**/api/data/${DataTypeEnum.EutaxonomyFinancials}?bypassQa=true`,
                   times: 1,
                 }).as('postCompanyAssociatedData');
                 submitButton.clickButton();
-                cy.wait('@postCompanyAssociatedData', { timeout: Cypress.env('long_timeout_in_ms') as number }).then(
+                cy.wait('@postCompanyAssociatedData', { timeout: Cypress.env('medium_timeout_in_ms') as number }).then(
                   (postInterception) => {
                     cy.url().should('eq', getBaseUrl() + '/datasets');
                     isDatasetApproved();


### PR DESCRIPTION
# Pull Request \<Title>
`<Description here>`
## Things to do during Peer Review
Please check all boxes before the Pull Request is merged. In case you skip a box, describe in the PRs description (that means: here) why the check is skipped.
- [x] The GitHub Actions for the CI are green. This is enforced by GitHub. 
- [ ] The PR has been peer-reviewed
  - [ ] The code has been manually inspected by someone who did not implement the feature
  - [ ] If this PR includes work on the frontend, at least one `@ts-nocheck` is removed. Additionally, there should not be any `@ts-nocheck` in files modified by this PR. If no `@ts-nocheck` are left: Celebrate :tada: :confetti_ball: type-safety and remove this entry. 
- [ ] The PR actually implements what is described in the JIRA-Issue
- [ ] At least one test exists testing the new feature
  - [ ] Make sure all newly added functionality (especially user facing) is tested
  - [ ] Make sure that new test files are included in a test container and actually run in the CI
- [ ] At least 3 consecutive CI runs are successfully executed to ensure that there are no flaky tests.
- [ ] Documentation is updated as required. If unsure whether or what to update, ask a fellow developer.
- [ ] If there was a database entity class added, there must also be a migration script for creating the corresponding database if flyway is already used by the service
- [ ] IF there are changes done to the framework data models or to a database entity class, the following steps were completed in order
  - [ ] A fresh clone of dataland.com is generated (see Wiki page on "OTC" for details)
  - [ ] The feature branch is deployed to clone with `Reset non-user related Docker Volumes & Re-populate` turned off
  - [ ] It's verified that the CD run is green
  - [ ] The new feature is manually used/tested/observed on the clone server. Testing of the new feature should (also) be done by a second, independent reviewer from the dev team
  - [ ] The feature branch is deployed to one of the dev servers with `Reset non-user related Docker Volumes & Re-populate` turned on, and it's verified that the CD run is green
- [ ] ELSE, the new version is deployed to one of the dev servers using this branch
  - [ ] Run with setting `Reset non-user related Docker Volumes & Re-populate` turned on 
  - [ ] It's verified that this version actually is the one deployed (check gitinfo for branch name and commit id!)
  - [ ] It's verified that the CD run is green
  - [ ] The new feature is manually used/tested/observed on dev server. Testing of the new feature should (also) be done by a second, independent reviewer from the dev team
- [ ] Confirm that the latest version (use the /gitinfo endpoint) of the feature branch is deployed to one of the dev servers (no longer enforced by GitHub)
