### PR TITLE
Dala 6700 nonsourceability backend remove correlationId

### DIFF
--- a/dataland-backend/src/main/kotlin/org/dataland/datalandbackend/services/NonSourceabilityInformationManager.kt
+++ b/dataland-backend/src/main/kotlin/org/dataland/datalandbackend/services/NonSourceabilityInformationManager.kt
@@ -181,18 +181,17 @@ class NonSourceabilityInformationManager(
 
         val saved = nonSourceabilityDataRepository.save(entity)
         val nonSourceabilityId = saved.nonSourceabilityId.toString()
-        val correlationId = nonSourceabilityId
 
         TransactionSynchronizationManager.registerSynchronization(
             object : TransactionSynchronization {
                 override fun afterCommit() {
-                    emitLifecycleEvent(saved, request.bypassQa, correlationId)
+                    emitLifecycleEvent(saved, request.bypassQa)
                 }
             },
         )
         logger.info(
             "NonSourceabilityInformation persisted with id=$nonSourceabilityId, " +
-                "bypassQa=${request.bypassQa}, qaStatus=$qaStatus (correlationId=$correlationId)",
+                "bypassQa=${request.bypassQa}, qaStatus=$qaStatus",
         )
         return ProcessNonSourceabilityResult.Success(saved.toResponse())
     }
