### PR TITLE
DALA-5793: Fix broken Tabs

### DIFF
--- a/dataland-frontend/src/components/pages/AdminAllRequestsOverview.vue
+++ b/dataland-frontend/src/components/pages/AdminAllRequestsOverview.vue
@@ -1,7 +1,7 @@
 <template>
   <AuthenticationWrapper>
     <TheHeader />
-    <DatasetsTabMenu :initial-tab-index="5">
+    <DatasetsTabMenu :initial-tab-index="6">
       <TheContent class="min-h-screen paper-section relative">
         <div>
           <div

--- a/dataland-frontend/src/components/pages/BulkDataRequest.vue
+++ b/dataland-frontend/src/components/pages/BulkDataRequest.vue
@@ -151,11 +151,11 @@
                       </span>
                     </BasicFormSection>
                   </div>
-                  <div class="col-12 flex align-items-end">
+                  <div class="col-12 flex justify-content-end">
                     <PrimeButton
                       type="submit"
                       label="Submit"
-                      class="p-button p-button-sm d-letters ml-auto"
+                      class="primary-button align-self-end"
                       name="submit_request_button"
                       @click="checkReportingPeriods()"
                     >

--- a/dataland-frontend/src/components/pages/CompanyDataRequestsOverview.vue
+++ b/dataland-frontend/src/components/pages/CompanyDataRequestsOverview.vue
@@ -1,7 +1,7 @@
 <template>
   <AuthenticationWrapper>
     <TheHeader />
-    <DatasetsTabMenu :initial-tab-index="4">
+    <DatasetsTabMenu :initial-tab-index="5">
       <TheContent class="min-h-screen paper-section relative">
         <div v-if="waitingForData || storedDataRequests.length > 0">
           <div

--- a/dataland-frontend/src/components/pages/MyDataRequestsOverview.vue
+++ b/dataland-frontend/src/components/pages/MyDataRequestsOverview.vue
@@ -1,7 +1,7 @@
 <template>
   <AuthenticationWrapper>
     <TheHeader />
-    <DatasetsTabMenu :initial-tab-index="3">
+    <DatasetsTabMenu :initial-tab-index="4">
       <TheContent class="min-h-screen paper-section relative">
         <div v-if="waitingForData || storedDataRequests.length > 0">
           <div

--- a/dataland-frontend/src/components/pages/QualityAssurance.vue
+++ b/dataland-frontend/src/components/pages/QualityAssurance.vue
@@ -1,7 +1,7 @@
 <template>
   <AuthenticationWrapper>
     <TheHeader />
-    <DatasetsTabMenu :initial-tab-index="2">
+    <DatasetsTabMenu :initial-tab-index="3">
       <TheContent class="min-h-screen paper-section relative">
         <AuthorizationWrapper :required-role="KEYCLOAK_ROLE_REVIEWER">
           <div


### PR DESCRIPTION
# Pull Request \<Title>
`<Description here>`
## Things to do during Peer Review
Please check all boxes before the Pull Request is merged. In case you skip a box, describe in the PRs description (that means: here) why the check is skipped.
- [x] The GitHub Actions for the CI are green. This is enforced by GitHub. 
- [x] The PR has been peer-reviewed
  - [x] The code has been manually inspected by someone who did not implement the feature
  - [x] If this PR includes work on the frontend, at least one `@ts-nocheck` is removed. Additionally, there should not be any `@ts-nocheck` in files modified by this PR. If no `@ts-nocheck` are left: Celebrate :tada: :confetti_ball: type-safety and remove this entry. 
- [x] The PR actually implements what is described in the JIRA-Issue
- [ ] At least one test exists testing the new feature
  - [ ] Make sure all newly added functionality (especially user facing) is tested
  - [ ] Make sure that new test files are included in a test container and actually run in the CI
- [ ] At least 3 consecutive CI runs are successfully executed to ensure that there are no flaky tests.
- [x] Documentation is updated as required. If unsure whether or what to update, ask a fellow developer.
- [x] If there was a database entity class added, there must also be a migration script for creating the corresponding database if flyway is already used by the service
- [ ] IF there are changes done to the framework data models or to a database entity class, the following steps were completed in order
  - [ ] A fresh clone of dataland.com is generated (see Wiki page on "OTC" for details)
  - [ ] The feature branch is deployed to clone with `Reset non-user related Docker Volumes & Re-populate` turned off
  - [ ] It's verified that the CD run is green
  - [ ] The new feature is manually used/tested/observed on the clone server. Testing of the new feature should (also) be done by a second, independent reviewer from the dev team
  - [ ] The feature branch is deployed to one of the dev servers with `Reset non-user related Docker Volumes & Re-populate` turned on, and it's verified that the CD run is green
- [x] ELSE, the new version is deployed to one of the dev servers using this branch
  - [x] Run with setting `Reset non-user related Docker Volumes & Re-populate` turned on 
  - [x] It's verified that this version actually is the one deployed (check gitinfo for branch name and commit id!)
  - [x] It's verified that the CD run is green
  - [x] The new feature is manually used/tested/observed on dev server. Testing of the new feature should (also) be done by a second, independent reviewer from the dev team
- [x] Confirm that the latest version (use the /gitinfo endpoint) of the feature branch is deployed to one of the dev servers (no longer enforced by GitHub)
