### PR TITLE
reworkedRequestBody

### DIFF
--- a/dataland-backend/backendOpenApi.json
+++ b/dataland-backend/backendOpenApi.json
@@ -617,6 +617,28 @@
         "summary": "Submit a non-sourceability request for a dataset.",
         "description": "Creates a NonSourceabilityInformation entry. With bypassQa\u003dfalse (default) and currentlyActive\u003dfalse the entry enters QA review. With bypassQa\u003dtrue and currentlyActive\u003dtrue (admin only) it is immediately activated. With bypassQa\u003dtrue and currentlyActive\u003dfalse (admin only) the active entry is deactivated (triple marked as sourceable again).",
         "operationId": "postNonSourceabilityOfADataset",
+        "parameters": [
+          {
+            "name": "bypassQa",
+            "in": "query",
+            "description": "When true the entry skips QA review and is immediately activated. Requires ROLE_ADMIN.",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "currentlyActive",
+            "in": "query",
+            "description": "When true the triple is marked as non-sourceable; false reverses an active entry.",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -8558,9 +8580,7 @@
       },
       "NonSourceabilityRequest": {
         "required": [
-          "bypassQa",
           "companyId",
-          "currentlyActive",
           "dataType",
           "reason",
           "reportingPeriod"
@@ -8584,14 +8604,6 @@
             "type": "string",
             "description": "The reason why there is no source available",
             "example": "Parent Uploaded"
-          },
-          "bypassQa": {
-            "type": "boolean",
-            "description": "When true the non-sourceability entry is immediately activated without QA review. Requires ROLE_ADMIN."
-          },
-          "currentlyActive": {
-            "type": "boolean",
-            "description": "When true the triple is treated as non-sourceable; when false the entry is inactive. Must be false when bypassQa\u003dfalse (the QA service sets this to true upon approval). When bypassQa\u003dtrue, signals whether the intent is to mark the triple as non-sourceable (true) or sourceable again (false)."
           }
         }
       },

