### PR TITLE
DALA-5871: Fix scheduler and font weight

### DIFF
--- a/dataland-community-manager/src/main/kotlin/org/dataland/datalandcommunitymanager/services/messaging/NotificationScheduler.kt
+++ b/dataland-community-manager/src/main/kotlin/org/dataland/datalandcommunitymanager/services/messaging/NotificationScheduler.kt
@@ -31,7 +31,7 @@ class NotificationScheduler
          * Scheduled method to send emails for unprocessed notification events.
          * Runs every Sunday at midnight.
          */
-        @Scheduled(cron = "0 */10 * * * *")
+        @Scheduled(cron = "0 0 0 * * SUN")
         fun scheduledWeeklyEmailSending() {
             processNotificationEvents(
                 "Investor Relations",

--- a/dataland-frontend/src/components/pages/CompanyCockpitPage.vue
+++ b/dataland-frontend/src/components/pages/CompanyCockpitPage.vue
@@ -337,7 +337,7 @@ export default defineComponent({
 
   &__subtitle {
     font-size: 16px;
-    font-weight: 400;
+    font-weight: 700;
     line-height: 21px;
 
     margin-top: 8px;


### PR DESCRIPTION
…ts card on Company Cockpit page.

# Pull Request \<Title>
`<Description here>`
## Things to do during Peer Review
Please check all boxes before the Pull Request is merged. In case you skip a box, describe in the PRs description (that means: here) why the check is skipped.
- [x] The GitHub Actions for the CI are green. This is enforced by GitHub. 
- [ ] The PR has been peer-reviewed
  - [ ] The code has been manually inspected by someone who did not implement the feature
  - [ ] The changes have been inspected for possible breaking API changes (changed data models, endpoints, response codes, exception handling, ...). If there are any discuss them with the team.
  - [ ] If this PR includes work on the frontend, at least one `@ts-nocheck` is removed. Additionally, there should not be any `@ts-nocheck` in files modified by this PR. If no `@ts-nocheck` are left: Celebrate :tada: :confetti_ball: type-safety and remove this entry. 
- [ ] The PR actually implements what is described in the JIRA-Issue
- [ ] At least one test exists testing the new feature
  - [ ] Make sure all newly added functionality (especially user facing) is tested
  - [ ] Make sure that new test files are included in a test container and actually run in the CI
- [ ] At least 3 consecutive CI runs are successfully executed to ensure that there are no flaky tests.
- [ ] Documentation is updated as required. If unsure whether or what to update, ask a fellow developer.
- [ ] If there was a database entity class added, there must also be a migration script for creating the corresponding database if flyway is already used by the service
- [ ] IF there are changes done to the framework data models or to a database entity class, the following steps were completed in order
  - [ ] A fresh clone of dataland.com is generated (see Wiki page on "OTC" for details)
  - [ ] The feature branch is deployed to clone with `Reset non-user related Docker Volumes & Re-populate` turned off
  - [ ] It's verified that the CD run is green
  - [ ] The new feature is manually used/tested/observed on the clone server. Testing of the new feature should (also) be done by a second, independent reviewer from the dev team
  - [ ] The feature branch is deployed to one of the dev servers with `Reset non-user related Docker Volumes & Re-populate` turned on, and it's verified that the CD run is green
- [ ] ELSE, the new version is deployed to one of the dev servers using this branch
  - [ ] Run with setting `Reset non-user related Docker Volumes & Re-populate` turned on 
  - [ ] It's verified that this version actually is the one deployed (check gitinfo for branch name and commit id!)
  - [ ] It's verified that the CD run is green
  - [ ] The new feature is manually used/tested/observed on dev server. Testing of the new feature should (also) be done by a second, independent reviewer from the dev team
- [ ] Confirm that the latest version (use the /gitinfo endpoint) of the feature branch is deployed to one of the dev servers (no longer enforced by GitHub)