@@ -248,7 +247,6 @@ class NonSourceabilityInformationManager(
     private fun emitLifecycleEvent(
         entity: NonSourceabilityInformationEntity,
         bypassQa: Boolean,
-        correlationId: String,
     ) {
         val event =
             NonSourceabilityLifecycleEvent(
@@ -262,7 +260,7 @@ class NonSourceabilityInformationManager(
         cloudEventMessageHandler.buildCEMessageAndSendToQueue(
             body = objectMapper.writeValueAsString(event),
             type = if (bypassQa) MessageType.NON_SOURCEABILITY_AUTO_ACCEPTED else MessageType.NON_SOURCEABILITY_CREATED,
-            correlationId = correlationId,
+            correlationId = event.nonSourceabilityId,
             exchange = ExchangeName.BACKEND_DATA_NONSOURCEABLE,
             routingKey = RoutingKeyNames.NON_SOURCEABILITY_SUBMISSION,
         )

--- a/dataland-backend/src/main/kotlin/org/dataland/datalandbackend/services/NonSourceabilityQaDecisionListener.kt
+++ b/dataland-backend/src/main/kotlin/org/dataland/datalandbackend/services/NonSourceabilityQaDecisionListener.kt
@@ -61,7 +61,6 @@ class NonSourceabilityQaDecisionListener(
     fun onNonSourceabilityQaDecision(
         @Payload payload: String,
         @Header(MessageHeaderKey.TYPE) messageType: String,
-        @Header(MessageHeaderKey.CORRELATION_ID) correlationId: String,
     ) {
         MessageQueueUtils.rejectMessageOnException {
             if (messageType != MessageType.NON_SOURCEABILITY_QA_ACCEPTED &&
@@ -72,7 +71,7 @@ class NonSourceabilityQaDecisionListener(
                 )
             }
             val event = MessageQueueUtils.readMessagePayload<NonSourceabilityLifecycleEvent>(payload)
-            processQaDecisionEvent(event, messageType, correlationId)
+            processQaDecisionEvent(event, messageType)
         }
     }
 
@@ -84,14 +83,12 @@ class NonSourceabilityQaDecisionListener(
     internal fun processQaDecisionEvent(
         event: NonSourceabilityLifecycleEvent,
         messageType: String,
-        correlationId: String,
     ) {
-        val nonSourceabilityId = parseAndValidateId(event.nonSourceabilityId, correlationId)
+        val nonSourceabilityId = parseAndValidateId(event.nonSourceabilityId)
         val entity =
             nonSourceabilityDataRepository.findById(nonSourceabilityId).orElseThrow {
                 logger.error(
-                    "Received QA decision event for unknown nonSourceabilityId=${event.nonSourceabilityId} " +
-                        "(correlationId=$correlationId). Discarding.",
+                    "Received QA decision event for unknown nonSourceabilityId=${event.nonSourceabilityId}.Discarding.",
                 )
                 MessageQueueRejectException(
                     "Unknown nonSourceabilityId=${event.nonSourceabilityId} in QA decision event",
@@ -103,8 +100,7 @@ class NonSourceabilityQaDecisionListener(
                 entity.qaStatus = QaStatus.Accepted
                 entity.currentlyActive = true
                 logger.info(
-                    "Set qaStatus=Accepted and currentlyActive=true for " +
-                        "nonSourceabilityId=${entity.nonSourceabilityId} (correlationId=$correlationId)",
+                    "Set qaStatus=Accepted and currentlyActive=true for nonSourceabilityId=${entity.nonSourceabilityId}",
                 )
             }
 
@@ -112,15 +108,13 @@ class NonSourceabilityQaDecisionListener(
                 entity.qaStatus = QaStatus.Rejected
                 entity.currentlyActive = false
                 logger.info(
-                    "Set qaStatus=Rejected and currentlyActive=false for " +
-                        "nonSourceabilityId=${entity.nonSourceabilityId} (correlationId=$correlationId)",
+                    "Set qaStatus=Rejected and currentlyActive=false for nonSourceabilityId=${entity.nonSourceabilityId}",
                 )
             }
 
             else -> {
                 logger.error(
-                    "Unexpected message type $messageType received in NonSourceabilityQaDecisionListener " +
-                        "(correlationId=$correlationId). Discarding.",
+                    "Unexpected message type $messageType received in NonSourceabilityQaDecisionListener. Discarding.",
                 )
                 throw MessageQueueRejectException("Unexpected message type $messageType in QA decision listener")
             }
@@ -128,16 +122,12 @@ class NonSourceabilityQaDecisionListener(
         nonSourceabilityDataRepository.save(entity)
     }
 
-    private fun parseAndValidateId(
-        rawId: String,
-        correlationId: String,
-    ): UUID {
+    private fun parseAndValidateId(rawId: String): UUID {
         try {
             return UUID.fromString(rawId)
         } catch (e: IllegalArgumentException) {
             logger.error(
-                "Malformed nonSourceabilityId='$rawId' received in QA decision event " +
-                    "(correlationId=$correlationId). Discarding.",
+                "Malformed nonSourceabilityId='$rawId' received in QA decision event. Discarding.",
                 e,
             )
             throw MessageQueueRejectException("Malformed nonSourceabilityId='$rawId'", e)

--- a/dataland-backend/src/test/kotlin/org/dataland/datalandbackend/services/NonSourceabilityQaDecisionConsumerTest.kt
+++ b/dataland-backend/src/test/kotlin/org/dataland/datalandbackend/services/NonSourceabilityQaDecisionConsumerTest.kt
@@ -61,7 +61,7 @@ class NonSourceabilityQaDecisionConsumerTest(
         val listener = NonSourceabilityQaDecisionListener(nonSourceabilityDataRepository)
         val event = buildEvent("not-a-uuid")
         assertThrows(MessageQueueRejectException::class.java) {
-            listener.processQaDecisionEvent(event, MessageType.NON_SOURCEABILITY_QA_ACCEPTED, "corr-id-001")
+            listener.processQaDecisionEvent(event, MessageType.NON_SOURCEABILITY_QA_ACCEPTED)
         }
     }
 
@@ -70,7 +70,7 @@ class NonSourceabilityQaDecisionConsumerTest(
         val listener = NonSourceabilityQaDecisionListener(nonSourceabilityDataRepository)
         val event = buildEvent("00000000-0000-0000-0000-000000000000")
         assertThrows(MessageQueueRejectException::class.java) {
-            listener.processQaDecisionEvent(event, MessageType.NON_SOURCEABILITY_QA_ACCEPTED, "corr-id-002")
+            listener.processQaDecisionEvent(event, MessageType.NON_SOURCEABILITY_QA_ACCEPTED)
         }
     }
 
@@ -83,7 +83,7 @@ class NonSourceabilityQaDecisionConsumerTest(
         val listener = NonSourceabilityQaDecisionListener(nonSourceabilityDataRepository)
         val event = buildEvent(id)
 
-        listener.processQaDecisionEvent(event, MessageType.NON_SOURCEABILITY_QA_ACCEPTED, "corr-accepted")
+        listener.processQaDecisionEvent(event, MessageType.NON_SOURCEABILITY_QA_ACCEPTED)
 
         val updated = nonSourceabilityDataRepository.findById(saved.nonSourceabilityId!!).orElseThrow()
         assertTrue(updated.currentlyActive)
@@ -97,7 +97,7 @@ class NonSourceabilityQaDecisionConsumerTest(
         val listener = NonSourceabilityQaDecisionListener(nonSourceabilityDataRepository)
         val event = buildEvent(id)
 
-        listener.processQaDecisionEvent(event, MessageType.NON_SOURCEABILITY_QA_REJECTED, "corr-rejected")
+        listener.processQaDecisionEvent(event, MessageType.NON_SOURCEABILITY_QA_REJECTED)
 
         val updated = nonSourceabilityDataRepository.findById(saved.nonSourceabilityId!!).orElseThrow()
         assertFalse(updated.currentlyActive)
@@ -111,7 +111,7 @@ class NonSourceabilityQaDecisionConsumerTest(
         val listener = NonSourceabilityQaDecisionListener(nonSourceabilityDataRepository)
         val event = buildEvent(id)
         assertThrows(MessageQueueRejectException::class.java) {
-            listener.processQaDecisionEvent(event, MessageType.NON_SOURCEABILITY_CREATED, "corr-unexpected")
+            listener.processQaDecisionEvent(event, MessageType.NON_SOURCEABILITY_CREATED)
         }
     }
 }

--- a/dataland-data-sourcing-service/src/main/kotlin/org/dataland/datasourcingservice/services/NonSourceabilityQaDecisionListener.kt
+++ b/dataland-data-sourcing-service/src/main/kotlin/org/dataland/datasourcingservice/services/NonSourceabilityQaDecisionListener.kt
@@ -61,7 +61,6 @@ class NonSourceabilityQaDecisionListener(
     fun onNonSourceabilityQaDecision(
         @Payload payload: String,
         @Header(MessageHeaderKey.TYPE) messageType: String,
-        @Header(MessageHeaderKey.CORRELATION_ID) correlationId: String,
     ) {
         MessageQueueUtils.rejectMessageOnException {
             if (messageType != MessageType.NON_SOURCEABILITY_QA_ACCEPTED &&
@@ -72,7 +71,7 @@ class NonSourceabilityQaDecisionListener(
                 )
             }
             val event = MessageQueueUtils.readMessagePayload<NonSourceabilityLifecycleEvent>(payload)
-            processQaDecisionEvent(event, messageType, correlationId)
+            processQaDecisionEvent(event, messageType)
         }
     }
 
@@ -80,28 +79,24 @@ class NonSourceabilityQaDecisionListener(
     internal fun processQaDecisionEvent(
         event: NonSourceabilityLifecycleEvent,
         messageType: String,
-        correlationId: String,
     ) {
         when (messageType) {
             MessageType.NON_SOURCEABILITY_QA_ACCEPTED ->
-                transitionToNonSourceable(event, correlationId)
+                transitionToNonSourceable(event)
             MessageType.NON_SOURCEABILITY_QA_REJECTED ->
-                transitionToDocumentSourcingDone(event, correlationId)
+                transitionToDocumentSourcingDone(event)
             else -> {
                 logger.error(
                     "Unexpected message type $messageType in NonSourceabilityQaDecisionListener " +
-                        "(correlationId=$correlationId). Discarding.",
+                        ". Discarding.",
                 )
                 throw MessageQueueRejectException("Unexpected message type $messageType in QA decision listener")
             }
         }
     }
 
-    private fun transitionToNonSourceable(
-        event: NonSourceabilityLifecycleEvent,
-        correlationId: String,
-    ) {
-        val sourcing = findSourcingForEvent(event, correlationId) ?: return
+    private fun transitionToNonSourceable(event: NonSourceabilityLifecycleEvent) {
+        val sourcing = findSourcingForEvent(event) ?: return
         if (sourcing.state == DataSourcingState.NonSourceable) {
             logger.info("Idempotent skip: already NonSourceable for nonSourceabilityId=${event.nonSourceabilityId}")
             return
@@ -112,16 +107,13 @@ class NonSourceabilityQaDecisionListener(
         )
         logger.info(
             "Transitioned dataSourcingId=${sourcing.dataSourcingId} to NonSourceable via QA accepted " +
-                "(correlationId=$correlationId, nonSourceabilityId=${event.nonSourceabilityId})",
+                "(nonSourceabilityId=${event.nonSourceabilityId})",
         )
     }
 
     @Transactional
-    internal fun transitionToDocumentSourcingDone(
-        event: NonSourceabilityLifecycleEvent,
-        correlationId: String,
-    ) {
-        val sourcing = findSourcingForEvent(event, correlationId) ?: return
+    internal fun transitionToDocumentSourcingDone(event: NonSourceabilityLifecycleEvent) {
+        val sourcing = findSourcingForEvent(event) ?: return
         if (sourcing.state == DataSourcingState.DocumentSourcingDone) {
             logger.info("Idempotent skip: already in DocumentSourcingDone for nonSourceabilityId=${event.nonSourceabilityId}")
             return
@@ -132,29 +124,27 @@ class NonSourceabilityQaDecisionListener(
         )
         logger.info(
             "Transitioned dataSourcingId=${sourcing.dataSourcingId} to DocumentSourcingDone " +
-                "(correlationId=$correlationId, nonSourceabilityId=${event.nonSourceabilityId})",
+                "(nonSourceabilityId=${event.nonSourceabilityId})",
         )
     }
 
-    private fun findSourcingForEvent(
-        event: NonSourceabilityLifecycleEvent,
-        correlationId: String,
-    ) = dataSourcingQueryManager
-        .searchDataSourcings(
-            companyId = UUID.fromString(event.companyId),
-            dataType = event.dataType,
-            reportingPeriod = event.reportingPeriod,
-            state = null,
-            chunkSize = 1,
-            chunkIndex = 0,
-        ).firstOrNull()
-        .also { sourcing ->
-            if (sourcing == null) {
-                logger.info(
-                    "No data sourcing object found for companyId=${event.companyId}, dataType=${event.dataType}, " +
-                        "reportingPeriod=${event.reportingPeriod} (correlationId=$correlationId, " +
-                        "nonSourceabilityId=${event.nonSourceabilityId}). Skipping.",
-                )
+    private fun findSourcingForEvent(event: NonSourceabilityLifecycleEvent) =
+        dataSourcingQueryManager
+            .searchDataSourcings(
+                companyId = UUID.fromString(event.companyId),
+                dataType = event.dataType,
+                reportingPeriod = event.reportingPeriod,
+                state = null,
+                chunkSize = 1,
+                chunkIndex = 0,
+            ).firstOrNull()
+            .also { sourcing ->
+                if (sourcing == null) {
+                    logger.info(
+                        "No data sourcing object found for companyId=${event.companyId}, dataType=${event.dataType}, " +
+                            "reportingPeriod=${event.reportingPeriod} (" +
+                            "nonSourceabilityId=${event.nonSourceabilityId}). Skipping.",
+                    )
+                }
             }
-        }
 }

--- a/dataland-data-sourcing-service/src/test/kotlin/org/dataland/datasourcingservice/serviceTests/NonSourceabilityQaAcceptedConsumerTest.kt
+++ b/dataland-data-sourcing-service/src/test/kotlin/org/dataland/datasourcingservice/serviceTests/NonSourceabilityQaAcceptedConsumerTest.kt
@@ -55,7 +55,7 @@ class NonSourceabilityQaAcceptedConsumerTest {
             .thenReturn(listOf(stored))
         whenever(sourcingManager.patchDataSourcingEntityById(any(), any())).thenReturn(stored)
 
-        listener.processQaDecisionEvent(buildEvent(), MessageType.NON_SOURCEABILITY_QA_ACCEPTED, "corr-1")
+        listener.processQaDecisionEvent(buildEvent(), MessageType.NON_SOURCEABILITY_QA_ACCEPTED)
 
         verify(sourcingManager).patchDataSourcingEntityById(any(), any())
     }
@@ -66,7 +66,7 @@ class NonSourceabilityQaAcceptedConsumerTest {
         whenever(queryManager.searchDataSourcings(anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), any(), any()))
             .thenReturn(listOf(stored))
 
-        listener.processQaDecisionEvent(buildEvent(), MessageType.NON_SOURCEABILITY_QA_ACCEPTED, "corr-2")
+        listener.processQaDecisionEvent(buildEvent(), MessageType.NON_SOURCEABILITY_QA_ACCEPTED)
 
         verify(sourcingManager, never()).patchDataSourcingEntityById(any(), any())
     }
@@ -78,7 +78,7 @@ class NonSourceabilityQaAcceptedConsumerTest {
             .thenReturn(listOf(stored))
         whenever(sourcingManager.patchDataSourcingEntityById(any(), any())).thenReturn(stored)
 
-        listener.processQaDecisionEvent(buildEvent(), MessageType.NON_SOURCEABILITY_QA_REJECTED, "corr-3")
+        listener.processQaDecisionEvent(buildEvent(), MessageType.NON_SOURCEABILITY_QA_REJECTED)
 
         verify(sourcingManager).patchDataSourcingEntityById(any(), argThat { state == DataSourcingState.DocumentSourcingDone })
     }
@@ -88,7 +88,7 @@ class NonSourceabilityQaAcceptedConsumerTest {
         whenever(queryManager.searchDataSourcings(anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), any(), any()))
             .thenReturn(emptyList())
 
-        listener.processQaDecisionEvent(buildEvent(), MessageType.NON_SOURCEABILITY_QA_ACCEPTED, "corr-4")
+        listener.processQaDecisionEvent(buildEvent(), MessageType.NON_SOURCEABILITY_QA_ACCEPTED)
 
         verify(sourcingManager, never()).patchDataSourcingEntityById(any(), any())
     }
@@ -96,7 +96,7 @@ class NonSourceabilityQaAcceptedConsumerTest {
     @Test
     fun `unexpected event type throws reject exception`() {
         assertThrows<MessageQueueRejectException> {
-            listener.processQaDecisionEvent(buildEvent(), MessageType.NON_SOURCEABILITY_CREATED, "corr-5")
+            listener.processQaDecisionEvent(buildEvent(), MessageType.NON_SOURCEABILITY_CREATED)
         }
     }
 }

--- a/dataland-qa-service/src/main/kotlin/org/dataland/datalandqaservice/controller/NonSourceabilityQaController.kt
+++ b/dataland-qa-service/src/main/kotlin/org/dataland/datalandqaservice/controller/NonSourceabilityQaController.kt
@@ -10,7 +10,6 @@ import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.RestController
-import java.util.UUID.randomUUID
 
 /**
  * Controller for non-sourceability QA review endpoints.
@@ -49,9 +48,8 @@ class NonSourceabilityQaController(
             return ResponseEntity.badRequest().build()
         }
         val reviewerUserId = DatalandAuthentication.fromContext().userId
-        val correlationId = randomUUID().toString()
         logger.info(
-            "POST /nonSourceable/$nonSourceabilityId qaStatus=${request.qaStatus} (correlationId=$correlationId)",
+            "POST /nonSourceable/$nonSourceabilityId qaStatus=${request.qaStatus}",
         )
         val result =
             nonSourceabilityQaReviewManager.postDecision(
@@ -59,7 +57,6 @@ class NonSourceabilityQaController(
                 qaStatus = request.qaStatus,
                 qaComment = request.qaComment,
                 reviewerUserId = reviewerUserId,
-                correlationId = correlationId,
             )
         return ResponseEntity.ok(result)
     }

--- a/dataland-qa-service/src/main/kotlin/org/dataland/datalandqaservice/services/NonSourceabilityEventListener.kt
+++ b/dataland-qa-service/src/main/kotlin/org/dataland/datalandqaservice/services/NonSourceabilityEventListener.kt
@@ -57,25 +57,20 @@ class NonSourceabilityEventListener(
     fun onNonSourceabilityCreated(
         @Payload payload: String,
         @Header(MessageHeaderKey.TYPE) messageType: String,
-        @Header(MessageHeaderKey.CORRELATION_ID) correlationId: String,
     ) {
         MessageQueueUtils.rejectMessageOnException {
             MessageQueueUtils.validateMessageType(messageType, MessageType.NON_SOURCEABILITY_CREATED)
             val event = MessageQueueUtils.readMessagePayload<NonSourceabilityLifecycleEvent>(payload)
-            processCreatedEvent(event, correlationId)
+            processCreatedEvent(event)
         }
     }
 
     @Transactional
-    internal fun processCreatedEvent(
-        event: NonSourceabilityLifecycleEvent,
-        correlationId: String,
-    ) {
+    internal fun processCreatedEvent(event: NonSourceabilityLifecycleEvent) {
         val existing = nonSourceableQaReviewRepository.findByNonSourceabilityId(event.nonSourceabilityId)
         if (existing != null) {
             logger.info(
-                "Idempotent skip: QA review record already exists for nonSourceabilityId=${event.nonSourceabilityId} " +
-                    "(correlationId=$correlationId)",
+                "Idempotent skip: QA review record already exists for nonSourceabilityId=${event.nonSourceabilityId}",
             )
             return
         }
@@ -93,7 +88,7 @@ class NonSourceabilityEventListener(
             )
         nonSourceableQaReviewRepository.save(entity)
         logger.info(
-            "Created QA review record for nonSourceabilityId=${event.nonSourceabilityId} (correlationId=$correlationId)",
+            "Created QA review record for nonSourceabilityId=${event.nonSourceabilityId}",
         )
     }
 }

--- a/dataland-qa-service/src/main/kotlin/org/dataland/datalandqaservice/services/NonSourceabilityQaReviewManager.kt
+++ b/dataland-qa-service/src/main/kotlin/org/dataland/datalandqaservice/services/NonSourceabilityQaReviewManager.kt
@@ -78,7 +78,6 @@ class NonSourceabilityQaReviewManager
             qaStatus: QaStatus,
             qaComment: String?,
             reviewerUserId: String,
-            correlationId: String,
         ): NonSourceableQaReviewInformation {
             require(qaStatus == QaStatus.Accepted || qaStatus == QaStatus.Rejected) {
                 "QA decision must be Accepted or Rejected, got $qaStatus"
@@ -88,12 +87,12 @@ class NonSourceabilityQaReviewManager
                 TransactionSynchronizationManager.registerSynchronization(
                     object : TransactionSynchronization {
                         override fun afterCommit() {
-                            sendQaDecisionEvent(entity, qaStatus, correlationId, nonSourceabilityId)
+                            sendQaDecisionEvent(entity, qaStatus, nonSourceabilityId)
                         }
                     },
                 )
             } else {
-                sendQaDecisionEvent(entity, qaStatus, correlationId, nonSourceabilityId)
+                sendQaDecisionEvent(entity, qaStatus, nonSourceabilityId)
             }
             return entity.toResponse()
         }
@@ -119,7 +118,6 @@ class NonSourceabilityQaReviewManager
         private fun sendQaDecisionEvent(
             entity: NonSourceableQaReviewInformationEntity,
             qaStatus: QaStatus,
-            correlationId: String,
             nonSourceabilityId: String,
         ) {
             val event =
@@ -138,12 +136,11 @@ class NonSourceabilityQaReviewManager
             cloudEventMessageHandler.buildCEMessageAndSendToQueue(
                 objectMapper.writeValueAsString(event),
                 messageType,
-                correlationId,
                 ExchangeName.QA_SERVICE_NON_SOURCEABILITY_DECISIONS,
                 RoutingKeyNames.NON_SOURCEABILITY_QA_DECISION,
             )
             logger.info(
-                "Emitted $messageType for nonSourceabilityId=$nonSourceabilityId (correlationId=$correlationId)",
+                "Emitted $messageType for nonSourceabilityId=$nonSourceabilityId",
             )
         }
 

--- a/dataland-qa-service/src/main/kotlin/org/dataland/datalandqaservice/services/NonSourceabilityQaReviewManager.kt
+++ b/dataland-qa-service/src/main/kotlin/org/dataland/datalandqaservice/services/NonSourceabilityQaReviewManager.kt
@@ -136,6 +136,7 @@ class NonSourceabilityQaReviewManager
             cloudEventMessageHandler.buildCEMessageAndSendToQueue(
                 objectMapper.writeValueAsString(event),
                 messageType,
+                entity.nonSourceabilityId,
                 ExchangeName.QA_SERVICE_NON_SOURCEABILITY_DECISIONS,
                 RoutingKeyNames.NON_SOURCEABILITY_QA_DECISION,
             )

--- a/dataland-qa-service/src/test/kotlin/org/dataland/datalandqaservice/controller/NonSourceabilityQaControllerTest.kt
+++ b/dataland-qa-service/src/test/kotlin/org/dataland/datalandqaservice/controller/NonSourceabilityQaControllerTest.kt
@@ -50,7 +50,7 @@ class NonSourceabilityQaControllerTest {
     @Test
     fun `postNonSourceabilityDecision returns 200 with accepted review`() {
         val accepted = review(qaStatus = QaStatus.Accepted)
-        whenever(manager.postDecision(any(), any(), anyOrNull(), any(), any())).thenReturn(accepted)
+        whenever(manager.postDecision(any(), any(), anyOrNull(), any())).thenReturn(accepted)
 
         withReviewerAuthentication {
             val request =
@@ -62,14 +62,14 @@ class NonSourceabilityQaControllerTest {
 
             assertEquals(HttpStatus.OK, result.statusCode)
             assertEquals(QaStatus.Accepted, result.body?.qaStatus)
-            verify(manager).postDecision(any(), any(), anyOrNull(), any(), any())
+            verify(manager).postDecision(any(), any(), anyOrNull(), any())
         }
     }
 
     @Test
     fun `postNonSourceabilityDecision returns 200 with rejected review and comment`() {
         val rejected = review(qaStatus = QaStatus.Rejected)
-        whenever(manager.postDecision(any(), any(), anyOrNull(), any(), any())).thenReturn(rejected)
+        whenever(manager.postDecision(any(), any(), anyOrNull(), any())).thenReturn(rejected)
 
         withReviewerAuthentication {
             val request =
@@ -89,7 +89,7 @@ class NonSourceabilityQaControllerTest {
         val exception = ResourceNotFoundApiException("Non-sourceability review not found", "No review exists")
         doThrow(exception)
             .whenever(manager)
-            .postDecision(any(), any(), anyOrNull(), any(), any())
+            .postDecision(any(), any(), anyOrNull(), any())
 
         withReviewerAuthentication {
             val request =

--- a/dataland-qa-service/src/test/kotlin/org/dataland/datalandqaservice/services/NonSourceabilityEventListenerTest.kt
+++ b/dataland-qa-service/src/test/kotlin/org/dataland/datalandqaservice/services/NonSourceabilityEventListenerTest.kt
@@ -39,7 +39,7 @@ class NonSourceabilityEventListenerTest {
     fun `processCreatedEvent persists QA review record with Pending status`() {
         whenever(repository.findByNonSourceabilityId(any())).thenReturn(null)
 
-        listener.processCreatedEvent(event(), "corr-1")
+        listener.processCreatedEvent(event())
 
         verify(repository).save(any<NonSourceableQaReviewInformationEntity>())
     }
@@ -59,7 +59,7 @@ class NonSourceabilityEventListenerTest {
             )
         whenever(repository.findByNonSourceabilityId(any())).thenReturn(existing)
 
-        listener.processCreatedEvent(event(), "corr-2")
+        listener.processCreatedEvent(event())
 
         verify(repository, never()).save(any())
     }
@@ -68,7 +68,7 @@ class NonSourceabilityEventListenerTest {
     fun `onNonSourceabilityCreated throws reject exception for wrong message type`() {
         val payload = objectMapper.writeValueAsString(event())
         assertThrows<MessageQueueRejectException> {
-            listener.onNonSourceabilityCreated(payload, MessageType.NON_SOURCEABILITY_AUTO_ACCEPTED, "corr-3")
+            listener.onNonSourceabilityCreated(payload, MessageType.NON_SOURCEABILITY_AUTO_ACCEPTED)
         }
     }
 }

--- a/dataland-qa-service/src/test/kotlin/org/dataland/datalandqaservice/services/NonSourceabilityQaReviewManagerTest.kt
+++ b/dataland-qa-service/src/test/kotlin/org/dataland/datalandqaservice/services/NonSourceabilityQaReviewManagerTest.kt
@@ -156,7 +156,7 @@ class NonSourceabilityQaReviewManagerTest {
         verify(cloudEventMessageHandler).buildCEMessageAndSendToQueue(
             any(),
             eq(MessageType.NON_SOURCEABILITY_QA_ACCEPTED),
-            eq("corr-1"),
+            any(),
             eq(ExchangeName.QA_SERVICE_NON_SOURCEABILITY_DECISIONS),
             eq(RoutingKeyNames.NON_SOURCEABILITY_QA_DECISION),
         )
@@ -175,7 +175,7 @@ class NonSourceabilityQaReviewManagerTest {
         verify(cloudEventMessageHandler).buildCEMessageAndSendToQueue(
             any(),
             eq(MessageType.NON_SOURCEABILITY_QA_REJECTED),
-            eq("corr-2"),
+            any(),
             eq(ExchangeName.QA_SERVICE_NON_SOURCEABILITY_DECISIONS),
             eq(RoutingKeyNames.NON_SOURCEABILITY_QA_DECISION),
         )

--- a/dataland-qa-service/src/test/kotlin/org/dataland/datalandqaservice/services/NonSourceabilityQaReviewManagerTest.kt
+++ b/dataland-qa-service/src/test/kotlin/org/dataland/datalandqaservice/services/NonSourceabilityQaReviewManagerTest.kt
@@ -148,7 +148,7 @@ class NonSourceabilityQaReviewManagerTest {
         whenever(repository.findByNonSourceabilityId(e.nonSourceabilityId)).thenReturn(e)
         whenever(repository.save(e)).thenReturn(e)
 
-        val result = manager.postDecision(e.nonSourceabilityId, QaStatus.Accepted, null, DEFAULT_REVIEWER_ID, "corr-1")
+        val result = manager.postDecision(e.nonSourceabilityId, QaStatus.Accepted, null, DEFAULT_REVIEWER_ID)
 
         assertEquals(QaStatus.Accepted, result.qaStatus)
         assertEquals(DEFAULT_REVIEWER_ID, result.reviewerUserId)
@@ -168,7 +168,7 @@ class NonSourceabilityQaReviewManagerTest {
         whenever(repository.findByNonSourceabilityId(e.nonSourceabilityId)).thenReturn(e)
         whenever(repository.save(e)).thenReturn(e)
 
-        val result = manager.postDecision(e.nonSourceabilityId, QaStatus.Rejected, "Not applicable", DEFAULT_REVIEWER_ID, "corr-2")
+        val result = manager.postDecision(e.nonSourceabilityId, QaStatus.Rejected, "Not applicable", DEFAULT_REVIEWER_ID)
 
         assertEquals(QaStatus.Rejected, result.qaStatus)
         assertEquals("Not applicable", result.qaComment)
@@ -186,7 +186,7 @@ class NonSourceabilityQaReviewManagerTest {
         whenever(repository.findByNonSourceabilityId(any())).thenReturn(null)
 
         assertThrows<ResourceNotFoundApiException> {
-            manager.postDecision("non-existent-id", QaStatus.Accepted, null, DEFAULT_REVIEWER_ID, "corr-3")
+            manager.postDecision("non-existent-id", QaStatus.Accepted, null, DEFAULT_REVIEWER_ID)
         }
 
         verify(cloudEventMessageHandler, never()).buildCEMessageAndSendToQueue(any(), any(), any(), any(), any())
@@ -195,7 +195,7 @@ class NonSourceabilityQaReviewManagerTest {
     @Test
     fun `postDecision throws IllegalArgumentException when qaStatus is Pending`() {
         assertThrows<IllegalArgumentException> {
-            manager.postDecision("some-id", QaStatus.Pending, null, DEFAULT_REVIEWER_ID, "corr-4")
+            manager.postDecision("some-id", QaStatus.Pending, null, DEFAULT_REVIEWER_ID)
         }
 
         verify(repository, never()).findByNonSourceabilityId(any())


### PR DESCRIPTION
# Pull Request \<Title>
`<Description here>`
## Things to do during Peer Review
Please check all boxes before the Pull Request is merged. In case you skip a box, describe in the PRs description (that means: here) why the check is skipped.
- [x] The GitHub Actions for the CI are green. This is enforced by GitHub. 
- [ ] The PR has been peer-reviewed
  - [ ] The code has been manually inspected by someone who did not implement the feature
  - [ ] The changes have been inspected for possible breaking API changes (changed data models, endpoints, response codes, exception handling, ...). If there are any discuss them with the team.
  - [ ] If this PR includes work on the frontend, at least one `@ts-nocheck` is removed. Additionally, there should not be any `@ts-nocheck` in files modified by this PR. If no `@ts-nocheck` are left: Celebrate :tada: :confetti_ball: type-safety and remove this entry. 
- [ ] The PR actually implements what is described in the JIRA-Issue
- [ ] At least one test exists testing the new feature
  - [ ] Make sure all newly added functionality (especially user facing) is tested
  - [ ] Make sure that new test files are included in a test container and actually run in the CI
- [ ] At least 3 consecutive CI runs are successfully executed to ensure that there are no flaky tests.
- [ ] Documentation is updated as required. If unsure whether or what to update, ask a fellow developer.
- [ ] If there was a database entity class added, there must also be a migration script for creating the corresponding database if flyway is already used by the service
- [ ] IF there are changes done to the framework data models or to a database entity class, the following steps were completed in order
  - [ ] A fresh clone of dataland.com is generated (see Wiki page on "OTC" for details)
  - [ ] The feature branch is deployed to clone with `Reset non-user related Docker Volumes & Re-populate` turned off
  - [ ] It's verified that the CD run is green
  - [ ] The new feature is manually used/tested/observed on the clone server. Testing of the new feature should (also) be done by a second, independent reviewer from the dev team
  - [ ] The feature branch is deployed to one of the dev servers with `Reset non-user related Docker Volumes & Re-populate` turned on, and it's verified that the CD run is green
- [ ] ELSE, the new version is deployed to one of the dev servers using this branch
  - [ ] Run with setting `Reset non-user related Docker Volumes & Re-populate` turned on 
  - [ ] It's verified that this version actually is the one deployed (check gitinfo for branch name and commit id!)
  - [ ] It's verified that the CD run is green
  - [ ] The new feature is manually used/tested/observed on dev server. Testing of the new feature should (also) be done by a second, independent reviewer from the dev team
- [ ] Confirm that the latest version (use the /gitinfo endpoint) of the feature branch is deployed to one of the dev servers (no longer enforced by GitHub)
- [ ] Ensure that the release notes are written in a way that is understandable to a non-technical audience.