--- a/dataland-backend/src/main/kotlin/org/dataland/datalandbackend/api/MetaDataApi.kt
+++ b/dataland-backend/src/main/kotlin/org/dataland/datalandbackend/api/MetaDataApi.kt
@@ -258,7 +258,9 @@ interface MetaDataApi {
      * Submits a non-sourceability request for a dataset.
      * When bypassQa=true the caller must hold ROLE_ADMIN; otherwise ROLE_UPLOADER is required.
      * When bypassQa=true and currentlyActive=false the request reverses a non-sourceability entry.
-     * @param nonSourceabilityRequest request body containing dataset dimensions, bypass flag, and currentlyActive flag.
+     * @param nonSourceabilityRequest request body containing dataset dimensions and reason.
+     * @param bypassQa when true the entry skips QA review and is immediately activated (requires ROLE_ADMIN).
+     * @param currentlyActive when true the triple is treated as non-sourceable; false reverses an active entry.
      */
     @Operation(
         summary = "Submit a non-sourceability request for a dataset.",
@@ -285,6 +287,12 @@ interface MetaDataApi {
     fun postNonSourceabilityOfADataset(
         @Valid @RequestBody
         nonSourceabilityRequest: NonSourceabilityRequest,
+        @Parameter(description = "When true the entry skips QA review and is immediately activated. Requires ROLE_ADMIN.")
+        @RequestParam(required = false, defaultValue = "false")
+        bypassQa: Boolean,
+        @Parameter(description = "When true the triple is marked as non-sourceable; false reverses an active entry.")
+        @RequestParam(required = false, defaultValue = "false")
+        currentlyActive: Boolean,
     ): ResponseEntity<NonSourceabilityInformationResponse>
 
     /**

--- a/dataland-backend/src/main/kotlin/org/dataland/datalandbackend/controller/MetaDataController.kt
+++ b/dataland-backend/src/main/kotlin/org/dataland/datalandbackend/controller/MetaDataController.kt
@@ -166,12 +166,14 @@ class MetaDataController(
 
     override fun postNonSourceabilityOfADataset(
         nonSourceabilityRequest: NonSourceabilityRequest,
+        bypassQa: Boolean,
+        currentlyActive: Boolean,
     ): ResponseEntity<NonSourceabilityInformationResponse> {
         val authentication = DatalandAuthentication.fromContext()
-        if (nonSourceabilityRequest.bypassQa && !authentication.roles.contains(DatalandRealmRole.ROLE_ADMIN)) {
+        if (bypassQa && !authentication.roles.contains(DatalandRealmRole.ROLE_ADMIN)) {
             throw AccessDeniedException("bypassQa=true requires ROLE_ADMIN.")
         }
-        val result = nonSourceabilityInformationManager.processNonSourceabilityRequest(nonSourceabilityRequest)
+        val result = nonSourceabilityInformationManager.processNonSourceabilityRequest(nonSourceabilityRequest, bypassQa, currentlyActive)
         return ResponseEntity.ok(result.response)
     }
 

--- a/dataland-backend/src/main/kotlin/org/dataland/datalandbackend/model/metainformation/NonSourceabilityRequest.kt
+++ b/dataland-backend/src/main/kotlin/org/dataland/datalandbackend/model/metainformation/NonSourceabilityRequest.kt
@@ -31,20 +31,4 @@ data class NonSourceabilityRequest(
         example = BackendOpenApiDescriptionsAndExamples.REASON_EXAMPLE,
     )
     val reason: String,
-    @field:JsonProperty(required = false)
-    @field:Schema(
-        description =
-            "When true the non-sourceability entry is immediately activated without QA review. " +
-                "Requires ROLE_ADMIN.",
-    )
-    val bypassQa: Boolean = false,
-    @field:JsonProperty(required = true)
-    @field:Schema(
-        description =
-            "When true the triple is treated as non-sourceable; when false the entry is inactive. " +
-                "Must be false when bypassQa=false (the QA service sets this to true upon approval). " +
-                "When bypassQa=true, signals whether the intent is to mark the triple as non-sourceable (true) " +
-                "or sourceable again (false).",
-    )
-    val currentlyActive: Boolean,
 )

--- a/dataland-backend/src/main/kotlin/org/dataland/datalandbackend/services/NonSourceabilityInformationManager.kt
+++ b/dataland-backend/src/main/kotlin/org/dataland/datalandbackend/services/NonSourceabilityInformationManager.kt
@@ -71,10 +71,14 @@ class NonSourceabilityInformationManager(
      * or if bypassQa=true, currentlyActive=fals` and no active entry exists to reverse.
      */
     @Transactional
-    fun processNonSourceabilityRequest(request: NonSourceabilityRequest): ProcessNonSourceabilityResult.Success {
+    fun processNonSourceabilityRequest(
+        request: NonSourceabilityRequest,
+        bypassQa: Boolean,
+        currentlyActive: Boolean,
+    ): ProcessNonSourceabilityResult.Success {
         companyQueryManager.assertCompanyIdExists(request.companyId)
 
-        if (!request.bypassQa && request.currentlyActive) {
+        if (!bypassQa && currentlyActive) {
             throw InvalidInputApiException(
                 summary = "Invalid non-sourceability request.",
                 message =
@@ -100,10 +104,10 @@ class NonSourceabilityInformationManager(
             )
         }
 
-        return if (request.bypassQa && !request.currentlyActive) {
+        return if (bypassQa && !currentlyActive) {
             processReversal(request)
         } else {
-            processStandardOrBypassCreate(request)
+            processStandardOrBypassCreate(request, bypassQa, currentlyActive)
         }
     }
 
@@ -159,7 +163,11 @@ class NonSourceabilityInformationManager(
      * bypassQa=true/currentlyActive=true (admin bypass mark as non-sourceable).
      * Creates a new entry and emits the appropriate lifecycle event.
      */
-    private fun processStandardOrBypassCreate(request: NonSourceabilityRequest): ProcessNonSourceabilityResult.Success {
+    private fun processStandardOrBypassCreate(
+        request: NonSourceabilityRequest,
+        bypassQa: Boolean,
+        currentlyActive: Boolean,
+    ): ProcessNonSourceabilityResult.Success {
         val hasActiveEntry =
             nonSourceabilityDataRepository
                 .findActiveForTuple(
@@ -178,7 +186,7 @@ class NonSourceabilityInformationManager(
         }
 
         val userId = DatalandAuthentication.fromContext().userId
-        val qaStatus = if (request.bypassQa) QaStatus.Accepted else QaStatus.Pending
+        val qaStatus = if (bypassQa) QaStatus.Accepted else QaStatus.Pending
         val entity =
             NonSourceabilityInformationEntity(
                 companyId = request.companyId,
@@ -187,9 +195,9 @@ class NonSourceabilityInformationManager(
                 qaStatus = qaStatus,
                 uploaderUserId = userId,
                 uploadTime = Instant.now().toEpochMilli(),
-                currentlyActive = request.currentlyActive,
+                currentlyActive = currentlyActive,
                 reason = request.reason,
-                bypassQa = request.bypassQa,
+                bypassQa = bypassQa,
             )
 
         val saved = nonSourceabilityDataRepository.save(entity)
@@ -198,13 +206,13 @@ class NonSourceabilityInformationManager(
         TransactionSynchronizationManager.registerSynchronization(
             object : TransactionSynchronization {
                 override fun afterCommit() {
-                    emitLifecycleEvent(saved, request.bypassQa)
+                    emitLifecycleEvent(saved, bypassQa)
                 }
             },
         )
         logger.info(
             "NonSourceabilityInformation persisted with id=$nonSourceabilityId, " +
-                "bypassQa=${request.bypassQa}, qaStatus=$qaStatus",
+                "bypassQa=$bypassQa, qaStatus=$qaStatus",
         )
         return ProcessNonSourceabilityResult.Success(saved.toResponse())
     }

--- a/dataland-backend/src/test/kotlin/org/dataland/datalandbackend/controller/MetaDataControllerNonSourceableTest.kt
+++ b/dataland-backend/src/test/kotlin/org/dataland/datalandbackend/controller/MetaDataControllerNonSourceableTest.kt
@@ -69,18 +69,17 @@ class MetaDataControllerNonSourceableTest
             storedCompany = companyManager.addCompany(companyInfo)
         }
 
+        private fun body(reason: String = "No public source") =
+            NonSourceabilityRequest(
+                companyId = storedCompany.companyId,
+                dataType = dataType,
+                reportingPeriod = reportingPeriod,
+                reason = reason,
+            )
+
         @Test
         fun `post nonSourceable creates entry with qaStatus Pending when bypassQa is false`() {
-            val request =
-                NonSourceabilityRequest(
-                    companyId = storedCompany.companyId,
-                    dataType = dataType,
-                    reportingPeriod = reportingPeriod,
-                    reason = "No public source",
-                    bypassQa = false,
-                    currentlyActive = false,
-                )
-            val response = metaDataController.postNonSourceabilityOfADataset(request)
+            val response = metaDataController.postNonSourceabilityOfADataset(body(), bypassQa = false, currentlyActive = false)
             assertEquals(QaStatus.Pending, response.body?.qaStatus)
             assertFalse(response.body?.currentlyActive ?: true)
         }
@@ -88,50 +87,22 @@ class MetaDataControllerNonSourceableTest
         @Test
         fun `post nonSourceable creates entry with qaStatus Accepted when bypassQa is true and caller is admin`() {
             AuthenticationMock.mockSecurityContext("admin", "adminId", adminRoles)
-
-            val request =
-                NonSourceabilityRequest(
-                    companyId = storedCompany.companyId,
-                    dataType = dataType,
-                    reportingPeriod = reportingPeriod,
-                    reason = "Admin bypass",
-                    bypassQa = true,
-                    currentlyActive = true,
-                )
-            val response = metaDataController.postNonSourceabilityOfADataset(request)
+            val response = metaDataController.postNonSourceabilityOfADataset(body("Admin bypass"), bypassQa = true, currentlyActive = true)
             assertEquals(QaStatus.Accepted, response.body?.qaStatus)
             assertTrue(response.body?.currentlyActive ?: false)
         }
 
         @Test
         fun `post nonSourceable with bypassQa true throws AccessDeniedException for non admin`() {
-            val request =
-                NonSourceabilityRequest(
-                    companyId = storedCompany.companyId,
-                    dataType = dataType,
-                    reportingPeriod = reportingPeriod,
-                    reason = "Attempting bypass",
-                    bypassQa = true,
-                    currentlyActive = true,
-                )
             assertThrows<AccessDeniedException> {
-                metaDataController.postNonSourceabilityOfADataset(request)
+                metaDataController.postNonSourceabilityOfADataset(body("Attempting bypass"), bypassQa = true, currentlyActive = true)
             }
         }
 
         @Test
         fun `get nonSourceable returns entries filtered by qaStatus`() {
             AuthenticationMock.mockSecurityContext("admin", "adminId", adminRoles)
-            metaDataController.postNonSourceabilityOfADataset(
-                NonSourceabilityRequest(
-                    companyId = storedCompany.companyId,
-                    dataType = dataType,
-                    reportingPeriod = reportingPeriod,
-                    reason = "Test",
-                    bypassQa = true,
-                    currentlyActive = true,
-                ),
-            )
+            metaDataController.postNonSourceabilityOfADataset(body("Test"), bypassQa = true, currentlyActive = true)
 
             val allResults =
                 metaDataController.getInfoOnNonSourceabilityOfDatasets(storedCompany.companyId, dataType, reportingPeriod, null)
@@ -158,43 +129,16 @@ class MetaDataControllerNonSourceableTest
         @Test
         fun `head nonSourceable returns 200 for active entry`() {
             AuthenticationMock.mockSecurityContext("admin", "adminId", adminRoles)
-            metaDataController.postNonSourceabilityOfADataset(
-                NonSourceabilityRequest(
-                    companyId = storedCompany.companyId,
-                    dataType = dataType,
-                    reportingPeriod = reportingPeriod,
-                    reason = "Active",
-                    bypassQa = true,
-                    currentlyActive = true,
-                ),
-            )
+            metaDataController.postNonSourceabilityOfADataset(body("Active"), bypassQa = true, currentlyActive = true)
             metaDataController.isDataNonSourceable(storedCompany.companyId, dataType, reportingPeriod)
         }
 
         @Test
         fun `reversal succeeds for admin and isDataNonSourceable returns 404 afterwards`() {
             AuthenticationMock.mockSecurityContext("admin", "adminId", adminRoles)
-            metaDataController.postNonSourceabilityOfADataset(
-                NonSourceabilityRequest(
-                    companyId = storedCompany.companyId,
-                    dataType = dataType,
-                    reportingPeriod = reportingPeriod,
-                    reason = "Mark non-sourceable",
-                    bypassQa = true,
-                    currentlyActive = true,
-                ),
-            )
+            metaDataController.postNonSourceabilityOfADataset(body("Mark non-sourceable"), bypassQa = true, currentlyActive = true)
             val reversalResponse =
-                metaDataController.postNonSourceabilityOfADataset(
-                    NonSourceabilityRequest(
-                        companyId = storedCompany.companyId,
-                        dataType = dataType,
-                        reportingPeriod = reportingPeriod,
-                        reason = "Reversal",
-                        bypassQa = true,
-                        currentlyActive = false,
-                    ),
-                )
+                metaDataController.postNonSourceabilityOfADataset(body("Reversal"), bypassQa = true, currentlyActive = false)
             assertFalse(reversalResponse.body?.currentlyActive ?: true)
             assertThrows<ResourceNotFoundApiException> {
                 metaDataController.isDataNonSourceable(storedCompany.companyId, dataType, reportingPeriod)

--- a/dataland-backend/src/test/kotlin/org/dataland/datalandbackend/services/NonSourceabilityInformationManagerTest.kt
+++ b/dataland-backend/src/test/kotlin/org/dataland/datalandbackend/services/NonSourceabilityInformationManagerTest.kt
@@ -70,23 +70,19 @@ class NonSourceabilityInformationManagerTest(
         companyId = storedCompany.companyId
     }
 
-    private fun request(
-        bypassQa: Boolean = false,
-        currentlyActive: Boolean = bypassQa,
-    ) = NonSourceabilityRequest(
-        companyId = companyId,
-        dataType = dataType,
-        reportingPeriod = reportingPeriod,
-        reason = "No source",
-        bypassQa = bypassQa,
-        currentlyActive = currentlyActive,
-    )
+    private fun request() =
+        NonSourceabilityRequest(
+            companyId = companyId,
+            dataType = dataType,
+            reportingPeriod = reportingPeriod,
+            reason = "No source",
+        )
 
     // --- Existing tests (updated) ---
 
     @Test
     fun `creates pending entry when bypassQa is false`() {
-        val result = manager.processNonSourceabilityRequest(request())
+        val result = manager.processNonSourceabilityRequest(request(), bypassQa = false, currentlyActive = false)
         val response = result.response
         assertEquals(QaStatus.Pending, response.qaStatus)
         assertFalse(response.currentlyActive)
@@ -95,7 +91,7 @@ class NonSourceabilityInformationManagerTest(
     @Test
     fun `creates accepted active entry when bypassQa is true`() {
         AuthenticationMock.mockSecurityContext("admin", "adminId", adminRoles)
-        val result = manager.processNonSourceabilityRequest(request(bypassQa = true))
+        val result = manager.processNonSourceabilityRequest(request(), bypassQa = true, currentlyActive = true)
         val response = result.response
         assertEquals(QaStatus.Accepted, response.qaStatus)
         assertTrue(response.currentlyActive)
@@ -103,25 +99,29 @@ class NonSourceabilityInformationManagerTest(
 
     @Test
     fun `duplicate request for Pending entry throws ConflictApiException`() {
-        manager.processNonSourceabilityRequest(request())
-        assertThrows<ConflictApiException> { manager.processNonSourceabilityRequest(request()) }
+        manager.processNonSourceabilityRequest(request(), bypassQa = false, currentlyActive = false)
+        assertThrows<ConflictApiException> {
+            manager.processNonSourceabilityRequest(request(), bypassQa = false, currentlyActive = false)
+        }
     }
 
     @Test
     fun `duplicate request for Accepted entry throws ConflictApiException`() {
         AuthenticationMock.mockSecurityContext("admin", "adminId", adminRoles)
-        manager.processNonSourceabilityRequest(request(bypassQa = true))
-        assertThrows<ConflictApiException> { manager.processNonSourceabilityRequest(request(bypassQa = true)) }
+        manager.processNonSourceabilityRequest(request(), bypassQa = true, currentlyActive = true)
+        assertThrows<ConflictApiException> {
+            manager.processNonSourceabilityRequest(request(), bypassQa = true, currentlyActive = true)
+        }
     }
 
     @Test
     fun `new request allowed after Rejected entry`() {
-        manager.processNonSourceabilityRequest(request())
+        manager.processNonSourceabilityRequest(request(), bypassQa = false, currentlyActive = false)
         val entity = nonSourceabilityDataRepository.findByFilters(companyId, dataType, reportingPeriod, QaStatus.Pending).first()
         entity.qaStatus = QaStatus.Rejected
         nonSourceabilityDataRepository.save(entity)
 
-        val secondResult = manager.processNonSourceabilityRequest(request())
+        val secondResult = manager.processNonSourceabilityRequest(request(), bypassQa = false, currentlyActive = false)
         assertEquals(QaStatus.Pending, secondResult.response.qaStatus)
     }
 
@@ -133,14 +133,14 @@ class NonSourceabilityInformationManagerTest(
     @Test
     fun `isCurrentlyActive returns true after admin bypass entry`() {
         AuthenticationMock.mockSecurityContext("admin", "adminId", adminRoles)
-        manager.processNonSourceabilityRequest(request(bypassQa = true))
+        manager.processNonSourceabilityRequest(request(), bypassQa = true, currentlyActive = true)
         assertTrue(manager.isTripleCurrentlyNonSourceable(companyId, dataType, reportingPeriod))
     }
 
     @Test
     fun `NonSourceabilityDataRepository is canonical runtime source not SourceabilityDataRepository`() {
         AuthenticationMock.mockSecurityContext("admin", "adminId", adminRoles)
-        manager.processNonSourceabilityRequest(request(bypassQa = true))
+        manager.processNonSourceabilityRequest(request(), bypassQa = true, currentlyActive = true)
         val entries = nonSourceabilityDataRepository.findByFilters(companyId, dataType, reportingPeriod, null)
         assertTrue(entries.isNotEmpty(), "NonSourceabilityDataRepository must be the runtime source")
     }
@@ -150,7 +150,7 @@ class NonSourceabilityInformationManagerTest(
     @Test
     fun `invalid combination bypassQa false currentlyActive true throws InvalidInputApiException`() {
         assertThrows<InvalidInputApiException> {
-            manager.processNonSourceabilityRequest(request(bypassQa = false, currentlyActive = true))
+            manager.processNonSourceabilityRequest(request(), bypassQa = false, currentlyActive = true)
         }
     }
 
@@ -159,18 +159,18 @@ class NonSourceabilityInformationManagerTest(
     @Test
     fun `bypassQa false currentlyActive false rejected when active entry exists throws ConflictApiException`() {
         AuthenticationMock.mockSecurityContext("admin", "adminId", adminRoles)
-        manager.processNonSourceabilityRequest(request(bypassQa = true, currentlyActive = true))
+        manager.processNonSourceabilityRequest(request(), bypassQa = true, currentlyActive = true)
         AuthenticationMock.mockSecurityContext("uploader", "uploaderId", uploaderRoles)
         assertThrows<ConflictApiException> {
-            manager.processNonSourceabilityRequest(request(bypassQa = false, currentlyActive = false))
+            manager.processNonSourceabilityRequest(request(), bypassQa = false, currentlyActive = false)
         }
     }
 
     @Test
     fun `bypassQa false currentlyActive false rejected when pending entry exists throws ConflictApiException`() {
-        manager.processNonSourceabilityRequest(request(bypassQa = false, currentlyActive = false))
+        manager.processNonSourceabilityRequest(request(), bypassQa = false, currentlyActive = false)
         assertThrows<ConflictApiException> {
-            manager.processNonSourceabilityRequest(request(bypassQa = false, currentlyActive = false))
+            manager.processNonSourceabilityRequest(request(), bypassQa = false, currentlyActive = false)
         }
     }
 
@@ -179,19 +179,19 @@ class NonSourceabilityInformationManagerTest(
     @Test
     fun `bypassQa true currentlyActive true rejected when active entry exists throws ConflictApiException`() {
         AuthenticationMock.mockSecurityContext("admin", "adminId", adminRoles)
-        manager.processNonSourceabilityRequest(request(bypassQa = true, currentlyActive = true))
+        manager.processNonSourceabilityRequest(request(), bypassQa = true, currentlyActive = true)
         assertThrows<ConflictApiException> {
-            manager.processNonSourceabilityRequest(request(bypassQa = true, currentlyActive = true))
+            manager.processNonSourceabilityRequest(request(), bypassQa = true, currentlyActive = true)
         }
     }
 
     @Test
     fun `bypassQa true currentlyActive true rejected when pending entry exists throws ConflictApiException`() {
         AuthenticationMock.mockSecurityContext("uploader", "uploaderId", uploaderRoles)
-        manager.processNonSourceabilityRequest(request(bypassQa = false, currentlyActive = false))
+        manager.processNonSourceabilityRequest(request(), bypassQa = false, currentlyActive = false)
         AuthenticationMock.mockSecurityContext("admin", "adminId", adminRoles)
         assertThrows<ConflictApiException> {
-            manager.processNonSourceabilityRequest(request(bypassQa = true, currentlyActive = true))
+            manager.processNonSourceabilityRequest(request(), bypassQa = true, currentlyActive = true)
         }
     }
 
@@ -200,8 +200,8 @@ class NonSourceabilityInformationManagerTest(
     @Test
     fun `bypassQa true currentlyActive false deactivates active entry and returns new entry`() {
         AuthenticationMock.mockSecurityContext("admin", "adminId", adminRoles)
-        manager.processNonSourceabilityRequest(request(bypassQa = true, currentlyActive = true))
-        val result = manager.processNonSourceabilityRequest(request(bypassQa = true, currentlyActive = false))
+        manager.processNonSourceabilityRequest(request(), bypassQa = true, currentlyActive = true)
+        val result = manager.processNonSourceabilityRequest(request(), bypassQa = true, currentlyActive = false)
         val response = result.response
         assertFalse(response.currentlyActive)
         assertEquals(QaStatus.Accepted, response.qaStatus)
@@ -216,26 +216,26 @@ class NonSourceabilityInformationManagerTest(
     fun `bypassQa true currentlyActive false returns ConflictApiException when no active entry exists`() {
         AuthenticationMock.mockSecurityContext("admin", "adminId", adminRoles)
         assertThrows<ConflictApiException> {
-            manager.processNonSourceabilityRequest(request(bypassQa = true, currentlyActive = false))
+            manager.processNonSourceabilityRequest(request(), bypassQa = true, currentlyActive = false)
         }
     }
 
     @Test
     fun `bypassQa true currentlyActive false returns ConflictApiException when pending entry exists`() {
         AuthenticationMock.mockSecurityContext("uploader", "uploaderId", uploaderRoles)
-        manager.processNonSourceabilityRequest(request(bypassQa = false, currentlyActive = false))
+        manager.processNonSourceabilityRequest(request(), bypassQa = false, currentlyActive = false)
         AuthenticationMock.mockSecurityContext("admin", "adminId", adminRoles)
         assertThrows<ConflictApiException> {
-            manager.processNonSourceabilityRequest(request(bypassQa = true, currentlyActive = false))
+            manager.processNonSourceabilityRequest(request(), bypassQa = true, currentlyActive = false)
         }
     }
 
     @Test
     fun `bypassQa true currentlyActive false does not emit lifecycle event`() {
         AuthenticationMock.mockSecurityContext("admin", "adminId", adminRoles)
-        manager.processNonSourceabilityRequest(request(bypassQa = true, currentlyActive = true))
+        manager.processNonSourceabilityRequest(request(), bypassQa = true, currentlyActive = true)
         clearInvocations(cloudEventMessageHandler)
-        manager.processNonSourceabilityRequest(request(bypassQa = true, currentlyActive = false))
+        manager.processNonSourceabilityRequest(request(), bypassQa = true, currentlyActive = false)
         verifyNoInteractions(cloudEventMessageHandler)
     }
 }

--- a/dataland-backend/src/test/kotlin/org/dataland/datalandbackend/services/NonSourceabilityInformationManagerTest.kt
+++ b/dataland-backend/src/test/kotlin/org/dataland/datalandbackend/services/NonSourceabilityInformationManagerTest.kt
@@ -172,6 +172,9 @@ class NonSourceabilityInformationManagerTest(
         assertThrows<ConflictApiException> {
             manager.processNonSourceabilityRequest(request(), bypassQa = false, currentlyActive = false)
         }
+        val entries = nonSourceabilityDataRepository.findByFilters(companyId, dataType, reportingPeriod, null)
+        assertEquals(1, entries.size, "Conflict must not create a duplicate entry")
+        assertEquals(QaStatus.Pending, entries.single().qaStatus)
     }
 
     // --- admin bypass constraint checks ---
@@ -183,6 +186,9 @@ class NonSourceabilityInformationManagerTest(
         assertThrows<ConflictApiException> {
             manager.processNonSourceabilityRequest(request(), bypassQa = true, currentlyActive = true)
         }
+        val entries = nonSourceabilityDataRepository.findByFilters(companyId, dataType, reportingPeriod, null)
+        assertEquals(1, entries.size, "Conflict must not create a duplicate entry")
+        assertTrue(entries.single().currentlyActive, "Active entry must remain active after rejected duplicate")
     }
 
     @Test

--- a/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/tests/NonSourceabilityTest.kt
+++ b/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/tests/NonSourceabilityTest.kt
@@ -41,14 +41,15 @@ class NonSourceabilityTest {
 
         asAdmin {
             apiAccessor.metaDataControllerApi.postNonSourceabilityOfADataset(
-                NonSourceabilityRequest(
-                    companyId = companyId,
-                    dataType = DataTypeEnum.sfdr,
-                    reportingPeriod = testReportingPeriod,
-                    reason = NO_PUBLIC_SOURCE_REASON,
-                    bypassQa = true,
-                    currentlyActive = true,
-                ),
+                nonSourceabilityRequest =
+                    NonSourceabilityRequest(
+                        companyId = companyId,
+                        dataType = DataTypeEnum.sfdr,
+                        reportingPeriod = testReportingPeriod,
+                        reason = NO_PUBLIC_SOURCE_REASON,
+                    ),
+                bypassQa = true,
+                currentlyActive = true,
             )
         }
 
@@ -146,14 +147,15 @@ class NonSourceabilityTest {
         val createdEntry =
             asAdmin {
                 apiAccessor.metaDataControllerApi.postNonSourceabilityOfADataset(
-                    NonSourceabilityRequest(
-                        companyId = ctx.companyId,
-                        dataType = ctx.dataType,
-                        reportingPeriod = ctx.reportingPeriod,
-                        reason = NO_PUBLIC_SOURCE_REASON,
-                        bypassQa = false,
-                        currentlyActive = false,
-                    ),
+                    nonSourceabilityRequest =
+                        NonSourceabilityRequest(
+                            companyId = ctx.companyId,
+                            dataType = ctx.dataType,
+                            reportingPeriod = ctx.reportingPeriod,
+                            reason = NO_PUBLIC_SOURCE_REASON,
+                        ),
+                    bypassQa = false,
+                    currentlyActive = false,
                 )
             }
         assertEquals(
@@ -328,14 +330,15 @@ class NonSourceabilityTest {
         val createdEntry =
             asAdmin {
                 apiAccessor.metaDataControllerApi.postNonSourceabilityOfADataset(
-                    NonSourceabilityRequest(
-                        companyId = ctx.companyId,
-                        dataType = ctx.dataType,
-                        reportingPeriod = ctx.reportingPeriod,
-                        reason = NO_PUBLIC_SOURCE_REASON,
-                        bypassQa = true,
-                        currentlyActive = true,
-                    ),
+                    nonSourceabilityRequest =
+                        NonSourceabilityRequest(
+                            companyId = ctx.companyId,
+                            dataType = ctx.dataType,
+                            reportingPeriod = ctx.reportingPeriod,
+                            reason = NO_PUBLIC_SOURCE_REASON,
+                        ),
+                    bypassQa = true,
+                    currentlyActive = true,
                 )
             }
         assertEquals(

--- a/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/tests/communityManager/DataRequestNonSourceableTest.kt
+++ b/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/tests/communityManager/DataRequestNonSourceableTest.kt
@@ -64,8 +64,6 @@ class DataRequestNonSourceableTest {
             dataType = DataTypeEnum.eutaxonomyMinusNonMinusFinancials,
             reportingPeriod = "2023",
             reason = "This dataset is non-sourceable.",
-            bypassQa = true,
-            currentlyActive = true,
         )
 
     private fun postTwoDataRequestForSameUserAndReturnRequestIds(): Pair<UUID, UUID> {
@@ -103,7 +101,11 @@ class DataRequestNonSourceableTest {
 
     private fun postSourceabilityInfo(sourceabilityInfo: NonSourceabilityRequest) {
         jwtHelper.authenticateApiCallsWithJwtForTechnicalUser(TechnicalUser.Admin)
-        apiAccessor.metaDataControllerApi.postNonSourceabilityOfADataset(sourceabilityInfo)
+        apiAccessor.metaDataControllerApi.postNonSourceabilityOfADataset(
+            nonSourceabilityRequest = sourceabilityInfo,
+            bypassQa = true,
+            currentlyActive = true,
+        )
     }
 
     @Test
@@ -143,8 +145,6 @@ class DataRequestNonSourceableTest {
                 dataType = DataTypeEnum.eutaxonomyMinusNonMinusFinancials,
                 reportingPeriod = "2024",
                 reason = "This dataset is non-sourceable.",
-                bypassQa = true,
-                currentlyActive = true,
             )
 
         postSourceabilityInfo(sourceabilityInfoRequest2024)


### PR DESCRIPTION
# Pull Request \<Title>
`<Description here>`
## Things to do during Peer Review
Please check all boxes before the Pull Request is merged. In case you skip a box, describe in the PRs description (that means: here) why the check is skipped.
- [x] The GitHub Actions for the CI are green. This is enforced by GitHub. 
- [ ] The PR has been peer-reviewed
  - [ ] The code has been manually inspected by someone who did not implement the feature
  - [ ] The changes have been inspected for possible breaking API changes (changed data models, endpoints, response codes, exception handling, ...). If there are any discuss them with the team.
  - [ ] If this PR includes work on the frontend, at least one `@ts-nocheck` is removed. Additionally, there should not be any `@ts-nocheck` in files modified by this PR. If no `@ts-nocheck` are left: Celebrate :tada: :confetti_ball: type-safety and remove this entry. 
- [ ] The PR actually implements what is described in the JIRA-Issue
- [ ] At least one test exists testing the new feature
  - [ ] Make sure all newly added functionality (especially user facing) is tested
  - [ ] Make sure that new test files are included in a test container and actually run in the CI
- [ ] At least 3 consecutive CI runs are successfully executed to ensure that there are no flaky tests.
- [ ] Documentation is updated as required. If unsure whether or what to update, ask a fellow developer.
- [ ] If there was a database entity class added, there must also be a migration script for creating the corresponding database if flyway is already used by the service
- [ ] IF there are changes done to the framework data models or to a database entity class, the following steps were completed in order
  - [ ] A fresh clone of dataland.com is generated (see Wiki page on "OTC" for details)
  - [ ] The feature branch is deployed to clone with `Reset non-user related Docker Volumes & Re-populate` turned off
  - [ ] It's verified that the CD run is green
  - [ ] The new feature is manually used/tested/observed on the clone server. Testing of the new feature should (also) be done by a second, independent reviewer from the dev team
  - [ ] The feature branch is deployed to one of the dev servers with `Reset non-user related Docker Volumes & Re-populate` turned on, and it's verified that the CD run is green
- [ ] ELSE, the new version is deployed to one of the dev servers using this branch
  - [ ] Run with setting `Reset non-user related Docker Volumes & Re-populate` turned on 
  - [ ] It's verified that this version actually is the one deployed (check gitinfo for branch name and commit id!)
  - [ ] It's verified that the CD run is green
  - [ ] The new feature is manually used/tested/observed on dev server. Testing of the new feature should (also) be done by a second, independent reviewer from the dev team
- [ ] Confirm that the latest version (use the /gitinfo endpoint) of the feature branch is deployed to one of the dev servers (no longer enforced by GitHub)
- [ ] Ensure that the release notes are written in a way that is understandable to a non-technical audience.
