### PR TITLE
Dala 6700 nonsourceability backend fix e2e tests

### DIFF
--- a/dataland-data-sourcing-service/src/main/kotlin/org/dataland/datasourcingservice/services/NonSourceabilityEventListener.kt
+++ b/dataland-data-sourcing-service/src/main/kotlin/org/dataland/datasourcingservice/services/NonSourceabilityEventListener.kt
@@ -90,53 +90,6 @@ class NonSourceabilityEventListener(
         }
     }
 
-    /**
-     * Handles a non-sourceability QA decision event from the QA service. Transitions the matching data
-     * sourcing object to [DataSourcingState.NonSourceable] if accepted, or to [DataSourcingState.DocumentSourcingDone]
-     * if rejected.
-     */
-    @RabbitListener(
-        bindings = [
-            QueueBinding(
-                value =
-                    Queue(
-                        QueueNames.DATA_SOURCING_SERVICE_NON_SOURCEABILITY_QA_DECISION,
-                        arguments = [
-                            Argument(name = "x-dead-letter-exchange", value = ExchangeName.DEAD_LETTER),
-                            Argument(name = "x-dead-letter-routing-key", value = "deadLetterKey"),
-                            Argument(name = "defaultRequeueRejected", value = "false"),
-                        ],
-                    ),
-                exchange = Exchange(ExchangeName.QA_SERVICE_NON_SOURCEABILITY_DECISIONS, declare = "false"),
-                key = [RoutingKeyNames.NON_SOURCEABILITY_QA_DECISION],
-            ),
-        ],
-    )
-    fun onNonSourceabilityQaDecision(
-        @Payload payload: String,
-        @Header(MessageHeaderKey.TYPE) messageType: String,
-        @Header(MessageHeaderKey.CORRELATION_ID) correlationId: String,
-    ) {
-        MessageQueueUtils.rejectMessageOnException {
-            if (messageType != MessageType.NON_SOURCEABILITY_QA_ACCEPTED &&
-                messageType != MessageType.NON_SOURCEABILITY_QA_REJECTED
-            ) {
-                throw MessageQueueRejectException(
-                    "Unexpected message type \"$messageType\" in non-sourceability QA decision listener",
-                )
-            }
-            val event = MessageQueueUtils.readMessagePayload<NonSourceabilityLifecycleEvent>(payload)
-            CorrelationLogging.withNonSourceabilityContext(correlationId, event.nonSourceabilityId) {
-                when (messageType) {
-                    MessageType.NON_SOURCEABILITY_QA_ACCEPTED ->
-                        transitionToNonSourceable(event, correlationId)
-                    MessageType.NON_SOURCEABILITY_QA_REJECTED ->
-                        transitionToDocumentSourcingDone(event, correlationId)
-                }
-            }
-        }
-    }
-
     @Transactional
     internal fun transitionToVerification(
         event: NonSourceabilityLifecycleEvent,
@@ -173,26 +126,6 @@ class NonSourceabilityEventListener(
         )
         logger.info(
             "Transitioned dataSourcingId=${sourcing.dataSourcingId} to NonSourceable " +
-                "(correlationId=$correlationId, nonSourceabilityId=${event.nonSourceabilityId})",
-        )
-    }
-
-    @Transactional
-    internal fun transitionToDocumentSourcingDone(
-        event: NonSourceabilityLifecycleEvent,
-        correlationId: String,
-    ) {
-        val sourcing = findSourcingForEvent(event, correlationId) ?: return
-        if (sourcing.state == DataSourcingState.DocumentSourcingDone) {
-            logger.info("Idempotent skip: already in DocumentSourcingDone for nonSourceabilityId=${event.nonSourceabilityId}")
-            return
-        }
-        dataSourcingManager.patchDataSourcingEntityById(
-            UUID.fromString(sourcing.dataSourcingId),
-            DataSourcingPatch(state = DataSourcingState.DocumentSourcingDone),
-        )
-        logger.info(
-            "Transitioned dataSourcingId=${sourcing.dataSourcingId} to DocumentSourcingDone " +
                 "(correlationId=$correlationId, nonSourceabilityId=${event.nonSourceabilityId})",
         )
     }

