### PR TITLE
reworked transactional logic

### DIFF
--- a/dataland-backend/src/main/kotlin/org/dataland/datalandbackend/services/NonSourceabilityInformationManager.kt
+++ b/dataland-backend/src/main/kotlin/org/dataland/datalandbackend/services/NonSourceabilityInformationManager.kt
@@ -17,22 +17,11 @@ import org.dataland.datalandmessagequeueutils.model.NonSourceabilityLifecycleEve
 import org.dataland.keycloakAdapter.auth.DatalandAuthentication
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import org.springframework.transaction.event.TransactionPhase
-import org.springframework.transaction.event.TransactionalEventListener
+import org.springframework.transaction.support.TransactionSynchronization
+import org.springframework.transaction.support.TransactionSynchronizationManager
 import java.time.Instant
-
-/**
- * Internal Spring application event published inside a transaction to trigger RabbitMQ message
- * sending only after the transaction commits successfully.
- */
-data class NonSourceabilityLifecycleApplicationEvent(
-    val entity: NonSourceabilityInformationEntity,
-    val bypassQa: Boolean,
-    val correlationId: String,
-)
 
 /**
  * Manages the canonical non-sourceability lifecycle in the backend.
@@ -43,7 +32,6 @@ class NonSourceabilityInformationManager(
     @Autowired private val companyQueryManager: CompanyQueryManager,
     @Autowired private val cloudEventMessageHandler: CloudEventMessageHandler,
     @Autowired private val objectMapper: ObjectMapper,
-    @Autowired private val applicationEventPublisher: ApplicationEventPublisher,
 ) {
     private val logger = LoggerFactory.getLogger(javaClass)
 
@@ -203,7 +191,13 @@ class NonSourceabilityInformationManager(
         val nonSourceabilityId = saved.nonSourceabilityId.toString()
         val correlationId = nonSourceabilityId
 
-        applicationEventPublisher.publishEvent(NonSourceabilityLifecycleApplicationEvent(saved, request.bypassQa, correlationId))
+        TransactionSynchronizationManager.registerSynchronization(
+            object : TransactionSynchronization {
+                override fun afterCommit() {
+                    emitLifecycleEvent(saved, request.bypassQa, correlationId)
+                }
+            },
+        )
         logger.info(
             "NonSourceabilityInformation persisted with id=$nonSourceabilityId, " +
                 "bypassQa=${request.bypassQa}, qaStatus=$qaStatus (correlationId=$correlationId)",
@@ -257,15 +251,6 @@ class NonSourceabilityInformationManager(
                     "companyId=$companyId, dataType=$dataType, reportingPeriod=$reportingPeriod",
             )
         }
-    }
-
-    /**
-     * Sends the RabbitMQ lifecycle event after the enclosing transaction commits successfully,
-     * preventing phantom messages if the DB commit fails.
-     */
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    fun onNonSourceabilityLifecycleEvent(event: NonSourceabilityLifecycleApplicationEvent) {
-        emitLifecycleEvent(event.entity, event.bypassQa, event.correlationId)
     }
 
     private fun emitLifecycleEvent(

--- a/dataland-backend/src/main/kotlin/org/dataland/datalandbackend/services/NonSourceabilityInformationManager.kt
+++ b/dataland-backend/src/main/kotlin/org/dataland/datalandbackend/services/NonSourceabilityInformationManager.kt
@@ -17,9 +17,22 @@ import org.dataland.datalandmessagequeueutils.model.NonSourceabilityLifecycleEve
 import org.dataland.keycloakAdapter.auth.DatalandAuthentication
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
 import java.time.Instant
+
+/**
+ * Internal Spring application event published inside a transaction to trigger RabbitMQ message
+ * sending only after the transaction commits successfully.
+ */
+data class NonSourceabilityLifecycleApplicationEvent(
+    val entity: NonSourceabilityInformationEntity,
+    val bypassQa: Boolean,
+    val correlationId: String,
+)
 
 /**
  * Manages the canonical non-sourceability lifecycle in the backend.
@@ -30,6 +43,7 @@ class NonSourceabilityInformationManager(
     @Autowired private val companyQueryManager: CompanyQueryManager,
     @Autowired private val cloudEventMessageHandler: CloudEventMessageHandler,
     @Autowired private val objectMapper: ObjectMapper,
+    @Autowired private val applicationEventPublisher: ApplicationEventPublisher,
 ) {
     private val logger = LoggerFactory.getLogger(javaClass)
 
@@ -42,7 +56,6 @@ class NonSourceabilityInformationManager(
      * - (true,  true)  → admin bypass: creates Accepted+active entry, emits AUTO_ACCEPTED event
      * - (true,  false) → admin reversal: deactivates active entry, creates audit entry, no event
      */
-    @Transactional
     sealed class ProcessNonSourceabilityResult {
         /**
          * Represents a successful non-sourceability request result.
@@ -64,6 +77,7 @@ class NonSourceabilityInformationManager(
      * Processes a non-sourceability submission request. Validates uniqueness, persists the entry,
      * and emits the appropriate lifecycle event.
      */
+    @Transactional
     fun processNonSourceabilityRequest(request: NonSourceabilityRequest): ProcessNonSourceabilityResult {
         companyQueryManager.assertCompanyIdExists(request.companyId)
 
@@ -189,7 +203,7 @@ class NonSourceabilityInformationManager(
         val nonSourceabilityId = saved.nonSourceabilityId.toString()
         val correlationId = nonSourceabilityId
 
-        emitLifecycleEvent(saved, request.bypassQa, correlationId)
+        applicationEventPublisher.publishEvent(NonSourceabilityLifecycleApplicationEvent(saved, request.bypassQa, correlationId))
         logger.info(
             "NonSourceabilityInformation persisted with id=$nonSourceabilityId, " +
                 "bypassQa=${request.bypassQa}, qaStatus=$qaStatus (correlationId=$correlationId)",
@@ -243,6 +257,15 @@ class NonSourceabilityInformationManager(
                     "companyId=$companyId, dataType=$dataType, reportingPeriod=$reportingPeriod",
             )
         }
+    }
+
+    /**
+     * Sends the RabbitMQ lifecycle event after the enclosing transaction commits successfully,
+     * preventing phantom messages if the DB commit fails.
+     */
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun onNonSourceabilityLifecycleEvent(event: NonSourceabilityLifecycleApplicationEvent) {
+        emitLifecycleEvent(event.entity, event.bypassQa, event.correlationId)
     }
 
     private fun emitLifecycleEvent(

--- a/dataland-qa-service/src/main/kotlin/org/dataland/datalandqaservice/services/NonSourceabilityQaReviewManager.kt
+++ b/dataland-qa-service/src/main/kotlin/org/dataland/datalandqaservice/services/NonSourceabilityQaReviewManager.kt
@@ -15,6 +15,8 @@ import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.support.TransactionSynchronization
+import org.springframework.transaction.support.TransactionSynchronizationManager
 
 /**
  * Manages QA review decisions for non-sourceability entries.
@@ -82,7 +84,17 @@ class NonSourceabilityQaReviewManager
                 "QA decision must be Accepted or Rejected, got $qaStatus"
             }
             val entity = updateReviewEntity(nonSourceabilityId, qaStatus, qaComment, reviewerUserId)
-            sendQaDecisionEvent(entity, qaStatus, correlationId, nonSourceabilityId)
+            if (TransactionSynchronizationManager.isSynchronizationActive()) {
+                TransactionSynchronizationManager.registerSynchronization(
+                    object : TransactionSynchronization {
+                        override fun afterCommit() {
+                            sendQaDecisionEvent(entity, qaStatus, correlationId, nonSourceabilityId)
+                        }
+                    },
+                )
+            } else {
+                sendQaDecisionEvent(entity, qaStatus, correlationId, nonSourceabilityId)
+            }
             return entity.toResponse()
         }
 


### PR DESCRIPTION
# Pull Request \<Title>
`<Description here>`
## Things to do during Peer Review
Please check all boxes before the Pull Request is merged. In case you skip a box, describe in the PRs description (that means: here) why the check is skipped.
- [x] The GitHub Actions for the CI are green. This is enforced by GitHub. 
- [ ] The PR has been peer-reviewed
  - [ ] The code has been manually inspected by someone who did not implement the feature
  - [ ] The changes have been inspected for possible breaking API changes (changed data models, endpoints, response codes, exception handling, ...). If there are any discuss them with the team.
  - [ ] If this PR includes work on the frontend, at least one `@ts-nocheck` is removed. Additionally, there should not be any `@ts-nocheck` in files modified by this PR. If no `@ts-nocheck` are left: Celebrate :tada: :confetti_ball: type-safety and remove this entry. 
- [ ] The PR actually implements what is described in the JIRA-Issue
- [ ] At least one test exists testing the new feature
  - [ ] Make sure all newly added functionality (especially user facing) is tested
  - [ ] Make sure that new test files are included in a test container and actually run in the CI
- [ ] At least 3 consecutive CI runs are successfully executed to ensure that there are no flaky tests.
- [ ] Documentation is updated as required. If unsure whether or what to update, ask a fellow developer.
- [ ] If there was a database entity class added, there must also be a migration script for creating the corresponding database if flyway is already used by the service
- [ ] IF there are changes done to the framework data models or to a database entity class, the following steps were completed in order
  - [ ] A fresh clone of dataland.com is generated (see Wiki page on "OTC" for details)
  - [ ] The feature branch is deployed to clone with `Reset non-user related Docker Volumes & Re-populate` turned off
  - [ ] It's verified that the CD run is green
  - [ ] The new feature is manually used/tested/observed on the clone server. Testing of the new feature should (also) be done by a second, independent reviewer from the dev team
  - [ ] The feature branch is deployed to one of the dev servers with `Reset non-user related Docker Volumes & Re-populate` turned on, and it's verified that the CD run is green
- [ ] ELSE, the new version is deployed to one of the dev servers using this branch
  - [ ] Run with setting `Reset non-user related Docker Volumes & Re-populate` turned on 
  - [ ] It's verified that this version actually is the one deployed (check gitinfo for branch name and commit id!)
  - [ ] It's verified that the CD run is green
  - [ ] The new feature is manually used/tested/observed on dev server. Testing of the new feature should (also) be done by a second, independent reviewer from the dev team
- [ ] Confirm that the latest version (use the /gitinfo endpoint) of the feature branch is deployed to one of the dev servers (no longer enforced by GitHub)
- [ ] Ensure that the release notes are written in a way that is understandable to a non-technical audience.
