### PR TITLE
DALA-5755: Flyway script for "notify me immediately"

### DIFF
--- a/dataland-community-manager/src/main/kotlin/db/migration/V14__AddNotifyMeImmediatelyColumn.kt
+++ b/dataland-community-manager/src/main/kotlin/db/migration/V14__AddNotifyMeImmediatelyColumn.kt
@@ -14,7 +14,7 @@ class V14__AddNotifyMeImmediatelyColumn : BaseJavaMigration() {
         val sql =
             """
             ALTER TABLE data_requests ADD COLUMN IF NOT EXISTS 
-            notify_me_immediately BOOLEAN;
+            notify_me_immediately BOOLEAN NOT NULL DEFAULT false;
             """.trimIndent()
 
         context!!.connection.createStatement().use { statement ->

--- a/dataland-community-manager/src/main/kotlin/db/migration/V14__AddNotifyMeImmediatelyColumn.kt
+++ b/dataland-community-manager/src/main/kotlin/db/migration/V14__AddNotifyMeImmediatelyColumn.kt
@@ -1,0 +1,24 @@
+package db.migration
+
+import org.flywaydb.core.api.migration.BaseJavaMigration
+import org.flywaydb.core.api.migration.Context
+
+/**
+ * The "notify me immediately" Boolean flag of DataRequestEntity objects
+ * is added manually in this script, as it appears to not be added in the database
+ * in case of a deployment to Clone or Prod.
+ */
+@Suppress("ClassName")
+class V14__AddNotifyMeImmediatelyColumn : BaseJavaMigration() {
+    override fun migrate(context: Context?) {
+        val sql =
+            """
+            ALTER TABLE data_requests ADD COLUMN IF NOT EXISTS 
+            notify_me_immediately BOOLEAN;
+            """.trimIndent()
+
+        context!!.connection.createStatement().use { statement ->
+            statement.execute(sql)
+        }
+    }
+}


### PR DESCRIPTION
# Pull Request \<Title>
`<Description here>`
## Things to do during Peer Review
Please check all boxes before the Pull Request is merged. In case you skip a box, describe in the PRs description (that means: here) why the check is skipped.
- [x] The GitHub Actions for the CI are green. This is enforced by GitHub. 
- [ ] The PR has been peer-reviewed
  - [ ] The code has been manually inspected by someone who did not implement the feature
  - [ ] If this PR includes work on the frontend, at least one `@ts-nocheck` is removed. Additionally, there should not be any `@ts-nocheck` in files modified by this PR. If no `@ts-nocheck` are left: Celebrate :tada: :confetti_ball: type-safety and remove this entry. 
- [ ] The PR actually implements what is described in the JIRA-Issue
- [ ] At least one test exists testing the new feature
  - [ ] Make sure all newly added functionality (especially user facing) is tested
  - [ ] Make sure that new test files are included in a test container and actually run in the CI
- [ ] At least 3 consecutive CI runs are successfully executed to ensure that there are no flaky tests.
- [ ] Documentation is updated as required. If unsure whether or what to update, ask a fellow developer.
- [ ] If there was a database entity class added, there must also be a migration script for creating the corresponding database if flyway is already used by the service
- [ ] IF there are changes done to the framework data models or to a database entity class, the following steps were completed in order
  - [ ] A fresh clone of dataland.com is generated (see Wiki page on "OTC" for details)
  - [ ] The feature branch is deployed to clone with `Reset non-user related Docker Volumes & Re-populate` turned off
  - [ ] It's verified that the CD run is green
  - [ ] The new feature is manually used/tested/observed on the clone server. Testing of the new feature should (also) be done by a second, independent reviewer from the dev team
  - [ ] The feature branch is deployed to one of the dev servers with `Reset non-user related Docker Volumes & Re-populate` turned on, and it's verified that the CD run is green
- [ ] ELSE, the new version is deployed to one of the dev servers using this branch
  - [ ] Run with setting `Reset non-user related Docker Volumes & Re-populate` turned on 
  - [ ] It's verified that this version actually is the one deployed (check gitinfo for branch name and commit id!)
  - [ ] It's verified that the CD run is green
  - [ ] The new feature is manually used/tested/observed on dev server. Testing of the new feature should (also) be done by a second, independent reviewer from the dev team
- [ ] Confirm that the latest version (use the /gitinfo endpoint) of the feature branch is deployed to one of the dev servers (no longer enforced by GitHub)
