### PR TITLE
Dala 6700 nonsourceability backend review backend changes 2

### DIFF
--- a/dataland-backend/src/main/kotlin/org/dataland/datalandbackend/repositories/NonSourceabilityDataRepository.kt
+++ b/dataland-backend/src/main/kotlin/org/dataland/datalandbackend/repositories/NonSourceabilityDataRepository.kt
@@ -47,14 +47,14 @@ interface NonSourceabilityDataRepository : JpaRepository<NonSourceabilityInforma
         WHERE e.companyId = :companyId
           AND e.dataType = :dataType
           AND e.reportingPeriod = :reportingPeriod
-          AND e.qaStatus IN :blockedStatuses
+          AND e.qaStatus IN :statuses
         """,
     )
-    fun existsActiveOrPendingForTuple(
+    fun existsWithGivenStatuses(
         @Param("companyId") companyId: String,
         @Param("dataType") dataType: DataType,
         @Param("reportingPeriod") reportingPeriod: String,
-        @Param("blockedStatuses") blockedStatuses: List<QaStatus>,
+        @Param("statuses") statuses: List<QaStatus>,
     ): Boolean
 
     /**

--- a/dataland-backend/src/main/kotlin/org/dataland/datalandbackend/services/NonSourceabilityInformationManager.kt
+++ b/dataland-backend/src/main/kotlin/org/dataland/datalandbackend/services/NonSourceabilityInformationManager.kt
@@ -79,7 +79,7 @@ class NonSourceabilityInformationManager(
         }
 
         val hasPendingEntry =
-            nonSourceabilityDataRepository.existsActiveOrPendingForTuple(
+            nonSourceabilityDataRepository.existsWithGivenStatuses(
                 request.companyId,
                 request.dataType,
                 request.reportingPeriod,

--- a/dataland-data-sourcing-service/src/main/kotlin/org/dataland/datasourcingservice/services/DataSourcingManager.kt
+++ b/dataland-data-sourcing-service/src/main/kotlin/org/dataland/datasourcingservice/services/DataSourcingManager.kt
@@ -174,10 +174,10 @@ class DataSourcingManager
             )
             cloudEventMessageHandler.buildCEMessageAndSendToQueue(
                 JsonUtils.defaultObjectMapper.writeValueAsString(messageBody),
-                MessageType.LEGACY_DATA_SOURCING_NON_SOURCEABLE,
+                MessageType.DATA_SOURCING_NON_SOURCEABLE,
                 correlationId,
                 ExchangeName.DATASOURCING_DATA_NONSOURCEABLE,
-                RoutingKeyNames.LEGACY_DATA_SOURCING_NON_SOURCEABLE,
+                RoutingKeyNames.DATA_SOURCING_NON_SOURCEABLE,
             )
         }
 

--- a/dataland-data-sourcing-service/src/test/kotlin/org/dataland/datasourcingservice/unitTests/ExistingRequestsManagerTest.kt
+++ b/dataland-data-sourcing-service/src/test/kotlin/org/dataland/datasourcingservice/unitTests/ExistingRequestsManagerTest.kt
@@ -182,10 +182,10 @@ class ExistingRequestsManagerTest {
                 times(1),
             ).buildCEMessageAndSendToQueue(
                 any(),
-                eq(MessageType.LEGACY_DATA_SOURCING_NON_SOURCEABLE),
+                eq(MessageType.DATA_SOURCING_NON_SOURCEABLE),
                 any(),
                 eq(ExchangeName.DATASOURCING_DATA_NONSOURCEABLE),
-                eq(RoutingKeyNames.LEGACY_DATA_SOURCING_NON_SOURCEABLE),
+                eq(RoutingKeyNames.DATA_SOURCING_NON_SOURCEABLE),
             )
         } else {
             verifyNoInteractions(mockCloudEventMessageHandler)

--- a/dataland-message-queue-utils/src/main/kotlin/org/dataland/datalandmessagequeueutils/constants/MessageType.kt
+++ b/dataland-message-queue-utils/src/main/kotlin/org/dataland/datalandmessagequeueutils/constants/MessageType.kt
@@ -16,7 +16,7 @@ object MessageType {
     const val PRIVATE_DATA_STORED = "Private Data Stored"
     const val PRIVATE_DATA_RECEIVED = "Private Data received"
     const val QA_STATUS_UPDATED = "QA status updated"
-    const val LEGACY_DATA_SOURCING_NON_SOURCEABLE = "DataSourcing non-sourceable" // This is for user notifications, maybe change process
+    const val DATA_SOURCING_NON_SOURCEABLE = "DataSourcing non-sourceable" // This is for user notifications, maybe change process
     const val NON_SOURCEABILITY_CREATED = "NonSourceability created"
     const val NON_SOURCEABILITY_AUTO_ACCEPTED = "NonSourceability auto-accepted"
     const val NON_SOURCEABILITY_QA_ACCEPTED = "NonSourceability QA accepted"

--- a/dataland-message-queue-utils/src/main/kotlin/org/dataland/datalandmessagequeueutils/constants/RoutingKeyNames.kt
+++ b/dataland-message-queue-utils/src/main/kotlin/org/dataland/datalandmessagequeueutils/constants/RoutingKeyNames.kt
@@ -18,7 +18,7 @@ object RoutingKeyNames {
     const val DATASET_QA = "dataset.qa"
     const val DATASET_DELETION = "dataset.deletion"
     const val DATASET_STORED_TO_ASSEMBLED_MIGRATION = "dataset.storedDatasetMigratedToAssembledDataset"
-    const val LEGACY_DATA_SOURCING_NON_SOURCEABLE = "dataSourcingNonSourceable"
+    const val DATA_SOURCING_NON_SOURCEABLE = "dataSourcingNonSourceable"
     const val NON_SOURCEABILITY_SUBMISSION = "nonSourceabilitySubmission"
     const val NON_SOURCEABILITY_QA_DECISION = "nonSourceabilityQaDecision"
     const val PORTFOLIO_UPDATE = "portfolio.update"

--- a/dataland-user-service/src/main/kotlin/org/dataland/datalanduserservice/service/NotificationEventListener.kt
+++ b/dataland-user-service/src/main/kotlin/org/dataland/datalanduserservice/service/NotificationEventListener.kt
@@ -55,7 +55,7 @@ class NotificationEventListener(
                         ],
                     ),
                 exchange = Exchange(ExchangeName.DATASOURCING_DATA_NONSOURCEABLE, declare = "false"),
-                key = [RoutingKeyNames.LEGACY_DATA_SOURCING_NON_SOURCEABLE],
+                key = [RoutingKeyNames.DATA_SOURCING_NON_SOURCEABLE],
             ),
         ],
     )
@@ -64,7 +64,7 @@ class NotificationEventListener(
         @Header(MessageHeaderKey.TYPE) type: String,
         @Header(MessageHeaderKey.CORRELATION_ID) correlationId: String,
     ) {
-        MessageQueueUtils.validateMessageType(type, MessageType.LEGACY_DATA_SOURCING_NON_SOURCEABLE)
+        MessageQueueUtils.validateMessageType(type, MessageType.DATA_SOURCING_NON_SOURCEABLE)
         val sourceabilityMessage = MessageQueueUtils.readMessagePayload<SourceabilityMessage>(payload)
         checkThatDatasetWasSetToNonSourceable(sourceabilityMessage)
 

--- a/dataland-user-service/src/test/kotlin/org/dataland/datalanduserservice/service/NotificationEventListenerTest.kt
+++ b/dataland-user-service/src/test/kotlin/org/dataland/datalanduserservice/service/NotificationEventListenerTest.kt
@@ -45,7 +45,7 @@ class NotificationEventListenerTest {
 
         notificationEventListener.processMessageForDataReportedAsNonSourceable(
             JsonUtils.defaultObjectMapper.writeValueAsString(payload),
-            MessageType.LEGACY_DATA_SOURCING_NON_SOURCEABLE,
+            MessageType.DATA_SOURCING_NON_SOURCEABLE,
             UUID.randomUUID().toString(),
         )
 


### PR DESCRIPTION
# Pull Request \<Title>
`<Description here>`
## Things to do during Peer Review
Please check all boxes before the Pull Request is merged. In case you skip a box, describe in the PRs description (that means: here) why the check is skipped.
- [x] The GitHub Actions for the CI are green. This is enforced by GitHub. 
- [ ] The PR has been peer-reviewed
  - [ ] The code has been manually inspected by someone who did not implement the feature
  - [ ] The changes have been inspected for possible breaking API changes (changed data models, endpoints, response codes, exception handling, ...). If there are any discuss them with the team.
  - [ ] If this PR includes work on the frontend, at least one `@ts-nocheck` is removed. Additionally, there should not be any `@ts-nocheck` in files modified by this PR. If no `@ts-nocheck` are left: Celebrate :tada: :confetti_ball: type-safety and remove this entry. 
- [ ] The PR actually implements what is described in the JIRA-Issue
- [ ] At least one test exists testing the new feature
  - [ ] Make sure all newly added functionality (especially user facing) is tested
  - [ ] Make sure that new test files are included in a test container and actually run in the CI
- [ ] At least 3 consecutive CI runs are successfully executed to ensure that there are no flaky tests.
- [ ] Documentation is updated as required. If unsure whether or what to update, ask a fellow developer.
- [ ] If there was a database entity class added, there must also be a migration script for creating the corresponding database if flyway is already used by the service
- [ ] IF there are changes done to the framework data models or to a database entity class, the following steps were completed in order
  - [ ] A fresh clone of dataland.com is generated (see Wiki page on "OTC" for details)
  - [ ] The feature branch is deployed to clone with `Reset non-user related Docker Volumes & Re-populate` turned off
  - [ ] It's verified that the CD run is green
  - [ ] The new feature is manually used/tested/observed on the clone server. Testing of the new feature should (also) be done by a second, independent reviewer from the dev team
  - [ ] The feature branch is deployed to one of the dev servers with `Reset non-user related Docker Volumes & Re-populate` turned on, and it's verified that the CD run is green
- [ ] ELSE, the new version is deployed to one of the dev servers using this branch
  - [ ] Run with setting `Reset non-user related Docker Volumes & Re-populate` turned on 
  - [ ] It's verified that this version actually is the one deployed (check gitinfo for branch name and commit id!)
  - [ ] It's verified that the CD run is green
  - [ ] The new feature is manually used/tested/observed on dev server. Testing of the new feature should (also) be done by a second, independent reviewer from the dev team
- [ ] Confirm that the latest version (use the /gitinfo endpoint) of the feature branch is deployed to one of the dev servers (no longer enforced by GitHub)
- [ ] Ensure that the release notes are written in a way that is understandable to a non-technical audience.