--- a/dataland-data-sourcing-service/src/main/kotlin/org/dataland/datasourcingservice/services/NonSourceabilityQaDecisionListener.kt
+++ b/dataland-data-sourcing-service/src/main/kotlin/org/dataland/datasourcingservice/services/NonSourceabilityQaDecisionListener.kt
@@ -89,7 +89,7 @@ class NonSourceabilityQaDecisionListener(
             MessageType.NON_SOURCEABILITY_QA_ACCEPTED ->
                 transitionToNonSourceable(event, correlationId)
             MessageType.NON_SOURCEABILITY_QA_REJECTED ->
-                keepInVerification(event, correlationId)
+                transitionToDocumentSourcingDone(event, correlationId)
             else -> {
                 logger.error(
                     "Unexpected message type $messageType in NonSourceabilityQaDecisionListener " +
@@ -119,22 +119,22 @@ class NonSourceabilityQaDecisionListener(
         )
     }
 
-    private fun keepInVerification(
+    @Transactional
+    internal fun transitionToDocumentSourcingDone(
         event: NonSourceabilityLifecycleEvent,
         correlationId: String,
     ) {
-        val sourcing = findSourcingForEvent(event, correlationId)
-        if (sourcing == null) return
-        if (sourcing.state != DataSourcingState.NonSourceableVerification) {
-            logger.warn(
-                "QA rejected for nonSourceabilityId=${event.nonSourceabilityId} but data sourcing is in " +
-                    "state ${sourcing.state} instead of NonSourceableVerification. No transition performed " +
-                    "(correlationId=$correlationId).",
-            )
+        val sourcing = findSourcingForEvent(event, correlationId) ?: return
+        if (sourcing.state == DataSourcingState.DocumentSourcingDone) {
+            logger.info("Idempotent skip: already in DocumentSourcingDone for nonSourceabilityId=${event.nonSourceabilityId}")
             return
         }
+        dataSourcingManager.patchDataSourcingEntityById(
+            UUID.fromString(sourcing.dataSourcingId),
+            DataSourcingPatch(state = DataSourcingState.DocumentSourcingDone),
+        )
         logger.info(
-            "QA rejected: dataSourcingId=${sourcing.dataSourcingId} stays in NonSourceableVerification " +
+            "Transitioned dataSourcingId=${sourcing.dataSourcingId} to DocumentSourcingDone " +
                 "(correlationId=$correlationId, nonSourceabilityId=${event.nonSourceabilityId})",
         )
     }

--- a/dataland-data-sourcing-service/src/test/kotlin/org/dataland/datasourcingservice/serviceTests/NonSourceabilityQaAcceptedConsumerTest.kt
+++ b/dataland-data-sourcing-service/src/test/kotlin/org/dataland/datasourcingservice/serviceTests/NonSourceabilityQaAcceptedConsumerTest.kt
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.argThat
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
@@ -71,14 +72,15 @@ class NonSourceabilityQaAcceptedConsumerTest {
     }
 
     @Test
-    fun `rejected event keeps sourcing in NonSourceableVerification no patch performed`() {
+    fun `rejected event transitions sourcing to DocumentSourcingDone`() {
         val stored = stubSourcing(DataSourcingState.NonSourceableVerification)
         whenever(queryManager.searchDataSourcings(anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), any(), any()))
             .thenReturn(listOf(stored))
+        whenever(sourcingManager.patchDataSourcingEntityById(any(), any())).thenReturn(stored)
 
         listener.processQaDecisionEvent(buildEvent(), MessageType.NON_SOURCEABILITY_QA_REJECTED, "corr-3")
 
-        verify(sourcingManager, never()).patchDataSourcingEntityById(any(), any())
+        verify(sourcingManager).patchDataSourcingEntityById(any(), argThat { state == DataSourcingState.DocumentSourcingDone })
     }
 
     @Test

--- a/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/tests/NonSourceabilityTest.kt
+++ b/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/tests/NonSourceabilityTest.kt
@@ -166,17 +166,19 @@ class NonSourceabilityTest {
     }
 
     private fun assertBackendEntryIsPending(ctx: Ctx) {
-        val entries =
-            asAdmin {
-                apiAccessor.metaDataControllerApi.getInfoOnNonSourceabilityOfDatasets(
-                    companyId = ctx.companyId,
-                    dataType = ctx.dataType,
-                    reportingPeriod = ctx.reportingPeriod,
-                )
-            }
-        assertEquals(1, entries.size, "Expected exactly one entry for the posted triple")
-        assertEquals(BackendQaStatus.Pending, entries.first().qaStatus)
-        assertFalse(entries.first().currentlyActive)
+        awaitUntilAsserted {
+            val entries =
+                asAdmin {
+                    apiAccessor.metaDataControllerApi.getInfoOnNonSourceabilityOfDatasets(
+                        companyId = ctx.companyId,
+                        dataType = ctx.dataType,
+                        reportingPeriod = ctx.reportingPeriod,
+                    )
+                }
+            assertEquals(1, entries.size, "Expected exactly one entry for the posted triple")
+            assertEquals(BackendQaStatus.Pending, entries.first().qaStatus)
+            assertFalse(entries.first().currentlyActive)
+        }
     }
 
     private fun assertQaReviewRowAppears(ctx: Ctx) {
@@ -215,19 +217,21 @@ class NonSourceabilityTest {
     }
 
     private fun assertQaReviewIsAccepted(ctx: Ctx) {
-        val qaReviews =
-            asAdmin {
-                apiAccessor.nonSourceabilityQaControllerApi.getNonSourceableReviews(
-                    companyId = ctx.companyId,
-                    dataType = ctx.dataType.value,
-                    reportingPeriod = ctx.reportingPeriod,
-                )
-            }
-        assertEquals(
-            QaServiceQaStatus.Accepted,
-            qaReviews.first().qaStatus,
-            "QA service must persist Accepted status after decision",
-        )
+        awaitUntilAsserted {
+            val qaReviews =
+                asAdmin {
+                    apiAccessor.nonSourceabilityQaControllerApi.getNonSourceableReviews(
+                        companyId = ctx.companyId,
+                        dataType = ctx.dataType.value,
+                        reportingPeriod = ctx.reportingPeriod,
+                    )
+                }
+            assertEquals(
+                QaServiceQaStatus.Accepted,
+                qaReviews.first().qaStatus,
+                "QA service must persist Accepted status after decision",
+            )
+        }
     }
 
     private fun assertBackendEntryIsAcceptedAndActive(ctx: Ctx) {
@@ -294,19 +298,21 @@ class NonSourceabilityTest {
     }
 
     private fun assertQaReviewIsRejected(ctx: Ctx) {
-        val qaReviews =
-            asAdmin {
-                apiAccessor.nonSourceabilityQaControllerApi.getNonSourceableReviews(
-                    companyId = ctx.companyId,
-                    dataType = ctx.dataType.value,
-                    reportingPeriod = ctx.reportingPeriod,
-                )
-            }
-        assertEquals(
-            QaServiceQaStatus.Rejected,
-            qaReviews.first().qaStatus,
-            "QA service must persist Rejected status after decision",
-        )
+        awaitUntilAsserted {
+            val qaReviews =
+                asAdmin {
+                    apiAccessor.nonSourceabilityQaControllerApi.getNonSourceableReviews(
+                        companyId = ctx.companyId,
+                        dataType = ctx.dataType.value,
+                        reportingPeriod = ctx.reportingPeriod,
+                    )
+                }
+            assertEquals(
+                QaServiceQaStatus.Rejected,
+                qaReviews.first().qaStatus,
+                "QA service must persist Rejected status after decision",
+            )
+        }
     }
 
     private fun assertBackendEntryIsRejectedAndInactive(ctx: Ctx) {


### PR DESCRIPTION
# Pull Request \<Title>
`<Description here>`
## Things to do during Peer Review
Please check all boxes before the Pull Request is merged. In case you skip a box, describe in the PRs description (that means: here) why the check is skipped.
- [x] The GitHub Actions for the CI are green. This is enforced by GitHub. 
- [ ] The PR has been peer-reviewed
  - [ ] The code has been manually inspected by someone who did not implement the feature
  - [ ] The changes have been inspected for possible breaking API changes (changed data models, endpoints, response codes, exception handling, ...). If there are any discuss them with the team.
  - [ ] If this PR includes work on the frontend, at least one `@ts-nocheck` is removed. Additionally, there should not be any `@ts-nocheck` in files modified by this PR. If no `@ts-nocheck` are left: Celebrate :tada: :confetti_ball: type-safety and remove this entry. 
- [ ] The PR actually implements what is described in the JIRA-Issue
- [ ] At least one test exists testing the new feature
  - [ ] Make sure all newly added functionality (especially user facing) is tested
  - [ ] Make sure that new test files are included in a test container and actually run in the CI
- [ ] At least 3 consecutive CI runs are successfully executed to ensure that there are no flaky tests.
- [ ] Documentation is updated as required. If unsure whether or what to update, ask a fellow developer.
- [ ] If there was a database entity class added, there must also be a migration script for creating the corresponding database if flyway is already used by the service
- [ ] IF there are changes done to the framework data models or to a database entity class, the following steps were completed in order
  - [ ] A fresh clone of dataland.com is generated (see Wiki page on "OTC" for details)
  - [ ] The feature branch is deployed to clone with `Reset non-user related Docker Volumes & Re-populate` turned off
  - [ ] It's verified that the CD run is green
  - [ ] The new feature is manually used/tested/observed on the clone server. Testing of the new feature should (also) be done by a second, independent reviewer from the dev team
  - [ ] The feature branch is deployed to one of the dev servers with `Reset non-user related Docker Volumes & Re-populate` turned on, and it's verified that the CD run is green
- [ ] ELSE, the new version is deployed to one of the dev servers using this branch
  - [ ] Run with setting `Reset non-user related Docker Volumes & Re-populate` turned on 
  - [ ] It's verified that this version actually is the one deployed (check gitinfo for branch name and commit id!)
  - [ ] It's verified that the CD run is green
  - [ ] The new feature is manually used/tested/observed on dev server. Testing of the new feature should (also) be done by a second, independent reviewer from the dev team
- [ ] Confirm that the latest version (use the /gitinfo endpoint) of the feature branch is deployed to one of the dev servers (no longer enforced by GitHub)
- [ ] Ensure that the release notes are written in a way that is understandable to a non-technical audience.
