### PR TITLE
Refs/heads/dala 6700 nonsourceability backend set currently active false

### DIFF
--- a/dataland-backend/backendOpenApi.json
+++ b/dataland-backend/backendOpenApi.json
@@ -615,7 +615,7 @@
           "meta-data-controller"
         ],
         "summary": "Submit a non-sourceability request for a dataset.",
-        "description": "Creates a NonSourceabilityInformation entry. With bypassQa\u003dfalse (default) the entry enters QA review; with bypassQa\u003dtrue (admin only) it is immediately activated.",
+        "description": "Creates a NonSourceabilityInformation entry. With bypassQa\u003dfalse (default) and currentlyActive\u003dfalse the entry enters QA review. With bypassQa\u003dtrue and currentlyActive\u003dtrue (admin only) it is immediately activated. With bypassQa\u003dtrue and currentlyActive\u003dfalse (admin only) the active entry is deactivated (triple marked as sourceable again).",
         "operationId": "postNonSourceabilityOfADataset",
         "requestBody": {
           "content": {
@@ -639,7 +639,7 @@
             }
           },
           "400": {
-            "description": "Duplicate or invalid request.",
+            "description": "Invalid combination of bypassQa and currentlyActive.",
             "content": {
               "application/json": {
                 "schema": {
@@ -650,6 +650,16 @@
           },
           "403": {
             "description": "Insufficient role for bypassQa.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NonSourceabilityInformationResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict — duplicate entry or invalid state transition.",
             "content": {
               "application/json": {
                 "schema": {
@@ -8550,6 +8560,7 @@
         "required": [
           "bypassQa",
           "companyId",
+          "currentlyActive",
           "dataType",
           "reason",
           "reportingPeriod"
@@ -8577,6 +8588,10 @@
           "bypassQa": {
             "type": "boolean",
             "description": "When true the non-sourceability entry is immediately activated without QA review. Requires ROLE_ADMIN."
+          },
+          "currentlyActive": {
+            "type": "boolean",
+            "description": "When true the triple is treated as non-sourceable; when false the entry is inactive. Must be false when bypassQa\u003dfalse (the QA service sets this to true upon approval). When bypassQa\u003dtrue, signals whether the intent is to mark the triple as non-sourceable (true) or sourceable again (false)."
           }
         }
       },
@@ -22695,15 +22710,15 @@
         ],
         "type": "object",
         "properties": {
-          "companyId": {
-            "type": "string",
-            "description": "The unique identifier under which a company can be found on Dataland.",
-            "example": "c9710c7b-9cd6-446b-85b0-3773d2aceb48"
-          },
           "companyName": {
             "type": "string",
             "description": "The official name of the company.",
             "example": "ABC Corporation"
+          },
+          "companyId": {
+            "type": "string",
+            "description": "The unique identifier under which a company can be found on Dataland.",
+            "example": "c9710c7b-9cd6-446b-85b0-3773d2aceb48"
           }
         }
       },

--- a/dataland-backend/src/main/kotlin/org/dataland/datalandbackend/api/MetaDataApi.kt
+++ b/dataland-backend/src/main/kotlin/org/dataland/datalandbackend/api/MetaDataApi.kt
@@ -257,19 +257,23 @@ interface MetaDataApi {
     /**
      * Submits a non-sourceability request for a dataset.
      * When bypassQa=true the caller must hold ROLE_ADMIN; otherwise ROLE_UPLOADER is required.
-     * @param nonSourceabilityRequest request body containing dataset dimensions and bypass flag.
+     * When bypassQa=true and currentlyActive=false the request reverses a non-sourceability entry.
+     * @param nonSourceabilityRequest request body containing dataset dimensions, bypass flag, and currentlyActive flag.
      */
     @Operation(
         summary = "Submit a non-sourceability request for a dataset.",
         description =
-            "Creates a NonSourceabilityInformation entry. With bypassQa=false (default) the entry " +
-                "enters QA review; with bypassQa=true (admin only) it is immediately activated.",
+            "Creates a NonSourceabilityInformation entry. With bypassQa=false (default) and currentlyActive=false " +
+                "the entry enters QA review. With bypassQa=true and currentlyActive=true (admin only) it is " +
+                "immediately activated. With bypassQa=true and currentlyActive=false (admin only) the active " +
+                "entry is deactivated (triple marked as sourceable again).",
     )
     @ApiResponses(
         value = [
             ApiResponse(responseCode = "200", description = "Successfully submitted non-sourceability request."),
-            ApiResponse(responseCode = "400", description = "Duplicate or invalid request."),
+            ApiResponse(responseCode = "400", description = "Invalid combination of bypassQa and currentlyActive."),
             ApiResponse(responseCode = "403", description = "Insufficient role for bypassQa."),
+            ApiResponse(responseCode = "409", description = "Conflict — duplicate entry or invalid state transition."),
         ],
     )
     @PostMapping(

--- a/dataland-backend/src/main/kotlin/org/dataland/datalandbackend/model/metainformation/NonSourceabilityRequest.kt
+++ b/dataland-backend/src/main/kotlin/org/dataland/datalandbackend/model/metainformation/NonSourceabilityRequest.kt
@@ -38,4 +38,13 @@ data class NonSourceabilityRequest(
                 "Requires ROLE_ADMIN.",
     )
     val bypassQa: Boolean = false,
+    @field:JsonProperty(required = true)
+    @field:Schema(
+        description =
+            "When true the triple is treated as non-sourceable; when false the entry is inactive. " +
+                "Must be false when bypassQa=false (the QA service sets this to true upon approval). " +
+                "When bypassQa=true, signals whether the intent is to mark the triple as non-sourceable (true) " +
+                "or sourceable again (false).",
+    )
+    val currentlyActive: Boolean,
 )

--- a/dataland-backend/src/main/kotlin/org/dataland/datalandbackend/services/NonSourceabilityInformationManager.kt
+++ b/dataland-backend/src/main/kotlin/org/dataland/datalandbackend/services/NonSourceabilityInformationManager.kt
@@ -6,6 +6,7 @@ import org.dataland.datalandbackend.model.DataType
 import org.dataland.datalandbackend.model.metainformation.NonSourceabilityInformationResponse
 import org.dataland.datalandbackend.model.metainformation.NonSourceabilityRequest
 import org.dataland.datalandbackend.repositories.NonSourceabilityDataRepository
+import org.dataland.datalandbackendutils.exceptions.ConflictApiException
 import org.dataland.datalandbackendutils.exceptions.InvalidInputApiException
 import org.dataland.datalandbackendutils.model.QaStatus
 import org.dataland.datalandmessagequeueutils.cloudevents.CloudEventMessageHandler
@@ -38,36 +39,123 @@ class NonSourceabilityInformationManager(
     private val logger = LoggerFactory.getLogger(javaClass)
 
     /**
-     * Processes a non-sourceability submission request. Validates uniqueness, persists the entry,
-     * and emits the appropriate lifecycle event (FR-001, FR-002, FR-003).
+     * Processes a non-sourceability submission request.
+     *
+     * Routes to one of four cases based on (bypassQa, currentlyActive):
+     * - (false, true)  → rejected immediately (invalid combination)
+     * - (false, false) → standard QA path: creates Pending entry, emits CREATED event
+     * - (true,  true)  → admin bypass: creates Accepted+active entry, emits AUTO_ACCEPTED event
+     * - (true,  false) → admin reversal: deactivates active entry, creates audit entry, no event
      */
     @Transactional
     fun processNonSourceabilityRequest(request: NonSourceabilityRequest): NonSourceabilityInformationResponse {
         companyQueryManager.assertCompanyIdExists(request.companyId)
 
-        val blockedStatuses = listOf(QaStatus.Pending, QaStatus.Accepted)
-        val hasDuplicate =
+        if (!request.bypassQa && request.currentlyActive) {
+            throw InvalidInputApiException(
+                summary = "Invalid non-sourceability request.",
+                message =
+                    "currentlyActive=true requires bypassQa=true. " +
+                        "The QA service is responsible for setting currentlyActive=true on QA-reviewed entries.",
+            )
+        }
+
+        val hasPendingEntry =
             nonSourceabilityDataRepository.existsActiveOrPendingForTuple(
                 request.companyId,
                 request.dataType,
                 request.reportingPeriod,
-                blockedStatuses,
+                listOf(QaStatus.Pending),
             )
-        if (hasDuplicate) {
-            throw InvalidInputApiException(
-                summary = "Duplicate non-sourceability entry.",
+        if (hasPendingEntry) {
+            throw ConflictApiException(
+                summary = "Pending non-sourceability entry exists.",
                 message =
-                    "An active or pending non-sourceability entry already exists for " +
+                    "A pending non-sourceability entry already exists for " +
+                        "companyId=${request.companyId}, dataType=${request.dataType}, " +
+                        "reportingPeriod=${request.reportingPeriod}. Resolve the pending entry first.",
+            )
+        }
+
+        return if (request.bypassQa && !request.currentlyActive) {
+            processReversal(request)
+        } else {
+            processStandardOrBypassCreate(request)
+        }
+    }
+
+    /**
+     * Handles bypassQa=true, currentlyActive=false: marks the triple as sourceable again.
+     * Deactivates the existing active entry and creates a new audit entry. No event is emitted.
+     */
+    private fun processReversal(request: NonSourceabilityRequest): NonSourceabilityInformationResponse {
+        val activeEntries =
+            nonSourceabilityDataRepository.findActiveForTuple(
+                request.companyId,
+                request.dataType,
+                request.reportingPeriod,
+            )
+        if (activeEntries.isEmpty()) {
+            throw ConflictApiException(
+                summary = "Triple is already sourceable.",
+                message =
+                    "No active non-sourceability entry exists for " +
+                        "companyId=${request.companyId}, dataType=${request.dataType}, " +
+                        "reportingPeriod=${request.reportingPeriod}. The triple is already sourceable.",
+            )
+        }
+
+        activeEntries.forEach { it.currentlyActive = false }
+        nonSourceabilityDataRepository.saveAll(activeEntries)
+
+        val userId = DatalandAuthentication.fromContext().userId
+        val saved =
+            nonSourceabilityDataRepository.save(
+                NonSourceabilityInformationEntity(
+                    companyId = request.companyId,
+                    dataType = request.dataType,
+                    reportingPeriod = request.reportingPeriod,
+                    qaStatus = QaStatus.Accepted,
+                    uploaderUserId = userId,
+                    uploadTime = Instant.now().toEpochMilli(),
+                    currentlyActive = false,
+                    reason = request.reason,
+                    bypassQa = true,
+                ),
+            )
+        logger.info(
+            "Non-sourceability reversal: deactivated ${activeEntries.size} active entry(entries) and " +
+                "created audit entry ${saved.nonSourceabilityId} for " +
+                "companyId=${request.companyId}, dataType=${request.dataType}, reportingPeriod=${request.reportingPeriod}",
+        )
+        return saved.toResponse()
+    }
+
+    /**
+     * Handles bypassQa=false/currentlyActive=false (standard QA) and
+     * bypassQa=true/currentlyActive=true (admin bypass mark as non-sourceable).
+     * Creates a new entry and emits the appropriate lifecycle event.
+     */
+    private fun processStandardOrBypassCreate(request: NonSourceabilityRequest): NonSourceabilityInformationResponse {
+        val hasActiveEntry =
+            nonSourceabilityDataRepository
+                .findActiveForTuple(
+                    request.companyId,
+                    request.dataType,
+                    request.reportingPeriod,
+                ).isNotEmpty()
+        if (hasActiveEntry) {
+            throw ConflictApiException(
+                summary = "Active non-sourceability entry exists.",
+                message =
+                    "An active non-sourceability entry already exists for " +
                         "companyId=${request.companyId}, dataType=${request.dataType}, " +
                         "reportingPeriod=${request.reportingPeriod}.",
             )
         }
 
         val userId = DatalandAuthentication.fromContext().userId
-        val uploadTime = Instant.now().toEpochMilli()
         val qaStatus = if (request.bypassQa) QaStatus.Accepted else QaStatus.Pending
-        val currentlyActive = request.bypassQa
-
         val entity =
             NonSourceabilityInformationEntity(
                 companyId = request.companyId,
@@ -75,8 +163,8 @@ class NonSourceabilityInformationManager(
                 reportingPeriod = request.reportingPeriod,
                 qaStatus = qaStatus,
                 uploaderUserId = userId,
-                uploadTime = uploadTime,
-                currentlyActive = currentlyActive,
+                uploadTime = Instant.now().toEpochMilli(),
+                currentlyActive = request.currentlyActive,
                 reason = request.reason,
                 bypassQa = request.bypassQa,
             )
@@ -88,12 +176,10 @@ class NonSourceabilityInformationManager(
         CorrelationLogging.withNonSourceabilityContext(correlationId, nonSourceabilityId) {
             emitLifecycleEvent(saved, request.bypassQa, correlationId)
         }
-
         logger.info(
             "NonSourceabilityInformation persisted with id=$nonSourceabilityId, " +
                 "bypassQa=${request.bypassQa}, qaStatus=$qaStatus (correlationId=$correlationId)",
         )
-
         return saved.toResponse()
     }
 

--- a/dataland-backend/src/test/kotlin/org/dataland/datalandbackend/controller/MetaDataControllerNonSourceableTest.kt
+++ b/dataland-backend/src/test/kotlin/org/dataland/datalandbackend/controller/MetaDataControllerNonSourceableTest.kt
@@ -8,6 +8,7 @@ import org.dataland.datalandbackend.model.metainformation.NonSourceabilityReques
 import org.dataland.datalandbackend.repositories.NonSourceabilityDataRepository
 import org.dataland.datalandbackend.services.CompanyAlterationManager
 import org.dataland.datalandbackend.utils.DefaultMocks
+import org.dataland.datalandbackendutils.exceptions.ResourceNotFoundApiException
 import org.dataland.datalandbackendutils.model.QaStatus
 import org.dataland.datalandmessagequeueutils.cloudevents.CloudEventMessageHandler
 import org.dataland.keycloakAdapter.auth.DatalandRealmRole
@@ -77,6 +78,7 @@ class MetaDataControllerNonSourceableTest
                     reportingPeriod = reportingPeriod,
                     reason = "No public source",
                     bypassQa = false,
+                    currentlyActive = false,
                 )
             val response = metaDataController.postNonSourceabilityOfADataset(request)
             assertEquals(QaStatus.Pending, response.body?.qaStatus)
@@ -94,6 +96,7 @@ class MetaDataControllerNonSourceableTest
                     reportingPeriod = reportingPeriod,
                     reason = "Admin bypass",
                     bypassQa = true,
+                    currentlyActive = true,
                 )
             val response = metaDataController.postNonSourceabilityOfADataset(request)
             assertEquals(QaStatus.Accepted, response.body?.qaStatus)
@@ -109,6 +112,7 @@ class MetaDataControllerNonSourceableTest
                     reportingPeriod = reportingPeriod,
                     reason = "Attempting bypass",
                     bypassQa = true,
+                    currentlyActive = true,
                 )
             assertThrows<AccessDeniedException> {
                 metaDataController.postNonSourceabilityOfADataset(request)
@@ -125,6 +129,7 @@ class MetaDataControllerNonSourceableTest
                     reportingPeriod = reportingPeriod,
                     reason = "Test",
                     bypassQa = true,
+                    currentlyActive = true,
                 ),
             )
 
@@ -160,8 +165,39 @@ class MetaDataControllerNonSourceableTest
                     reportingPeriod = reportingPeriod,
                     reason = "Active",
                     bypassQa = true,
+                    currentlyActive = true,
                 ),
             )
             metaDataController.isDataNonSourceable(storedCompany.companyId, dataType, reportingPeriod)
+        }
+
+        @Test
+        fun `reversal succeeds for admin and isDataNonSourceable returns 404 afterwards`() {
+            AuthenticationMock.mockSecurityContext("admin", "adminId", adminRoles)
+            metaDataController.postNonSourceabilityOfADataset(
+                NonSourceabilityRequest(
+                    companyId = storedCompany.companyId,
+                    dataType = dataType,
+                    reportingPeriod = reportingPeriod,
+                    reason = "Mark non-sourceable",
+                    bypassQa = true,
+                    currentlyActive = true,
+                ),
+            )
+            val reversalResponse =
+                metaDataController.postNonSourceabilityOfADataset(
+                    NonSourceabilityRequest(
+                        companyId = storedCompany.companyId,
+                        dataType = dataType,
+                        reportingPeriod = reportingPeriod,
+                        reason = "Reversal",
+                        bypassQa = true,
+                        currentlyActive = false,
+                    ),
+                )
+            assertFalse(reversalResponse.body?.currentlyActive ?: true)
+            assertThrows<ResourceNotFoundApiException> {
+                metaDataController.isDataNonSourceable(storedCompany.companyId, dataType, reportingPeriod)
+            }
         }
     }

--- a/dataland-backend/src/test/kotlin/org/dataland/datalandbackend/services/NonSourceabilityInformationManagerTest.kt
+++ b/dataland-backend/src/test/kotlin/org/dataland/datalandbackend/services/NonSourceabilityInformationManagerTest.kt
@@ -204,6 +204,7 @@ class NonSourceabilityInformationManagerTest(
         val allEntries = nonSourceabilityDataRepository.findByFilters(companyId, dataType, reportingPeriod, null)
         assertEquals(2, allEntries.size)
         assertTrue(allEntries.all { !it.currentlyActive })
+        assertEquals(2, allEntries.count { it.bypassQa && !it.currentlyActive && it.qaStatus == QaStatus.Accepted })
     }
 
     @Test

--- a/dataland-backend/src/test/kotlin/org/dataland/datalandbackend/services/NonSourceabilityInformationManagerTest.kt
+++ b/dataland-backend/src/test/kotlin/org/dataland/datalandbackend/services/NonSourceabilityInformationManagerTest.kt
@@ -1,14 +1,15 @@
 package org.dataland.datalandbackend.services
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import org.dataland.datalandbackend.DatalandBackend
 import org.dataland.datalandbackend.model.DataType
 import org.dataland.datalandbackend.model.companies.CompanyInformation
 import org.dataland.datalandbackend.model.metainformation.NonSourceabilityRequest
 import org.dataland.datalandbackend.repositories.NonSourceabilityDataRepository
 import org.dataland.datalandbackend.utils.DefaultMocks
+import org.dataland.datalandbackendutils.exceptions.ConflictApiException
 import org.dataland.datalandbackendutils.exceptions.InvalidInputApiException
 import org.dataland.datalandbackendutils.model.QaStatus
+import org.dataland.datalandbackendutils.services.utils.BaseIntegrationTest
 import org.dataland.datalandmessagequeueutils.cloudevents.CloudEventMessageHandler
 import org.dataland.keycloakAdapter.auth.DatalandRealmRole
 import org.dataland.keycloakAdapter.utils.AuthenticationMock
@@ -18,33 +19,26 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.mockito.Mockito.clearInvocations
+import org.mockito.Mockito.verifyNoInteractions
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.jdbc.EmbeddedDatabaseConnection
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.context.bean.override.mockito.MockitoBean
-import org.springframework.transaction.annotation.Transactional
 
 /**
- * Tests for the canonical NonSourceabilityInformationManager (T016, T048).
- * Verifies duplicate rejection, bypass authorization, qaStatus transitions,
- * and that SourceabilityEntity is not used as a runtime source.
+ * Tests for NonSourceabilityInformationManager.
+ * Covers all four (bypassQa, currentlyActive) combinations, constraint checks,
+ * reversal logic, and event emission behaviour.
  */
-@SpringBootTest(classes = [DatalandBackend::class], properties = ["spring.profiles.active=nodb"])
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
-@AutoConfigureTestDatabase(connection = EmbeddedDatabaseConnection.H2)
-@Transactional
+@SpringBootTest(classes = [DatalandBackend::class], properties = ["spring.profiles.active=containerized-db"])
 @DefaultMocks
 @MockitoBean(types = [CloudEventMessageHandler::class])
 class NonSourceabilityInformationManagerTest(
     @Autowired private val nonSourceabilityDataRepository: NonSourceabilityDataRepository,
-    @Autowired private val companyQueryManager: CompanyQueryManager,
+    @Autowired private val manager: NonSourceabilityInformationManager,
     @Autowired private val companyAlterationManager: CompanyAlterationManager,
-    @Autowired private val objectMapper: ObjectMapper,
     @Autowired private val cloudEventMessageHandler: CloudEventMessageHandler,
-) {
-    private lateinit var manager: NonSourceabilityInformationManager
+) : BaseIntegrationTest() {
     private lateinit var companyId: String
     private val dataType = DataType("eutaxonomy-financials")
     private val reportingPeriod = "2023"
@@ -53,42 +47,40 @@ class NonSourceabilityInformationManagerTest(
 
     @BeforeEach
     fun setUp() {
-        manager =
-            NonSourceabilityInformationManager(
-                nonSourceabilityDataRepository = nonSourceabilityDataRepository,
-                companyQueryManager = companyQueryManager,
-                cloudEventMessageHandler = cloudEventMessageHandler,
-                objectMapper = objectMapper,
-            )
-        nonSourceabilityDataRepository.deleteAll()
         AuthenticationMock.mockSecurityContext("uploader", "uploaderId", uploaderRoles)
-        val companyInfo =
-            CompanyInformation(
-                companyName = "TestCo",
-                headquarters = "DE",
-                headquartersPostalCode = "10115",
-                countryCode = "DE",
-                companyContactDetails = emptyList(),
-                companyLegalForm = null,
-                sector = null,
-                website = null,
-                identifiers = emptyMap(),
-                companyAlternativeNames = null,
-                isTeaserCompany = false,
-                parentCompanyLei = null,
+        val storedCompany =
+            companyAlterationManager.addCompany(
+                CompanyInformation(
+                    companyName = "TestCo",
+                    headquarters = "DE",
+                    headquartersPostalCode = "10115",
+                    countryCode = "DE",
+                    companyContactDetails = emptyList(),
+                    companyLegalForm = null,
+                    sector = null,
+                    website = null,
+                    identifiers = emptyMap(),
+                    companyAlternativeNames = null,
+                    isTeaserCompany = false,
+                    parentCompanyLei = null,
+                ),
             )
-        val storedCompany = companyAlterationManager.addCompany(companyInfo)
         companyId = storedCompany.companyId
     }
 
-    private fun request(bypassQa: Boolean = false) =
-        NonSourceabilityRequest(
-            companyId = companyId,
-            dataType = dataType,
-            reportingPeriod = reportingPeriod,
-            reason = "No source",
-            bypassQa = bypassQa,
-        )
+    private fun request(
+        bypassQa: Boolean = false,
+        currentlyActive: Boolean = bypassQa,
+    ) = NonSourceabilityRequest(
+        companyId = companyId,
+        dataType = dataType,
+        reportingPeriod = reportingPeriod,
+        reason = "No source",
+        bypassQa = bypassQa,
+        currentlyActive = currentlyActive,
+    )
+
+    // --- Existing tests (updated) ---
 
     @Test
     fun `creates pending entry when bypassQa is false`() {
@@ -106,16 +98,16 @@ class NonSourceabilityInformationManagerTest(
     }
 
     @Test
-    fun `duplicate request for Pending entry throws InvalidInputApiException`() {
+    fun `duplicate request for Pending entry throws ConflictApiException`() {
         manager.processNonSourceabilityRequest(request())
-        assertThrows<InvalidInputApiException> { manager.processNonSourceabilityRequest(request()) }
+        assertThrows<ConflictApiException> { manager.processNonSourceabilityRequest(request()) }
     }
 
     @Test
-    fun `duplicate request for Accepted entry throws InvalidInputApiException`() {
+    fun `duplicate request for Accepted entry throws ConflictApiException`() {
         AuthenticationMock.mockSecurityContext("admin", "adminId", adminRoles)
         manager.processNonSourceabilityRequest(request(bypassQa = true))
-        assertThrows<InvalidInputApiException> { manager.processNonSourceabilityRequest(request(bypassQa = true)) }
+        assertThrows<ConflictApiException> { manager.processNonSourceabilityRequest(request(bypassQa = true)) }
     }
 
     @Test
@@ -147,5 +139,97 @@ class NonSourceabilityInformationManagerTest(
         manager.processNonSourceabilityRequest(request(bypassQa = true))
         val entries = nonSourceabilityDataRepository.findByFilters(companyId, dataType, reportingPeriod, null)
         assertTrue(entries.isNotEmpty(), "NonSourceabilityDataRepository must be the runtime source (SC-005)")
+    }
+
+    // --- T004 US4: invalid combination ---
+
+    @Test
+    fun `invalid combination bypassQa false currentlyActive true throws InvalidInputApiException`() {
+        assertThrows<InvalidInputApiException> {
+            manager.processNonSourceabilityRequest(request(bypassQa = false, currentlyActive = true))
+        }
+    }
+
+    // --- T006-T007 US3: standard QA path constraint checks ---
+
+    @Test
+    fun `bypassQa false currentlyActive false rejected when active entry exists throws ConflictApiException`() {
+        AuthenticationMock.mockSecurityContext("admin", "adminId", adminRoles)
+        manager.processNonSourceabilityRequest(request(bypassQa = true, currentlyActive = true))
+        AuthenticationMock.mockSecurityContext("uploader", "uploaderId", uploaderRoles)
+        assertThrows<ConflictApiException> {
+            manager.processNonSourceabilityRequest(request(bypassQa = false, currentlyActive = false))
+        }
+    }
+
+    @Test
+    fun `bypassQa false currentlyActive false rejected when pending entry exists throws ConflictApiException`() {
+        manager.processNonSourceabilityRequest(request(bypassQa = false, currentlyActive = false))
+        assertThrows<ConflictApiException> {
+            manager.processNonSourceabilityRequest(request(bypassQa = false, currentlyActive = false))
+        }
+    }
+
+    // --- T009-T010 US2: admin bypass constraint checks ---
+
+    @Test
+    fun `bypassQa true currentlyActive true rejected when active entry exists throws ConflictApiException`() {
+        AuthenticationMock.mockSecurityContext("admin", "adminId", adminRoles)
+        manager.processNonSourceabilityRequest(request(bypassQa = true, currentlyActive = true))
+        assertThrows<ConflictApiException> {
+            manager.processNonSourceabilityRequest(request(bypassQa = true, currentlyActive = true))
+        }
+    }
+
+    @Test
+    fun `bypassQa true currentlyActive true rejected when pending entry exists throws ConflictApiException`() {
+        AuthenticationMock.mockSecurityContext("uploader", "uploaderId", uploaderRoles)
+        manager.processNonSourceabilityRequest(request(bypassQa = false, currentlyActive = false))
+        AuthenticationMock.mockSecurityContext("admin", "adminId", adminRoles)
+        assertThrows<ConflictApiException> {
+            manager.processNonSourceabilityRequest(request(bypassQa = true, currentlyActive = true))
+        }
+    }
+
+    // --- T012-T015 US1: admin reversal ---
+
+    @Test
+    fun `bypassQa true currentlyActive false deactivates active entry and returns new entry`() {
+        AuthenticationMock.mockSecurityContext("admin", "adminId", adminRoles)
+        manager.processNonSourceabilityRequest(request(bypassQa = true, currentlyActive = true))
+        val result = manager.processNonSourceabilityRequest(request(bypassQa = true, currentlyActive = false))
+        assertFalse(result.currentlyActive)
+        assertEquals(QaStatus.Accepted, result.qaStatus)
+        assertFalse(manager.isCurrentlyActive(companyId, dataType, reportingPeriod))
+        val allEntries = nonSourceabilityDataRepository.findByFilters(companyId, dataType, reportingPeriod, null)
+        assertEquals(2, allEntries.size)
+        assertTrue(allEntries.all { !it.currentlyActive })
+    }
+
+    @Test
+    fun `bypassQa true currentlyActive false returns ConflictApiException when no active entry exists`() {
+        AuthenticationMock.mockSecurityContext("admin", "adminId", adminRoles)
+        assertThrows<ConflictApiException> {
+            manager.processNonSourceabilityRequest(request(bypassQa = true, currentlyActive = false))
+        }
+    }
+
+    @Test
+    fun `bypassQa true currentlyActive false returns ConflictApiException when pending entry exists`() {
+        AuthenticationMock.mockSecurityContext("uploader", "uploaderId", uploaderRoles)
+        manager.processNonSourceabilityRequest(request(bypassQa = false, currentlyActive = false))
+        AuthenticationMock.mockSecurityContext("admin", "adminId", adminRoles)
+        assertThrows<ConflictApiException> {
+            manager.processNonSourceabilityRequest(request(bypassQa = true, currentlyActive = false))
+        }
+    }
+
+    @Test
+    fun `bypassQa true currentlyActive false does not emit lifecycle event`() {
+        AuthenticationMock.mockSecurityContext("admin", "adminId", adminRoles)
+        manager.processNonSourceabilityRequest(request(bypassQa = true, currentlyActive = true))
+        clearInvocations(cloudEventMessageHandler)
+        manager.processNonSourceabilityRequest(request(bypassQa = true, currentlyActive = false))
+        verifyNoInteractions(cloudEventMessageHandler)
     }
 }

--- a/dataland-community-manager/src/main/kotlin/org/dataland/datalandcommunitymanager/services/DataRequestUpdateManager.kt
+++ b/dataland-community-manager/src/main/kotlin/org/dataland/datalandcommunitymanager/services/DataRequestUpdateManager.kt
@@ -60,9 +60,12 @@ class DataRequestUpdateManager
             dataRequestPatch: DataRequestPatch,
             correlationId: String,
         ) {
-            requestEmailManager.sendEmailsWhenRequestStatusChanged(
-                dataRequestEntity, dataRequestPatch.requestStatus, dataRequestPatch.requestStatusChangeReason,
-                dataRequestUpdateUtils.existsEarlierQaApprovalOfDatasetForDataDimension(dataRequestEntity),
+            sendImmediateNotificationOnRequestStatusChange(
+                dataRequestEntity,
+                dataRequestPatch,
+                dataRequestUpdateUtils.existsEarlierQaApprovalOfDatasetForDataDimension(
+                    dataRequestEntity,
+                ),
                 correlationId,
             )
             createNotificationEvent(dataRequestEntity, dataRequestPatch)
@@ -180,6 +183,21 @@ class DataRequestUpdateManager
             }
 
             return updateDataRequestEntity(dataRequestEntity, dataRequestPatch, answeringDataId)
+        }
+
+        /**
+         * If applicable, send an immediate notification email corresponding to the status change to the user.
+         */
+        private fun sendImmediateNotificationOnRequestStatusChange(
+            dataRequestEntity: DataRequestEntity,
+            dataRequestPatch: DataRequestPatch,
+            earlierQaApprovedVersionOfDatasetExists: Boolean,
+            correlationId: String,
+        ) {
+            requestEmailManager.sendEmailsWhenRequestStatusChanged(
+                dataRequestEntity, dataRequestPatch.requestStatus, dataRequestPatch.requestStatusChangeReason,
+                earlierQaApprovedVersionOfDatasetExists, correlationId,
+            )
         }
 
         /**

--- a/dataland-community-manager/src/main/kotlin/org/dataland/datalandcommunitymanager/services/DataRequestUpdateManager.kt
+++ b/dataland-community-manager/src/main/kotlin/org/dataland/datalandcommunitymanager/services/DataRequestUpdateManager.kt
@@ -191,30 +191,20 @@ class DataRequestUpdateManager
             correlationId: String,
             requestStatusChangeReason: String? = null,
         ) {
-            if (dataRequestEntity.dataType == DataTypeEnum.vsme.name && dataRequestEntity.accessStatus != AccessStatus.Granted) {
-                patchDataRequest(
-                    dataRequestId = dataRequestEntity.dataRequestId,
-                    dataRequestPatch =
-                        DataRequestPatch(
-                            requestStatus = RequestStatus.Answered,
-                            accessStatus = AccessStatus.Pending,
-                            requestStatusChangeReason = requestStatusChangeReason,
-                        ),
-                    correlationId = correlationId,
-                    answeringDataId = answeringDataId,
-                )
-            } else {
-                patchDataRequest(
-                    dataRequestId = dataRequestEntity.dataRequestId,
-                    dataRequestPatch =
-                        DataRequestPatch(
-                            requestStatus = RequestStatus.Answered,
-                            requestStatusChangeReason = requestStatusChangeReason,
-                        ),
-                    correlationId = correlationId,
-                    answeringDataId = answeringDataId,
-                )
-            }
+            val isVsmeWithoutAccess =
+                dataRequestEntity.dataType == DataTypeEnum.vsme.name &&
+                    dataRequestEntity.accessStatus != AccessStatus.Granted
+            patchDataRequest(
+                dataRequestId = dataRequestEntity.dataRequestId,
+                dataRequestPatch =
+                    DataRequestPatch(
+                        requestStatus = RequestStatus.Answered,
+                        accessStatus = if (isVsmeWithoutAccess) AccessStatus.Pending else null,
+                        requestStatusChangeReason = requestStatusChangeReason,
+                    ),
+                correlationId = correlationId,
+                answeringDataId = answeringDataId,
+            )
         }
 
         /**
@@ -338,12 +328,9 @@ class DataRequestUpdateManager
             val requestsToProcess = answeredOrClosedOrResolvedDataRequestEntities.filter { it.dataRequestId !in requestIdsToIgnore }
             for (dataRequestEntity in requestsToProcess) {
                 if (dataRequestEntity.dataType == DataTypeEnum.vsme.name) {
-                    val accessStatusIsOkay =
-                        listOf(
-                            dataRequestEntity.accessStatus != AccessStatus.Declined,
-                            dataRequestEntity.accessStatus != AccessStatus.Revoked,
-                        ).all { it }
-                    if (accessStatusIsOkay) {
+                    if (dataRequestEntity.accessStatus != AccessStatus.Declined &&
+                        dataRequestEntity.accessStatus != AccessStatus.Revoked
+                    ) {
                         requestEmailManager.sendDataUpdatedEmail(
                             dataRequestEntity,
                             correlationId,

--- a/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/tests/NonSourceabilityTest.kt
+++ b/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/tests/NonSourceabilityTest.kt
@@ -47,6 +47,7 @@ class NonSourceabilityTest {
                     reportingPeriod = testReportingPeriod,
                     reason = NO_PUBLIC_SOURCE_REASON,
                     bypassQa = true,
+                    currentlyActive = true,
                 ),
             )
         }
@@ -151,6 +152,7 @@ class NonSourceabilityTest {
                         reportingPeriod = ctx.reportingPeriod,
                         reason = NO_PUBLIC_SOURCE_REASON,
                         bypassQa = false,
+                        currentlyActive = false,
                     ),
                 )
             }
@@ -346,6 +348,7 @@ class NonSourceabilityTest {
                         reportingPeriod = ctx.reportingPeriod,
                         reason = NO_PUBLIC_SOURCE_REASON,
                         bypassQa = true,
+                        currentlyActive = true,
                     ),
                 )
             }

--- a/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/tests/communityManager/DataRequestNonSourceableTest.kt
+++ b/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/tests/communityManager/DataRequestNonSourceableTest.kt
@@ -65,6 +65,7 @@ class DataRequestNonSourceableTest {
             reportingPeriod = "2023",
             reason = "This dataset is non-sourceable.",
             bypassQa = true,
+            currentlyActive = true,
         )
 
     private fun postTwoDataRequestForSameUserAndReturnRequestIds(): Pair<UUID, UUID> {
@@ -143,6 +144,7 @@ class DataRequestNonSourceableTest {
                 reportingPeriod = "2024",
                 reason = "This dataset is non-sourceable.",
                 bypassQa = true,
+                currentlyActive = true,
             )
 
         postSourceabilityInfo(sourceabilityInfoRequest2024)

--- a/specs/010-nonsource-deactivate/checklists/requirements.md
+++ b/specs/010-nonsource-deactivate/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Deactivate Non-Sourceability via Endpoint
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-04-17  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All checklist items pass. Spec is ready for `/speckit.clarify` or `/speckit.plan`.
+- FR-001 through FR-012 cover all four bypassQa × currentlyActive combinations exhaustively.
+- SC-004 (zero spurious notifications) is verifiable via integration test.
+- Frontend changes explicitly scoped out in Assumptions section.

--- a/specs/010-nonsource-deactivate/data-model.md
+++ b/specs/010-nonsource-deactivate/data-model.md
@@ -1,0 +1,115 @@
+# Data Model: Deactivate Non-Sourceability via Endpoint
+
+**Feature**: `010-nonsource-deactivate`  
+**Phase**: 1 — Design
+
+---
+
+## Entities
+
+### NonSourceabilityInformationEntity (unchanged)
+
+No schema changes. All required columns already exist.
+
+| Column | Type | Notes |
+|---|---|---|
+| `non_sourceability_id` | UUID PK | Auto-generated |
+| `company_id` | String | Part of triple key |
+| `data_type` | String (converted) | Part of triple key |
+| `reporting_period` | String | Part of triple key |
+| `qa_status` | Enum (Pending/Accepted/Rejected) | Mutable |
+| `uploader_user_id` | String | Set from auth context |
+| `upload_time` | Long (epoch ms) | Set at upload time |
+| `currently_active` | Boolean | Mutable — the key field |
+| `reason` | String? | Optional free text |
+| `bypass_qa` | Boolean | Whether QA was bypassed |
+
+---
+
+## Request Model Change
+
+### NonSourceabilityRequest — add `currentlyActive` field
+
+```kotlin
+// NEW — add after existing `reason` field:
+@field:JsonProperty(required = true)
+@field:Schema(description = "When true the triple is treated as non-sourceable; when false the entry is inactive. " +
+    "Must be false when bypassQa=false (the QA service sets this upon approval). " +
+    "When bypassQa=true, this signals whether the intent is to mark non-sourceable (true) or sourceable (false).")
+val currentlyActive: Boolean
+```
+
+---
+
+## Service Logic (NonSourceabilityInformationManager)
+
+### `processNonSourceabilityRequest` — refactored branching
+
+The single method is split into four logical paths based on `(bypassQa, currentlyActive)`:
+
+```
+┌──────────────────────────────────────────────────────────────────────────────┐
+│  bypassQa=false, currentlyActive=true                                        │
+│  → InvalidInputApiException (400)  — invalid combination                     │
+├──────────────────────────────────────────────────────────────────────────────┤
+│  bypassQa=false, currentlyActive=false   (standard QA path)                  │
+│  1. existsActiveOrPendingForTuple([Pending]) → ConflictApiException (409)    │
+│  2. findActiveForTuple().isNotEmpty()    → ConflictApiException (409)        │
+│  3. Create entity: qaStatus=Pending, currentlyActive=false                   │
+│  4. Emit NON_SOURCEABILITY_CREATED event                                     │
+├──────────────────────────────────────────────────────────────────────────────┤
+│  bypassQa=true, currentlyActive=true   (admin bypass — mark non-sourceable)  │
+│  1. existsActiveOrPendingForTuple([Pending]) → ConflictApiException (409)    │
+│  2. findActiveForTuple().isNotEmpty()    → ConflictApiException (409)        │
+│  3. Create entity: qaStatus=Accepted, currentlyActive=true                   │
+│  4. Emit NON_SOURCEABILITY_AUTO_ACCEPTED event                               │
+├──────────────────────────────────────────────────────────────────────────────┤
+│  bypassQa=true, currentlyActive=false  (admin reversal — mark sourceable)    │
+│  1. existsActiveOrPendingForTuple([Pending]) → ConflictApiException (409)    │
+│  2. findActiveForTuple() → if empty   → ConflictApiException (409, already   │
+│       sourceable)                                                             │
+│  3. Set existing active entry: currentlyActive=false  (save)                 │
+│  4. Create new entity: qaStatus=Accepted, currentlyActive=false, bypassQa=T  │
+│  5. NO event emitted                                                          │
+│  6. Return new entity as response                                             │
+└──────────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Repository (NonSourceabilityDataRepository) — no changes
+
+Existing methods used by the new logic:
+
+| Method | Used in new logic for |
+|---|---|
+| `findActiveForTuple(companyId, dataType, reportingPeriod)` | Check active exists; get entity to deactivate |
+| `existsActiveOrPendingForTuple(…, listOf(QaStatus.Pending))` | Check pending exists |
+
+---
+
+## State Transition Diagram
+
+```
+Triple state:
+  [Sourceable]
+      │
+      │ bypassQa=false / currentlyActive=false  (any uploader)
+      ▼
+  [Pending]  ──(QA reject)──► [Sourceable]
+      │
+      │ QA approves (existing QA service, out of scope)
+      ▼
+  [Non-sourceable]  (currentlyActive=true, qaStatus=Accepted)
+      │
+      │ bypassQa=true / currentlyActive=false  (admin reversal) [NEW]
+      ▼
+  [Sourceable]  +  audit entry (currentlyActive=false, qaStatus=Accepted)
+
+  OR (shortcut):
+  [Sourceable]
+      │
+      │ bypassQa=true / currentlyActive=true  (admin bypass)
+      ▼
+  [Non-sourceable]
+```

--- a/specs/010-nonsource-deactivate/plan.md
+++ b/specs/010-nonsource-deactivate/plan.md
@@ -1,0 +1,100 @@
+# Implementation Plan: Deactivate Non-Sourceability via Endpoint
+
+**Branch**: `010-nonsource-deactivate` | **Date**: 2026-04-17 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/010-nonsource-deactivate/spec.md`
+
+## Summary
+
+Extend the existing `POST /metadata/nonSourceable` endpoint by adding a required `currentlyActive` boolean field to `NonSourceabilityRequest`. This unlocks a fourth logical path (`bypassQa=true, currentlyActive=false`) that allows an admin to reverse a non-sourceability marking: the existing active entry is set to inactive, a new audit entry is created, no lifecycle message is emitted, and the triple is immediately treated as sourceable again. The other three combinations align constraint-checking to the new field semantics (active-entry check instead of accepted-status check), and one new invalid combination (`bypassQa=false, currentlyActive=true`) is explicitly rejected.
+
+## Technical Context
+
+**Language/Version**: Kotlin on JVM 21  
+**Primary Dependencies**: Spring Boot, Spring Security, JPA/Hibernate, JUnit 5, H2 (test), `dataland-backend-utils` (exceptions), auto-generated OpenAPI clients  
+**Storage**: PostgreSQL (`non_sourceability_information` table — no schema changes needed)  
+**Testing**: `./gradlew dataland-backend:test` — Spring Boot integration tests using `BaseIntegrationTest` (real Postgres container, `containerized-db` profile, `@Transactional @Rollback`)  
+**Target Platform**: Running Dataland backend service (Spring Boot)  
+**Project Type**: Web service (REST API change within existing module)  
+**Performance Goals**: N/A (single-row read/write per request)  
+**Constraints**: No new dependencies; no DB migration; existing tests must continue to pass  
+**Scale/Scope**: 5 files modified, ~8 new test cases, 0 new production files
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|---|---|---|
+| I. Contract-First Service Boundaries | ✅ PASS | `NonSourceabilityRequest` is the contract; `currentlyActive` is added as a required field. OpenAPI spec regenerates automatically. Existing consumers (community-manager) read the response only — not affected. |
+| II. Backward-Compatible Messaging | ✅ PASS | No new message types. The reversal path explicitly emits NO message (FR-010). |
+| III. Microservice Autonomy | ✅ PASS | All changes are within `dataland-backend`. Tests use embedded H2 and mock `CloudEventMessageHandler`. |
+| IV. Mandatory Test Coverage and Coverage Floor | ✅ PASS | All four new logic branches are covered by unit/integration tests in `NonSourceabilityInformationManagerTest`. Controller-level tests added for the reversal path. |
+| V. Traceability, Validation, and Operational Clarity | ✅ PASS | Invalid combination rejected fast (400). State conflicts rejected as 409. Existing logger statements retained. |
+| VI. Minimal Dependencies and Reviewable Changes | ✅ PASS | Zero new dependencies. Uses `ConflictApiException` already in `dataland-backend-utils`. 5 files touched. |
+
+**Post-design re-check**: All gates pass. No violations.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/010-nonsource-deactivate/
+├── plan.md        # This file
+├── research.md    # Phase 0 output
+├── data-model.md  # Phase 1 output
+├── quickstart.md  # Phase 1 output
+└── tasks.md       # Phase 2 output (not yet created)
+```
+
+### Source Code (repository root)
+
+```text
+dataland-backend/src/main/kotlin/org/dataland/datalandbackend/
+├── model/metainformation/
+│   └── NonSourceabilityRequest.kt       # Add currentlyActive: Boolean (required)
+├── services/
+│   └── NonSourceabilityInformationManager.kt  # Refactor processNonSourceabilityRequest
+└── api/
+    └── MetaDataApi.kt                   # Update description + add 409 ApiResponse
+
+dataland-backend/src/test/kotlin/org/dataland/datalandbackend/
+├── services/
+│   └── NonSourceabilityInformationManagerTest.kt  # Update helpers + ~8 new tests
+└── controller/
+    └── MetaDataControllerNonSourceableTest.kt     # Update call sites + new tests
+```
+
+**Note**: E2e tests (`dataland-e2etests`) use the generated OpenAPI client model and will need their `NonSourceabilityRequest(…)` constructors updated after `./gradlew dataland-e2etests:generateClients`. This is tracked as a follow-up scope item in [quickstart.md](quickstart.md).
+
+## Complexity Tracking
+
+No constitution violations. No entry required.
+
+## Phase Plan
+
+### Phase 0: Research
+
+No unknowns. All relevant source files were inspected. Key findings:
+- `ConflictApiException` (409) already exists in `dataland-backend-utils` — no new exception class needed.
+- No DB migration required (`currently_active` column already exists).
+- No new repository methods required (existing `findActiveForTuple` + `existsActiveOrPendingForTuple` cover all needed queries).
+- Community-manager is not a caller of `postNonSourceabilityOfADataset` — not affected.
+
+See [research.md](research.md) for full details.
+
+### Phase 1: Design
+
+See [data-model.md](data-model.md) for entity model and service branching logic, and [quickstart.md](quickstart.md) for step-by-step implementation order.
+
+**Key decisions**:
+- `currentlyActive` is **required** (not optional) — follows `@field:JsonProperty(required = true)` pattern.
+- Constraint violations throw `ConflictApiException` → HTTP 409.
+- Invalid combination (`bypassQa=false, currentlyActive=true`) throws `InvalidInputApiException` → HTTP 400.
+- Reversal path (`bypassQa=true, currentlyActive=false`): deactivates active entry in place, creates audit entry, emits **no** lifecycle event.
+- All logic changes are confined to `NonSourceabilityInformationManager.processNonSourceabilityRequest`; no other service is modified.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| [e.g., 4th project] | [current need] | [why 3 projects insufficient] |
+| [e.g., Repository pattern] | [specific problem] | [why direct DB access insufficient] |

--- a/specs/010-nonsource-deactivate/quickstart.md
+++ b/specs/010-nonsource-deactivate/quickstart.md
@@ -1,0 +1,106 @@
+# Quickstart: Deactivate Non-Sourceability via Endpoint
+
+**Feature**: `010-nonsource-deactivate`  
+**Phase**: 1 — Design
+
+---
+
+## What is being changed
+
+One endpoint, one model, one service. No new files for the production code.
+
+| File | Change |
+|---|---|
+| `NonSourceabilityRequest.kt` | Add required `currentlyActive: Boolean` field |
+| `NonSourceabilityInformationManager.kt` | Refactor `processNonSourceabilityRequest` into 4 cases |
+| `MetaDataApi.kt` | Update OpenAPI description + add 409 response code |
+| `NonSourceabilityInformationManagerTest.kt` | Update existing tests; add ~8 new tests |
+| `MetaDataControllerNonSourceableTest.kt` | Update existing call sites; add new tests |
+
+---
+
+## Step-by-step implementation order
+
+### Step 1 — Update `NonSourceabilityRequest.kt`
+
+Add `currentlyActive: Boolean` as the last field, marked required.  
+Convention to follow (same file): `@field:JsonProperty(required = true)` + `@field:Schema(description = "…")`, no default value.
+
+**After this step**: All existing callers of `NonSourceabilityRequest(…)` fail to compile. Proceed to Step 2 before running tests.
+
+### Step 2 — Fix existing test call sites
+
+In both `NonSourceabilityInformationManagerTest.kt` and `MetaDataControllerNonSourceableTest.kt`:
+- Update the `request(bypassQa)` helper to accept a `currentlyActive: Boolean` parameter and pass it through.
+- Update every inline `NonSourceabilityRequest(…)` literal to include `currentlyActive = <appropriate value>`.
+  - Where `bypassQa=false` → `currentlyActive = false`
+  - Where `bypassQa=true` → `currentlyActive = true`
+
+**After this step**: Project compiles and all existing tests pass against the old service logic.
+
+### Step 3 — Refactor `NonSourceabilityInformationManager.processNonSourceabilityRequest`
+
+Replace the existing single-constraint check with four-way branching. Key rules:
+- Import `ConflictApiException` from `dataland-backend-utils`.
+- Check pending with `existsActiveOrPendingForTuple(…, listOf(QaStatus.Pending))`.
+- Check active with `findActiveForTuple(…).isNotEmpty()`.
+- For the reversal path: call `findActiveForTuple` once, save the result, use it for both the guard check and the entity to update.
+- Call `emitLifecycleEvent` only when `currentlyActive=true` OR `bypassQa=false`.
+
+> **Note on naming**: the repository methods use the word "Tuple" (e.g. `findActiveForTuple`) while the domain language uses "triple". This pre-existing inconsistency is **not** fixed in this feature's scope.
+
+### Step 4 — Update `MetaDataApi.kt`
+
+Add `currentlyActive` to the endpoint description. Add `ApiResponse(responseCode = "409", description = "Conflict — duplicate or invalid state.")` to the `@ApiResponses` annotation.
+
+### Step 5 — Add new tests to `NonSourceabilityInformationManagerTest.kt`
+
+Migrate and extend this test class to use `BaseIntegrationTest` (from `dataland-backend-utils`):  
+`class NonSourceabilityInformationManagerTest : BaseIntegrationTest()`
+
+This replaces the current H2 + `@AutoConfigureTestDatabase` + `@DirtiesContext` setup with a real Postgres container backed by `@Transactional @Rollback`. Profile annotation becomes `properties = ["spring.profiles.active=containerized-db"]`.
+
+New test cases (service-level):
+
+| Test name | Setup | Expected |
+|---|---|---|
+| `invalid combination bypassQa false currentlyActive true throws` | — | `InvalidInputApiException` |
+| `bypassQa false currentlyActive false rejected when active entry exists` | Admin creates active entry first | `ConflictApiException` |
+| `bypassQa false currentlyActive false rejected when pending entry exists` | Create pending entry first | `ConflictApiException` |
+| `bypassQa true currentlyActive true rejected when active entry exists` | Admin creates active entry first | `ConflictApiException` |
+| `bypassQa true currentlyActive true rejected when pending entry exists` | Create pending entry first | `ConflictApiException` |
+| `bypassQa true currentlyActive false deactivates active entry` | Admin creates active entry first | Old entry `currentlyActive=false`, new entry returned, `isCurrentlyActive=false` |
+| `bypassQa true currentlyActive false returns 409 when no active entry` | No entries | `ConflictApiException` |
+| `bypassQa true currentlyActive false rejected when pending entry exists` | Create pending entry first | `ConflictApiException` |
+| `bypassQa true currentlyActive false does not emit lifecycle event` | Admin creates active entry first | `cloudEventMessageHandler` called only once (for setup), zero times after reversal |
+
+### Step 6 — Update `MetaDataControllerNonSourceableTest.kt`
+
+Add controller-level tests for:
+- Reversal succeeds for admin and returns OK.
+- `isDataNonSourceable` returns 404 after successful reversal.
+
+---
+
+## Running the tests
+
+```bash
+# Service-level tests (uses Postgres test container — requires Docker):
+./gradlew dataland-backend:test --tests "org.dataland.datalandbackend.services.NonSourceabilityInformationManagerTest"
+
+# Full backend test suite:
+./gradlew dataland-backend:test
+
+# Lint:
+./gradlew ktlintFormat
+```
+
+---
+
+## E2E tests (out of scope — note for implementer)
+
+After regenerating the OpenAPI client (`./gradlew dataland-e2etests:generateClients`), the following e2e test files will fail to compile until their `NonSourceabilityRequest(…)` constructors are updated with `currentlyActive`:
+- `dataland-e2etests/src/test/kotlin/org/dataland/e2etests/tests/NonSourceabilityTest.kt`
+- `dataland-e2etests/src/test/kotlin/org/dataland/e2etests/tests/communityManager/DataRequestNonSourceableTest.kt`
+
+These are tracked as a follow-up concern; the primary implementation scope is `dataland-backend`.

--- a/specs/010-nonsource-deactivate/research.md
+++ b/specs/010-nonsource-deactivate/research.md
@@ -1,0 +1,125 @@
+# Research: Deactivate Non-Sourceability via Endpoint
+
+**Feature**: `010-nonsource-deactivate`  
+**Phase**: 0 — Research
+
+No NEEDS CLARIFICATION items were identified in the Technical Context. This document records
+the discoveries made by reading existing source code that inform the design decisions in Phase 1.
+
+---
+
+## 1. Existing Request Model
+
+**File**: `dataland-backend/src/main/kotlin/org/dataland/datalandbackend/model/metainformation/NonSourceabilityRequest.kt`
+
+**Current fields**: `companyId` (required), `dataType` (required), `reportingPeriod` (required), `reason` (required), `bypassQa` (optional, defaults `false` via `@field:JsonProperty(required = false)`).
+
+**Pattern for required fields**: `@field:JsonProperty(required = true)` with no Kotlin default.
+
+**Decision**: `currentlyActive: Boolean` is added as a **required** field (`@field:JsonProperty(required = true)`) — consistent with how other mandatory fields in this class are declared. Callers that omit the field receive HTTP 400 from the JSON deserializer.
+
+---
+
+## 2. Existing Service Logic
+
+**File**: `dataland-backend/src/main/kotlin/org/dataland/datalandbackend/services/NonSourceabilityInformationManager.kt`
+
+**Current constraint check** (in `processNonSourceabilityRequest`):
+```
+blockedStatuses = [Pending, Accepted]
+existsActiveOrPendingForTuple(…, blockedStatuses) → reject with InvalidInputApiException
+```
+
+**Current value derivation**:
+```
+qaStatus      = if (bypassQa) Accepted else Pending
+currentlyActive = bypassQa   // always mirrors bypassQa today
+```
+
+**Existing utilities already available**:
+- `findActiveForTuple(companyId, dataType, reportingPeriod): List<…>` — returns the currently-active entry (if any). Used by `isCurrentlyActive` and `deactivateForTriple`.
+- `existsActiveOrPendingForTuple(…, blockedStatuses: List<QaStatus>): Boolean` — generic check. Calling it with `listOf(QaStatus.Pending)` gives the pending-only check needed by the new logic.
+- `deactivateForTriple(…)` — bulk-sets `currentlyActive=false` on all active entries (used by the dataset-upload deactivation path). **Not reused for the reversal flow** because the reversal must also create a new entry, and should not emit a lifecycle event.
+
+**Decision**: No new repository methods required. The refactored service calls the two existing repository methods with different argument combinations per case.
+
+---
+
+## 3. Lifecycle Event Rules
+
+**File**: `NonSourceabilityInformationManager.emitLifecycleEvent`
+
+Current logic always emits one of:
+- `NON_SOURCEABILITY_CREATED` (bypassQa=false, QA path)
+- `NON_SOURCEABILITY_AUTO_ACCEPTED` (bypassQa=true, admin bypass)
+
+**FR-010 ruling**: The `bypassQa=true, currentlyActive=false` (reversal) path MUST NOT emit any event. The data-sourcing service must not be triggered.
+
+**Decision**: `emitLifecycleEvent` is only called when `currentlyActive=true` OR `bypassQa=false`. The private helper remains unchanged; the call-site is guarded by the new branching logic.
+
+---
+
+## 4. Exception Types
+
+**File**: `dataland-backend-utils/src/main/kotlin/org/dataland/datalandbackendutils/exceptions/`
+
+| Exception class | HTTP status | Use |
+|---|---|---|
+| `InvalidInputApiException` | 400 | Invalid combination (`bypassQa=false, currentlyActive=true`) |
+| `ConflictApiException` | 409 | All constraint-violation rejections (active exists, pending exists, already sourceable) |
+
+`ConflictApiException` already exists and maps to `HttpStatus.CONFLICT` (409). This matches the spec requirement (FR-003–FR-006, FR-008, FR-009 → 409). The existing duplicate check used `InvalidInputApiException` (400); this will be changed to `ConflictApiException` for the constraint cases to align with the spec.
+
+---
+
+## 5. Database Schema Impact
+
+**`currently_active` column**: Already present in `non_sourceability_information` table (created in `V13__CreateNonSourceabilityInformation`). No migration required.  
+**`NonSourceabilityRequest` is a DTO only** — not persisted. No schema change at all.
+
+---
+
+## 6. Call-site Impact
+
+Adding `currentlyActive` as a **required** field to `NonSourceabilityRequest` (the source Kotlin model) breaks all callers that construct the object:
+
+| File | Type | Impact |
+|---|---|---|
+| `NonSourceabilityInformationManagerTest.kt` | backend unit/integration test | Update `request()` helper + all `NonSourceabilityRequest(...)` literals |
+| `MetaDataControllerNonSourceableTest.kt` | backend controller test | Update all `NonSourceabilityRequest(...)` literals |
+| `NonSourceabilityTest.kt` (e2e) | uses generated OpenAPI client model | Regenerate clients; update constructors after |
+| `DataRequestNonSourceableTest.kt` (e2e) | uses generated OpenAPI client model | Regenerate clients; update constructors after |
+
+The community-manager (`DataRequestNonSourceabilityManager`) reads `NonSourceabilityInformationResponse` only — it does NOT construct `NonSourceabilityRequest`. No changes required there.
+
+---
+
+## 7. Test Infrastructure Pattern
+
+The preferred pattern for new service-level integration tests in `dataland-backend` is `BaseIntegrationTest` (from `dataland-backend-utils`), which provides:
+- Real Postgres container via `TestPostgresContainer`
+- `@Transactional @Rollback` — data reset between tests automatically
+- `@SpringBootTest` with `properties = ["spring.profiles.active=containerized-db"]`
+
+The existing `NonSourceabilityInformationManagerTest` was written before this pattern and uses H2 + `@DirtiesContext`. The new tests should migrate this class to extend `BaseIntegrationTest` and drop the H2/`@DirtiesContext`/`@AutoConfigureTestDatabase` annotations.
+
+**Decision**: Migrate `NonSourceabilityInformationManagerTest` to `BaseIntegrationTest` while adding the new test cases.
+
+---
+
+## 8. Tuple vs Triple Naming
+
+The repository methods use the word "Tuple" (e.g. `existsActiveOrPendingForTuple`, `findActiveForTuple`) while the domain language (spec, PR descriptions, business discussions) uses "triple". This pre-existing inconsistency is not corrected in this feature's scope to keep the change minimal. References in this plan use "triple" for domain language and "Tuple" only when referring to the actual method names.
+
+---
+
+## Summary of Decisions
+
+| Decision | Chosen | Rationale |
+|---|---|---|
+| `currentlyActive` required vs optional | Required | Explicit intent, existing pattern for mandatory fields |
+| Constraint violation HTTP code | 409 via `ConflictApiException` | Matches spec; existing class already in codebase |
+| Invalid combination HTTP code | 400 via `InvalidInputApiException` | Input validation, not a state conflict |
+| New repository methods | None | Existing methods cover all new query patterns |
+| DB migration | None | `currently_active` column already exists |
+| Lifecycle event on reversal | None emitted | FR-010; data-sourcing must not be triggered |

--- a/specs/010-nonsource-deactivate/spec.md
+++ b/specs/010-nonsource-deactivate/spec.md
@@ -1,0 +1,133 @@
+# Feature Specification: Deactivate Non-Sourceability via Endpoint
+
+**Feature Branch**: `010-nonsource-deactivate`  
+**Created**: 2026-04-17  
+**Status**: Draft  
+**Input**: User description: "Extend non-sourceability endpoint to allow marking a triple as sourceable again by adding currentlyActive field"
+
+## Background
+
+Non-sourceability is assigned to triples of the form `{companyId, dataType, reportingPeriod}`. When an active non-sourceability entry exists (`currentlyActive = true`, `qaStatus = Accepted`), the triple is treated as non-sourceable by the data sourcing pipeline — no dataset upload attempts will be made for it.
+
+Currently, once a triple is marked as non-sourceable there is no supported way to reverse this via the API. This feature extends the existing `/metadata/nonSourceable` endpoint with a `currentlyActive` field so that an admin can explicitly mark a triple as sourceable again.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Admin Reverses Non-Sourceability (Priority: P1)
+
+An admin notices that a company triple that was previously marked as non-sourceable now has a valid data source available. The admin wants to mark the triple as sourceable again so the data sourcing pipeline will resume attempts for it.
+
+**Why this priority**: This is the only new capability introduced by this feature. Without it, the entire feature has no unique value.
+
+**Independent Test**: Can be tested end-to-end by first creating an active non-sourceability entry (bypassQa=true, currentlyActive=true), then submitting a reversal request (bypassQa=true, currentlyActive=false), and verifying the triple is no longer reported as non-sourceable.
+
+**Acceptance Scenarios**:
+
+1. **Given** a triple with an active non-sourceability entry (currentlyActive=true, qaStatus=Accepted), **When** an admin submits bypassQa=true / currentlyActive=false for the same triple, **Then** the existing entry is set to currentlyActive=false, a new entry is recorded with currentlyActive=false / bypassQa=true / qaStatus=Accepted, the response is 201, and the triple is no longer reported as non-sourceable.
+2. **Given** a triple with an active non-sourceability entry, **When** the reversal is submitted, **Then** no notification is sent to the data sourcing service.
+3. **Given** a triple that has no active non-sourceability entry (already sourceable), **When** an admin submits bypassQa=true / currentlyActive=false, **Then** the response is 409 with a message stating that the triple is already sourceable.
+4. **Given** a triple with a pending non-sourceability entry (qaStatus=Pending), **When** an admin submits bypassQa=true / currentlyActive=false, **Then** the response is 409 Conflict (pending entry must be resolved first).
+
+---
+
+### User Story 2 - Admin Marks Triple as Non-Sourceable (Bypass QA) (Priority: P2)
+
+An admin wants to immediately mark a triple as non-sourceable without waiting for QA review, using the existing bypass-QA path. The constraint logic is tightened to prevent double-marking.
+
+**Why this priority**: Existing capability whose constraint changes slightly; admins must be prevented from inadvertently creating duplicate active entries.
+
+**Independent Test**: Can be tested by submitting bypassQa=true / currentlyActive=true for a triple and verifying it becomes immediately non-sourceable. Can also verify the duplicate and pending-entry rejection cases.
+
+**Acceptance Scenarios**:
+
+1. **Given** a triple with no existing non-sourceability entry, **When** an admin submits bypassQa=true / currentlyActive=true, **Then** the triple is immediately marked as non-sourceable (qaStatus=Accepted, currentlyActive=true) and returns 201.
+2. **Given** a triple that is already actively non-sourceable, **When** an admin submits bypassQa=true / currentlyActive=true, **Then** the response is 409 Conflict because the triple is already non-sourceable.
+3. **Given** a triple with a pending non-sourceability entry, **When** an admin submits bypassQa=true / currentlyActive=true, **Then** the response is 409 Conflict because a pending entry must be resolved first.
+
+---
+
+### User Story 3 - Standard User Submits Non-Sourceability for QA Review (Priority: P3)
+
+An uploader identifies a triple for which no valid data source exists and submits a non-sourceability request. The request enters a QA review queue; until approved the triple remains sourceable.
+
+**Why this priority**: This is the existing dominant use case. The behaviour is unchanged except for tightened constraints to prevent uploads when the triple is already actively non-sourceable or already pending.
+
+**Independent Test**: Can be tested by submitting bypassQa=false / currentlyActive=false and verifying a pending entry is created. Rejection cases (active entry exists, pending entry exists) can be tested independently.
+
+**Acceptance Scenarios**:
+
+1. **Given** a triple with no existing non-sourceability entry, **When** a user submits bypassQa=false / currentlyActive=false, **Then** an entry with qaStatus=Pending and currentlyActive=false is created and returns 201.
+2. **Given** a triple with an active non-sourceability entry (currentlyActive=true), **When** a user submits bypassQa=false / currentlyActive=false, **Then** the response is 409 Conflict (triple is already non-sourceable).
+3. **Given** a triple with a pending non-sourceability entry, **When** a user submits bypassQa=false / currentlyActive=false, **Then** the response is 409 Conflict (must wait for the pending entry to be resolved first).
+
+---
+
+### User Story 4 - Invalid Combination Rejection (Priority: P4)
+
+Any caller submits bypassQa=false together with currentlyActive=true, which is a logically inconsistent combination (setting a triple as actively non-sourceable without QA approval is not permitted for non-admin submissions, and the QA service—not the caller—sets currentlyActive=true).
+
+**Why this priority**: Defensive validation to prevent misuse; lower priority than the primary flows.
+
+**Independent Test**: Submit bypassQa=false / currentlyActive=true and verify a clear error response is returned.
+
+**Acceptance Scenarios**:
+
+1. **Given** any triple, **When** any caller submits bypassQa=false / currentlyActive=true, **Then** the request is rejected with a clear error message explaining that currentlyActive=true requires bypassQa=true.
+
+---
+
+### Edge Cases
+
+- What happens when a triple has multiple historical entries (some with currentlyActive=false) but none currently active, and the admin tries to deactivate? → Returns 409 (already sourceable).
+- What happens when a pending entry exists and the reversal (bypassQa=true, currentlyActive=false) is attempted? → Rejected; pending entry must be resolved first.
+- What happens when an admin sends bypassQa=true / currentlyActive=false for a triple that was never marked non-sourceable? → Returns 409 with message that the triple is already sourceable.
+- What happens when a non-admin submits bypassQa=true? → Rejected with an authorisation error (existing behaviour, unchanged).
+
+## Clarifications
+
+### Session 2026-04-17
+
+- Q: When `bypassQa=true` but `currentlyActive` is omitted, should the field default or be required? → A: Required — must be explicitly provided. Follows the existing `@field:JsonProperty(required = true)` pattern used for all mandatory fields in `NonSourceabilityRequest.kt`.
+- Q: What HTTP status code should all constraint-violation rejections (duplicate active entry, pending entry exists, etc.) return? → A: 409 Conflict — consistent with the existing uniqueness-constraint rejection pattern in the backend.
+- Q: Does the QA service set `currentlyActive=true` when approving a standard non-sourceability entry? → A: Yes, but that happens later (entry starts as Pending / currentlyActive=false); the QA approval path is existing behaviour and is out of scope for this implementation.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The `/metadata/nonSourceable` endpoint MUST accept a **required** `currentlyActive` boolean field in the request body. Omitting the field MUST result in a 400 Bad Request. This follows the existing `@field:JsonProperty(required = true)` convention used for all mandatory fields in the request model.
+- **FR-002**: The combination `bypassQa=false, currentlyActive=true` MUST be rejected with a descriptive error message stating that active non-sourceability without QA bypass is not permitted.
+- **FR-003**: For `bypassQa=false, currentlyActive=false`: the request MUST be rejected with 409 Conflict if an entry with `currentlyActive=true` already exists for the triple.
+- **FR-004**: For `bypassQa=false, currentlyActive=false`: the request MUST be rejected with 409 Conflict if an entry with `qaStatus=Pending` already exists for the triple.
+- **FR-005**: For `bypassQa=true, currentlyActive=true`: the request MUST be rejected with 409 Conflict if an entry with `currentlyActive=true` already exists for the triple.
+- **FR-006**: For `bypassQa=true, currentlyActive=true`: the request MUST be rejected with 409 Conflict if an entry with `qaStatus=Pending` already exists for the triple.
+- **FR-007**: For `bypassQa=true, currentlyActive=false` when an active entry (`currentlyActive=true`) exists: the system MUST set that existing entry's `currentlyActive` to `false` (preserving its `qaStatus=Accepted`), create a new entry with `currentlyActive=false / bypassQa=true / qaStatus=Accepted`, and return 201.
+- **FR-008**: For `bypassQa=true, currentlyActive=false` when no active entry exists: the system MUST return 409 with a message stating the triple is already sourceable.
+- **FR-009**: For `bypassQa=true, currentlyActive=false` when a pending entry exists: the request MUST be rejected with 409 Conflict.
+- **FR-010**: The `bypassQa=true, currentlyActive=false` deactivation flow MUST NOT trigger any notification to the data sourcing service.
+- **FR-011**: All `bypassQa=true` operations MUST remain restricted to admin users only (existing authorisation requirement, unchanged).
+- **FR-012**: After a successful deactivation (FR-007), the triple MUST no longer be reported as non-sourceable by the non-sourceability query endpoint.
+
+### Key Entities
+
+- **NonSourceabilityInformation**: Represents a non-sourceability record for a `{companyId, dataType, reportingPeriod}` triple. Key fields: `nonSourceabilityId`, `companyId`, `dataType`, `reportingPeriod`, `qaStatus` (Pending / Accepted / Rejected), `currentlyActive` (boolean), `bypassQa` (boolean), `reason` (free text), `uploaderUserId`, `uploadTime`.
+- **Triple**: The composite key `{companyId, dataType, reportingPeriod}` that uniquely identifies a non-sourceability scope.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: An admin can reverse a non-sourceability marking for a triple in a single API call, with the triple immediately becoming sourceable upon the response.
+- **SC-002**: The audit trail is fully preserved — no entries are deleted; all state transitions are recorded as new entries or field updates, making the history reconstructable by inspection order.
+- **SC-003**: All four `bypassQa × currentlyActive` combinations return the correct HTTP status code and a meaningful error message on rejection in 100% of cases.
+- **SC-004**: The data sourcing service receives zero spurious notifications as a result of the deactivation flow.
+- **SC-005**: All existing non-sourceability workflows (standard QA submission, admin bypass-mark) continue to function correctly after the change.
+
+## Assumptions
+
+- The `currentlyActive` field is required in all requests (no default). Existing callers that omit it will need to be updated to pass `currentlyActive: false` explicitly.
+- Only one entry per triple can have `currentlyActive=true` at any point in time (enforced by existing business logic and the new constraints).
+- The QA service is the only actor that sets `currentlyActive=true` for QA-reviewed (`bypassQa=false`) entries; it does so upon approval (after an interim Pending / currentlyActive=false state). This existing behaviour is unchanged and out of scope for this implementation.
+- "No notification to the data sourcing service" means no message is published to the RabbitMQ exchange that would trigger data sourcing pipeline resumption — the deactivation is intentional and should not cause an immediate sourcing attempt.
+- The reason field remains free-text and optional; this feature does not constrain its format.
+- Frontend changes (UI for the new field) are out of scope for this specification; the API change is backend-only.

--- a/specs/010-nonsource-deactivate/tasks.md
+++ b/specs/010-nonsource-deactivate/tasks.md
@@ -1,0 +1,164 @@
+# Tasks: Deactivate Non-Sourceability via Endpoint
+
+**Input**: Design documents from `/specs/010-nonsource-deactivate/`
+**Branch**: `010-nonsource-deactivate`
+**Prerequisites**: plan.md ✅ | spec.md ✅ | research.md ✅ | data-model.md ✅ | quickstart.md ✅
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Compile-safe foundation — add the new required field so all dependent changes build correctly.
+
+- [X] T001 Add required `currentlyActive: Boolean` field to `NonSourceabilityRequest` in `dataland-backend/src/main/kotlin/org/dataland/datalandbackend/model/metainformation/NonSourceabilityRequest.kt`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Fix all existing call sites that construct `NonSourceabilityRequest` so the project compiles and existing tests pass. Must be complete before any logic or test changes.
+
+**⚠️ CRITICAL**: Nothing else can be built or tested until this phase is done.
+
+- [X] T002 Update `request()` helper and all `NonSourceabilityRequest(…)` literals in `dataland-backend/src/test/kotlin/org/dataland/datalandbackend/services/NonSourceabilityInformationManagerTest.kt` — set `currentlyActive = true` where `bypassQa = true`, `currentlyActive = false` otherwise
+- [X] T003 Update all `NonSourceabilityRequest(…)` literals in `dataland-backend/src/test/kotlin/org/dataland/datalandbackend/controller/MetaDataControllerNonSourceableTest.kt` with the same rule
+
+**Checkpoint**: `./gradlew dataland-backend:compileTestKotlin` succeeds; all pre-existing tests pass.
+
+---
+
+## Phase 3: User Story 4 — Invalid Combination Rejection (Priority: P4) ⬆️ prerequisite for all stories
+
+> US4 is implemented first because its guard (`bypassQa=false, currentlyActive=true → 400`) is a fast-path validation that runs before any other case. Implementing it first avoids writing duplicate guards in later phases.
+
+**Goal**: Any `bypassQa=false, currentlyActive=true` request is rejected immediately with HTTP 400.
+
+**Independent Test**: Submit `bypassQa=false, currentlyActive=true` and verify `InvalidInputApiException` is thrown.
+
+### Tests for User Story 4
+
+- [X] T004 [P] [US4] Add test `invalid combination bypassQa false currentlyActive true throws InvalidInputApiException` to `dataland-backend/src/test/kotlin/org/dataland/datalandbackend/services/NonSourceabilityInformationManagerTest.kt`
+
+### Implementation for User Story 4
+
+- [X] T005 [US4] Add early-exit guard in `processNonSourceabilityRequest`
+
+**Checkpoint**: T004 test passes; all existing tests still pass.
+
+---
+
+## Phase 4: User Story 3 — Standard QA Submission (Priority: P3)
+
+**Goal**: `bypassQa=false, currentlyActive=false` (existing happy path) enforces tightened constraints — reject if active entry exists (409) or pending entry exists (409).
+
+**Independent Test**: Submit with no existing entries → pending entry created. Submit again with active or pending entry → `ConflictApiException`.
+
+### Tests for User Story 3
+
+- [X] T006 [P] [US3] Add test `bypassQa false currentlyActive false rejected when active entry exists throws ConflictApiException` to `NonSourceabilityInformationManagerTest.kt`
+- [X] T007 [P] [US3] Add test `bypassQa false currentlyActive false rejected when pending entry exists throws ConflictApiException` to `NonSourceabilityInformationManagerTest.kt`
+
+### Implementation for User Story 3
+
+- [X] T008 [US3] Replace the existing `InvalidInputApiException` duplicate check in `processNonSourceabilityRequest`
+
+**Checkpoint**: T006, T007 pass. Existing `creates pending entry when bypassQa is false` test still passes.
+
+---
+
+## Phase 5: User Story 2 — Admin Bypass-Mark as Non-Sourceable (Priority: P2)
+
+**Goal**: `bypassQa=true, currentlyActive=true` (existing admin bypass) enforces the same tightened constraints as US3.
+
+**Independent Test**: Submit with no existing entries → accepted active entry. Submit when active entry or pending entry exists → `ConflictApiException`.
+
+### Tests for User Story 2
+
+- [X] T009 [P] [US2] Add test `bypassQa true currentlyActive true rejected when active entry exists throws ConflictApiException` to `NonSourceabilityInformationManagerTest.kt`
+- [X] T010 [P] [US2] Add test `bypassQa true currentlyActive true rejected when pending entry exists throws ConflictApiException` to `NonSourceabilityInformationManagerTest.kt`
+
+### Implementation for User Story 2
+
+- [X] T011 [US2] Add the `bypassQa=true, currentlyActive=true` branch in `processNonSourceabilityRequest`
+
+**Checkpoint**: T009, T010 pass. Existing `creates accepted active entry when bypassQa is true` test still passes.
+
+---
+
+## Phase 6: User Story 1 — Admin Reversal (Priority: P1) 🎯 MVP
+
+**Goal**: `bypassQa=true, currentlyActive=false` deactivates the active entry, creates a new audit entry, returns 201-equivalent response, emits no lifecycle event.
+
+**Independent Test**: Create active entry → submit reversal → verify old entry `currentlyActive=false`, new entry returned, `isCurrentlyActive=false`.
+
+### Tests for User Story 1
+
+- [X] T012 [P] [US1] Add test `bypassQa true currentlyActive false deactivates active entry and returns new entry` to `NonSourceabilityInformationManagerTest.kt`
+- [X] T013 [P] [US1] Add test `bypassQa true currentlyActive false returns ConflictApiException when no active entry exists` to `NonSourceabilityInformationManagerTest.kt`
+- [X] T014 [P] [US1] Add test `bypassQa true currentlyActive false returns ConflictApiException when pending entry exists` to `NonSourceabilityInformationManagerTest.kt`
+- [X] T015 [P] [US1] Add test `bypassQa true currentlyActive false does not emit lifecycle event` to `NonSourceabilityInformationManagerTest.kt` (verify `cloudEventMessageHandler` not called for the reversal)
+
+### Implementation for User Story 1
+
+- [X] T016 [US1] Add the `bypassQa=true, currentlyActive=false` branch in `processNonSourceabilityRequest`
+
+**Checkpoint**: T012–T015 pass. `isCurrentlyActive` returns false after reversal.
+
+---
+
+## Phase 7: Controller & API (All Stories)
+
+**Purpose**: Expose the changes correctly at the HTTP layer and add controller-level validation for the reversal flow.
+
+- [X] T017 [P] Update `@ApiResponses` on `postNonSourceabilityOfADataset` in `MetaDataApi.kt`
+- [X] T018 [P] Add controller test `reversal succeeds for admin and isDataNonSourceable returns 404 afterwards`
+
+---
+
+## Phase 8: Test Infrastructure Migration
+
+**Purpose**: Migrate `NonSourceabilityInformationManagerTest` from H2 + `@DirtiesContext` to `BaseIntegrationTest` (real Postgres container, `containerized-db` profile) — consistent with the established backend test pattern.
+
+- [X] T019 Migrate `NonSourceabilityInformationManagerTest` to extend `BaseIntegrationTest`
+
+---
+
+## Phase 9: Polish & Cross-Cutting Concerns
+
+- [X] T020 [P] Run `./gradlew ktlintFormat` and fix any lint issues in changed files
+- [X] T021 [P] Run `./gradlew dataland-backend:test` and confirm all tests pass
+- [ ] T022 Note in a PR description comment that `dataland-e2etests` callers of `NonSourceabilityRequest(…)` will need `currentlyActive` added after `./gradlew dataland-e2etests:generateClients` is run (tracked as follow-up)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1** (Setup): No dependencies — start here
+- **Phase 2** (Foundational): Depends on Phase 1 — unblocks all further work
+- **Phase 3** (US4 guard): Depends on Phase 2 — implement first; guard is prerequisite for all other branches
+- **Phase 4** (US3), **Phase 5** (US2), **Phase 6** (US1): All depend on Phase 2. Can proceed in any order after Phase 3 guard is in place. US1 is the highest business value.
+- **Phase 7** (Controller/API): Depends on Phases 3–6 being complete
+- **Phase 8** (Test migration): Independent of Phases 3–7; can be done any time after Phase 2
+- **Phase 9** (Polish): After all above
+
+### Parallel Opportunities per User Story
+
+**US1 (reversal)**: T012, T013, T014, T015 can all be written in parallel (different test methods, same file). T016 depends on none of them (tests validate it, not the other way around).
+
+**US2 + US3**: T006, T007, T009, T010 are all independent test additions — parallel. T008 and T011 touch the same method so should be sequential.
+
+**Phase 7**: T017 and T018 are in different files — parallel.
+
+### Implementation Strategy (MVP first)
+
+1. T001–T003 (must-do first)
+2. T005 (US4 guard — fast, then everything builds correctly)
+3. T016 (US1 reversal logic — highest business value)
+4. T012–T015 (US1 tests to validate)
+5. T008, T011 (US3 + US2 constraint tightening)
+6. T006, T007, T009, T010 (US3 + US2 tests)
+7. T017, T018 (API layer)
+8. T019 (test migration — low risk, independent)
+9. T020–T022 (polish)


### PR DESCRIPTION
# Pull Request \<Title>
`<Description here>`
## Things to do during Peer Review
Please check all boxes before the Pull Request is merged. In case you skip a box, describe in the PRs description (that means: here) why the check is skipped.
- [x] The GitHub Actions for the CI are green. This is enforced by GitHub. 
- [ ] The PR has been peer-reviewed
  - [ ] The code has been manually inspected by someone who did not implement the feature
  - [ ] The changes have been inspected for possible breaking API changes (changed data models, endpoints, response codes, exception handling, ...). If there are any discuss them with the team.
  - [ ] If this PR includes work on the frontend, at least one `@ts-nocheck` is removed. Additionally, there should not be any `@ts-nocheck` in files modified by this PR. If no `@ts-nocheck` are left: Celebrate :tada: :confetti_ball: type-safety and remove this entry. 
- [ ] The PR actually implements what is described in the JIRA-Issue
- [ ] At least one test exists testing the new feature
  - [ ] Make sure all newly added functionality (especially user facing) is tested
  - [ ] Make sure that new test files are included in a test container and actually run in the CI
- [ ] At least 3 consecutive CI runs are successfully executed to ensure that there are no flaky tests.
- [ ] Documentation is updated as required. If unsure whether or what to update, ask a fellow developer.
- [ ] If there was a database entity class added, there must also be a migration script for creating the corresponding database if flyway is already used by the service
- [ ] IF there are changes done to the framework data models or to a database entity class, the following steps were completed in order
  - [ ] A fresh clone of dataland.com is generated (see Wiki page on "OTC" for details)
  - [ ] The feature branch is deployed to clone with `Reset non-user related Docker Volumes & Re-populate` turned off
  - [ ] It's verified that the CD run is green
  - [ ] The new feature is manually used/tested/observed on the clone server. Testing of the new feature should (also) be done by a second, independent reviewer from the dev team
  - [ ] The feature branch is deployed to one of the dev servers with `Reset non-user related Docker Volumes & Re-populate` turned on, and it's verified that the CD run is green
- [ ] ELSE, the new version is deployed to one of the dev servers using this branch
  - [ ] Run with setting `Reset non-user related Docker Volumes & Re-populate` turned on 
  - [ ] It's verified that this version actually is the one deployed (check gitinfo for branch name and commit id!)
  - [ ] It's verified that the CD run is green
  - [ ] The new feature is manually used/tested/observed on dev server. Testing of the new feature should (also) be done by a second, independent reviewer from the dev team
- [ ] Confirm that the latest version (use the /gitinfo endpoint) of the feature branch is deployed to one of the dev servers (no longer enforced by GitHub)
- [ ] Ensure that the release notes are written in a way that is understandable to a non-technical audience.
