### PR TITLE
DALA-7244: Add free text reason comment in qa UI

### DIFF
--- a/dataland-backend-utils/src/main/kotlin/org/dataland/datalandbackendutils/utils/swaggerdocumentation/QaServiceOpenApiDescriptionsAndExamples.kt
+++ b/dataland-backend-utils/src/main/kotlin/org/dataland/datalandbackendutils/utils/swaggerdocumentation/QaServiceOpenApiDescriptionsAndExamples.kt
@@ -95,4 +95,10 @@ object QaServiceOpenApiDescriptionsAndExamples {
         "The unique identifier of the user whose QA report was " +
             "accepted for this data point, if applicable."
     const val ACCEPTED_REPORTER_USER_ID_EXAMPLE = UPLOADER_USER_ID_EXAMPLE
+
+    const val REASON_FOR_CUSTOM_DATA_POINT_DESCRIPTION =
+        "An optional comment explaining why a custom data point was created instead of " +
+            "accepting the original uploaded value or the QA bot suggestion. " +
+            "Only relevant when acceptedSource is Custom; null for all other sources."
+    const val REASON_FOR_CUSTOM_DATA_POINT_EXAMPLE = "The original value was incorrect and the QA report claimed there was not data found."
 }

--- a/dataland-backend-utils/src/main/kotlin/org/dataland/datalandbackendutils/utils/swaggerdocumentation/QaServiceOpenApiDescriptionsAndExamples.kt
+++ b/dataland-backend-utils/src/main/kotlin/org/dataland/datalandbackendutils/utils/swaggerdocumentation/QaServiceOpenApiDescriptionsAndExamples.kt
@@ -100,5 +100,5 @@ object QaServiceOpenApiDescriptionsAndExamples {
         "An optional comment explaining why a custom data point was created instead of " +
             "accepting the original uploaded value or the QA bot suggestion. " +
             "Only relevant when acceptedSource is Custom; null for all other sources."
-    const val REASON_FOR_CUSTOM_DATA_POINT_EXAMPLE = "The original value was incorrect and the QA report claimed there was not data found."
+    const val REASON_FOR_CUSTOM_DATA_POINT_EXAMPLE = "The original value was incorrect and the QA report claimed there was no data found."
 }

--- a/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/tests/DatasetJudgementTest.kt
+++ b/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/tests/DatasetJudgementTest.kt
@@ -37,6 +37,7 @@ class DatasetJudgementTest {
     private val dataPointType2 = "extendedDecimalScope2GhgEmissionsLocationBasedInTonnes"
     private val dataPointType3 = "extendedDecimalScope2GhgEmissionsMarketBasedInTonnes"
     private val customDataPoint = "{\"value\":1000,\"quality\":\"Reported\",\"comment\":null,\"dataSource\":null}"
+    private val customDataPointReason = "Both original and QA suggestion values were out of the expected range."
 
     private val dummyQaReport1 =
         QaReportDataPointString(
@@ -107,6 +108,7 @@ class DatasetJudgementTest {
                 val acceptedSource: AcceptedDataPointSource,
                 val reporterUserIdOfAcceptedQaReport: String? = null,
                 val customDataPoint: String? = null,
+                val reasonForCustomDataPoint: String? = null,
             )
             val explicitlyHandledDataPointIds = setOf(dataPointId1, dataPointId2, dataPointId3)
 
@@ -116,7 +118,7 @@ class DatasetJudgementTest {
                     PatchOperation(dataPointType2, AcceptedDataPointSource.Qa, reporterUserId2),
                     PatchOperation(dataPointType1, AcceptedDataPointSource.Original),
                     PatchOperation(dataPointType2, AcceptedDataPointSource.Qa, reporterUserId2),
-                    PatchOperation(dataPointType3, AcceptedDataPointSource.Custom, null, customDataPoint),
+                    PatchOperation(dataPointType3, AcceptedDataPointSource.Custom, null, customDataPoint, customDataPointReason),
                 ) +
                     dataPoints
                         .filter { (_, dataPointId) -> dataPointId !in explicitlyHandledDataPointIds }
@@ -133,6 +135,7 @@ class DatasetJudgementTest {
                         it.acceptedSource,
                         it.reporterUserIdOfAcceptedQaReport,
                         it.customDataPoint,
+                        it.reasonForCustomDataPoint,
                     ),
                 )
             }
@@ -170,9 +173,11 @@ class DatasetJudgementTest {
         assertNull(datasetJudgement.dataPoints[dataPointType1]?.reporterUserIdOfAcceptedQaReport)
 
         assertEquals(AcceptedDataPointSource.Qa, datasetJudgement.dataPoints[dataPointType2]?.acceptedSource)
+        assertNull(datasetJudgement.dataPoints[dataPointType2]?.reasonForCustomDataPoint)
 
         assertEquals(AcceptedDataPointSource.Custom, datasetJudgement.dataPoints[dataPointType3]?.acceptedSource)
         assertEquals(customDataPoint, datasetJudgement.dataPoints[dataPointType3]?.customValue)
+        assertEquals(customDataPointReason, datasetJudgement.dataPoints[dataPointType3]?.reasonForCustomDataPoint)
     }
 
     @Test

--- a/dataland-frontend/src/components/resources/datasetReview/JudgeDialog.vue
+++ b/dataland-frontend/src/components/resources/datasetReview/JudgeDialog.vue
@@ -166,7 +166,6 @@
     :dismissable-mask="false"
     :show-cancel-button="true"
     confirm-label="Proceed"
-    data-test="reason-warning-modal"
   />
 </template>
 

--- a/dataland-frontend/src/components/resources/datasetReview/JudgeDialog.vue
+++ b/dataland-frontend/src/components/resources/datasetReview/JudgeDialog.vue
@@ -162,7 +162,7 @@
     :is-loading="false"
     :is-success="false"
     @confirm="proceedWithNonCustomAccept"
-    @cancel="isReasonWarningModalVisible = false"
+    @cancel="cancelReasonWarningModal"
     :dismissable-mask="false"
     :show-cancel-button="true"
     confirm-label="Proceed"
@@ -695,6 +695,14 @@ function proceedWithNonCustomAccept(): void {
     executeAccept(pendingAcceptedSource.value);
     pendingAcceptedSource.value = null;
   }
+}
+
+/**
+ * Resets the state when the warning modal is closed by clicking "Cancel".
+ */
+function cancelReasonWarningModal(): void {
+  isReasonWarningModalVisible.value = false;
+  pendingAcceptedSource.value = null;
 }
 
 /**

--- a/dataland-frontend/src/components/resources/datasetReview/JudgeDialog.vue
+++ b/dataland-frontend/src/components/resources/datasetReview/JudgeDialog.vue
@@ -93,6 +93,7 @@
         v-model:edit-mode-enabled="editModeEnabled"
         v-model:json="customJson"
         v-model:form-data="customFormData"
+        v-model:reason-for-custom-data-point="reasonForCustomDataPoint"
         :accept-disabled="isPatching"
         :can-copy-original="!!originalData"
         :can-copy-corrected="!!currentQaCorrectedData"
@@ -152,6 +153,20 @@
     :dismissable-mask="true"
     :show-cancel-button="false"
     confirm-label="OK"
+  />
+  <PopupConfirmationModal
+    v-model:visible="isReasonWarningModalVisible"
+    header="Reason will be discarded"
+    message="You have entered a reason for a custom data point, but you're accepting a different source. The reason will be cleared if you proceed."
+    :error-message="undefined"
+    :is-loading="false"
+    :is-success="false"
+    @confirm="proceedWithNonCustomAccept"
+    @cancel="isReasonWarningModalVisible = false"
+    :dismissable-mask="false"
+    :show-cancel-button="true"
+    confirm-label="Proceed"
+    data-test="reason-warning-modal"
   />
 </template>
 
@@ -436,6 +451,11 @@ function goToNextReport(): void {
 const editModeEnabled = ref<boolean>(false);
 const customJson = ref<string>(DEFAULT_CUSTOM_JSON);
 const customFormData = ref<CustomFormData>({ ...DEFAULT_CUSTOM_FORM_DATA });
+const reasonForCustomDataPoint = ref<string>('');
+
+// Warning modal state for when a reason has been entered but a non-Custom source is accepted
+const isReasonWarningModalVisible = ref<boolean>(false);
+const pendingAcceptedSource = ref<AcceptedDataPointSource | null>(null);
 
 /**
  * Copies the original data point values into the custom section
@@ -581,6 +601,7 @@ function afterSuccessfulPatch(): void {
  * @param acceptedSource - The accepted data point source.
  * @param reporterUserIdOfAcceptedQaReport - The reporter user ID of the accepted QA report, if applicable.
  * @param customDataPoint - The custom data point JSON string, if applicable.
+ * @param reasonForCustomDataPoint - The reason for creating a custom data point, if applicable.
  * @param errorLogMessage - Message logged when the patch fails.
  * @returns Nothing.
  */
@@ -588,13 +609,14 @@ function patchCurrentDatapoint(
   acceptedSource: AcceptedDataPointSource,
   reporterUserIdOfAcceptedQaReport: string | undefined,
   customDataPoint: string | undefined,
+  reasonForCustomDataPoint: string | undefined,
   errorLogMessage: string
 ): void {
   patchJudgementDetail(
     {
       judgementId: props.datasetReviewId,
       dataPointTypeId: currentDataPointTypeId.value,
-      details: { acceptedSource, reporterUserIdOfAcceptedQaReport, customDataPoint },
+      details: { acceptedSource, reporterUserIdOfAcceptedQaReport, customDataPoint, reasonForCustomDataPoint },
     },
     {
       onSuccess: () => {
@@ -645,10 +667,44 @@ function patchCurrentDatapoint(
  * Central handler for accepting a data point from a given source
  * (original / QA / custom).
  *
+ * When a non-Custom source is selected but a reason for a custom data point has
+ * been entered, the Judge is asked to confirm before proceeding, since the reason
+ * will be discarded.
+ *
  * @param acceptedSource - The selected data point source to accept.
  * @returns Nothing.
  */
 function onAcceptClick(acceptedSource: AcceptedDataPointSource): void {
+  if (acceptedSource !== AcceptedDataPointSource.Custom && reasonForCustomDataPoint.value.trim().length > 0) {
+    pendingAcceptedSource.value = acceptedSource;
+    isReasonWarningModalVisible.value = true;
+    return;
+  }
+  executeAccept(acceptedSource);
+}
+
+/**
+ * Called when the Judge confirms they want to proceed after the reason-warning modal.
+ * Clears the reason and executes the pending acceptance.
+ *
+ * @returns Nothing.
+ */
+function proceedWithNonCustomAccept(): void {
+  isReasonWarningModalVisible.value = false;
+  reasonForCustomDataPoint.value = '';
+  if (pendingAcceptedSource.value !== null) {
+    executeAccept(pendingAcceptedSource.value);
+    pendingAcceptedSource.value = null;
+  }
+}
+
+/**
+ * Executes the accept action for the given source without any warnings.
+ *
+ * @param acceptedSource - The selected data point source to accept.
+ * @returns Nothing.
+ */
+function executeAccept(acceptedSource: AcceptedDataPointSource): void {
   switch (acceptedSource) {
     case AcceptedDataPointSource.Original:
       acceptOriginalDatapoint();
@@ -673,6 +729,7 @@ function acceptOriginalDatapoint(): void {
     AcceptedDataPointSource.Original,
     undefined,
     undefined,
+    undefined,
     `Error in patching datasetJudgement object for dataPointId: ${currentDataPointTypeId.value} with AcceptedDataPointSource.Original.`
   );
 }
@@ -688,6 +745,7 @@ function acceptQaReportDatapoint(): void {
   patchCurrentDatapoint(
     AcceptedDataPointSource.Qa,
     currentQaReport.value.reporterUserId,
+    undefined,
     undefined,
     `Error in patching datasetJudgement object for dataPointId: ${currentDataPointTypeId.value} with AcceptedDataPointSource.Qa and reporterUserId: ${currentQaReport.value.reporterUserId}`
   );
@@ -706,10 +764,12 @@ function acceptCustomDatapoint(): void {
     editModeEnabled.value ? customJson.value : parseFormDataToDataPointJson(customFormData.value, documentOption),
     originalDataPoint.value?.dataPoint ?? DEFAULT_CUSTOM_JSON
   );
+  const reason = reasonForCustomDataPoint.value.trim() || undefined;
   patchCurrentDatapoint(
     AcceptedDataPointSource.Custom,
     undefined,
     customDataPointJson,
+    reason,
     `Error in patching datasetJudgement object for dataPointType: ${currentDataPointTypeId.value} with AcceptedDataPointSource.Custom.`
   );
 }
@@ -737,12 +797,14 @@ function setCustomFormForCurrentDataPoint(judgementMetaData: DataPointJudgement 
       customFormData.value = parsed;
       const wrapped = wrapDataPointJson(judgementMetaData.customValue);
       customJson.value = wrapped === null ? judgementMetaData.customValue : JSON.stringify(wrapped, null, 2);
+      reasonForCustomDataPoint.value = judgementMetaData.reasonForCustomDataPoint ?? '';
       return;
     }
     console.error('Failed to parse previously accepted custom data point JSON');
   }
   customJson.value = DEFAULT_CUSTOM_JSON;
   customFormData.value = { ...DEFAULT_CUSTOM_FORM_DATA };
+  reasonForCustomDataPoint.value = '';
 }
 
 watch(currentDatapointJudgement, setCustomFormForCurrentDataPoint, { immediate: true });

--- a/dataland-frontend/src/components/resources/datasetReview/JudgeDialogCustomSection.vue
+++ b/dataland-frontend/src/components/resources/datasetReview/JudgeDialogCustomSection.vue
@@ -133,6 +133,24 @@
       />
     </div>
 
+    <div style="margin-top: var(--spacing-xs)">
+      <label
+        for="reason-for-custom-datapoint-field"
+        style="display: block; font-size: var(--font-size-xs); font-weight: var(--font-weight-semibold); margin-bottom: var(--spacing-xxs)"
+      >
+        Reason for custom data point
+      </label>
+      <Textarea
+        id="reason-for-custom-datapoint-field"
+        v-model="reasonForCustomDataPoint"
+        size="small"
+        spellcheck="false"
+        data-test="reason-for-custom-datapoint-field"
+        placeholder="Reason for custom data point (optional)"
+        style="width: 100%; height: 4rem; resize: none"
+      />
+    </div>
+
     <div style="margin-top: auto; padding-top: var(--spacing-xs)">
       <PrimeButton
         label="ACCEPT CUSTOM"
@@ -189,6 +207,7 @@ const jsonValue = defineModel<string>('json', {
 const formData = defineModel<CustomFormData>('formData', {
   default: () => DEFAULT_CUSTOM_FORM_DATA,
 });
+const reasonForCustomDataPoint = defineModel<string>('reasonForCustomDataPoint', { default: '' });
 
 const selectedDocumentOption = computed<DocumentOption | null>(
   () => props.availableDocuments?.find((doc) => doc.value === formData.value.document) ?? null

--- a/dataland-frontend/src/components/resources/datasetReview/JudgeDialogCustomSection.vue
+++ b/dataland-frontend/src/components/resources/datasetReview/JudgeDialogCustomSection.vue
@@ -136,11 +136,7 @@
     <div style="margin-top: var(--spacing-xs)">
       <label
         for="reason-for-custom-datapoint-field"
-        style="
-          display: block;
-          font-weight: var(--font-weight-semibold);
-          margin-bottom: var(--spacing-xxs);
-        "
+        style="display: block; font-weight: var(--font-weight-semibold); margin-bottom: var(--spacing-xxs)"
       >
         Reason for custom data point (internal only)
       </label>

--- a/dataland-frontend/src/components/resources/datasetReview/JudgeDialogCustomSection.vue
+++ b/dataland-frontend/src/components/resources/datasetReview/JudgeDialogCustomSection.vue
@@ -138,20 +138,18 @@
         for="reason-for-custom-datapoint-field"
         style="
           display: block;
-          font-size: var(--font-size-xs);
           font-weight: var(--font-weight-semibold);
           margin-bottom: var(--spacing-xxs);
         "
       >
-        Reason for custom data point
+        Reason for custom data point (internal only)
       </label>
       <Textarea
         id="reason-for-custom-datapoint-field"
         v-model="reasonForCustomDataPoint"
         size="small"
-        spellcheck="false"
         data-test="reason-for-custom-datapoint-field"
-        placeholder="Reason for custom data point (optional)"
+        placeholder="Reason for custom data point (optional, internal only)"
         style="width: 100%; height: 4rem; resize: none"
       />
     </div>

--- a/dataland-frontend/src/components/resources/datasetReview/JudgeDialogCustomSection.vue
+++ b/dataland-frontend/src/components/resources/datasetReview/JudgeDialogCustomSection.vue
@@ -136,7 +136,12 @@
     <div style="margin-top: var(--spacing-xs)">
       <label
         for="reason-for-custom-datapoint-field"
-        style="display: block; font-size: var(--font-size-xs); font-weight: var(--font-weight-semibold); margin-bottom: var(--spacing-xxs)"
+        style="
+          display: block;
+          font-size: var(--font-size-xs);
+          font-weight: var(--font-weight-semibold);
+          margin-bottom: var(--spacing-xxs);
+        "
       >
         Reason for custom data point
       </label>

--- a/dataland-frontend/tests/component/components/resources/datasetReview/JudgeDialog.cy.ts
+++ b/dataland-frontend/tests/component/components/resources/datasetReview/JudgeDialog.cy.ts
@@ -1403,4 +1403,176 @@ describe('JudgeDialog component tests', () => {
       checkOverflowBehavior(testCase);
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // 13. Reason for custom data point
+  // ---------------------------------------------------------------------------
+  describe('Reason for custom data point', () => {
+    it('shows the reason textarea in the custom section', () => {
+      mountJudgeDialog();
+
+      cy.get('[data-test="custom-datapoint-section"]').within(() => {
+        cy.get('[data-test="reason-for-custom-datapoint-field"]').should('be.visible');
+        cy.contains('Reason for custom data point').should('be.visible');
+      });
+    });
+
+    it('shows warning modal when accepting Original source with a non-blank reason', () => {
+      mountJudgeDialog();
+
+      cy.get('[data-test="reason-for-custom-datapoint-field"]').clear().type('my-custom-reason');
+      cy.get('[data-test="accept-original-button"]').click();
+
+      cy.get('[data-test="confirmation-modal"]').should('be.visible').and('contain.text', 'Reason will be discarded');
+    });
+
+    it('shows warning modal when accepting QA report source with a non-blank reason', () => {
+      mountJudgeDialog();
+
+      cy.get('[data-test="reason-for-custom-datapoint-field"]').clear().type('my-custom-reason');
+      cy.get('[data-test="accept-report-button"]').click();
+
+      cy.get('[data-test="confirmation-modal"]').should('be.visible').and('contain.text', 'Reason will be discarded');
+    });
+
+    it('does not show warning modal when accepting Custom source with a non-blank reason', () => {
+      mountJudgeDialog();
+
+      cy.get('[data-test="custom-value-field"]').clear().type('my-custom-value');
+      cy.get('[data-test="reason-for-custom-datapoint-field"]').clear().type('my-custom-reason');
+      cy.get('[data-test="accept-custom-button"]').click();
+
+      cy.wait('@patchJudgementDetail');
+      cy.get('[data-test="confirmation-modal"]').should('not.be.visible');
+    });
+
+    it('does not show warning modal when accepting Original source with a blank reason', () => {
+      mountJudgeDialog();
+
+      cy.get('[data-test="reason-for-custom-datapoint-field"]').should('have.value', '');
+      cy.get('[data-test="accept-original-button"]').click();
+
+      cy.wait('@patchJudgementDetail');
+      cy.get('[data-test="confirmation-modal"]').should('not.be.visible');
+    });
+
+    it('closes the warning modal and preserves the reason when clicking Go back', () => {
+      mountJudgeDialog();
+
+      cy.get('[data-test="reason-for-custom-datapoint-field"]').clear().type('reason-to-preserve');
+      cy.get('[data-test="accept-original-button"]').click();
+      cy.get('[data-test="confirmation-modal"]').should('be.visible').and('contain.text', 'Reason will be discarded');
+
+      cy.get('[data-test="cancel-confirmation-modal-button"]').click();
+
+      cy.get('[data-test="confirmation-modal"]').should('not.be.visible');
+      cy.get('[data-test="reason-for-custom-datapoint-field"]').should('have.value', 'reason-to-preserve');
+      cy.get('@patchJudgementDetail.all').should('have.length', 0);
+    });
+
+    it('clears the reason and fires PATCH when clicking Proceed on the warning modal', () => {
+      mountJudgeDialog();
+
+      cy.get('[data-test="reason-for-custom-datapoint-field"]').clear().type('reason-to-discard');
+      cy.get('[data-test="accept-original-button"]').click();
+      cy.get('[data-test="confirmation-modal"]').should('be.visible').and('contain.text', 'Reason will be discarded');
+
+      cy.get('[data-test="ok-confirmation-modal-button"]').click();
+
+      cy.wait('@patchJudgementDetail').then((interception) => {
+          expect(interception.request.body.acceptedSource).to.eq(AcceptedDataPointSource.Original);
+          expect(interception.request.body.reasonForCustomDataPoint).to.be.undefined;
+      });
+      cy.get('[data-test="reason-for-custom-datapoint-field"]').should('have.value', '');
+    });
+
+    it('advances to the next KPI after clicking Proceed on the warning modal', () => {
+      mountJudgeDialog();
+
+      cy.contains('KPI Alpha Label').should('be.visible');
+      cy.get('[data-test="reason-for-custom-datapoint-field"]').clear().type('reason-to-discard');
+      cy.get('[data-test="accept-original-button"]').click();
+      cy.get('[data-test="confirmation-modal"]').should('be.visible').and('contain.text', 'Reason will be discarded');
+
+      cy.get('[data-test="ok-confirmation-modal-button"]').click();
+      cy.wait('@patchJudgementDetail');
+
+      cy.get('[data-test^="judge-dialog-header-"]').should('contain.text', 'KPI Beta Label');
+      cy.get('[data-test^="judge-dialog-header-"]').should('not.contain.text', 'KPI Alpha Label');
+    });
+
+    it('includes reasonForCustomDataPoint in the PATCH body when accepting Custom source with a reason', () => {
+      mountJudgeDialog();
+
+      cy.get('[data-test="custom-value-field"]').clear().type('my-custom-value');
+      cy.get('[data-test="reason-for-custom-datapoint-field"]').clear().type('my-custom-reason');
+      cy.get('[data-test="accept-custom-button"]').click();
+
+      cy.wait('@patchJudgementDetail').then((interception) => {
+          expect(interception.request.body.acceptedSource).to.eq(AcceptedDataPointSource.Custom);
+          expect(interception.request.body.reasonForCustomDataPoint).to.eq('my-custom-reason');
+      });
+    });
+
+    it('omits reasonForCustomDataPoint from the PATCH body when accepting Custom source without a reason', () => {
+      mountJudgeDialog();
+
+      cy.get('[data-test="custom-value-field"]').clear().type('my-custom-value');
+      cy.get('[data-test="accept-custom-button"]').click();
+
+      cy.wait('@patchJudgementDetail').then((interception) => {
+        expect(interception.request.body.acceptedSource).to.eq(AcceptedDataPointSource.Custom);
+        expect(interception.request.body.reasonForCustomDataPoint).to.be.undefined;
+      });
+    });
+
+    it('pre-populates the reason textarea from a previously accepted custom data point', () => {
+      const previousCustomValue = { value: 'accepted-custom-val', quality: 'Audited' };
+      const judgementWithPreviousCustomAndReason: DatasetJudgementResponse = {
+        ...baseDatasetJudgement,
+        dataPoints: {
+          ...baseDatasetJudgement.dataPoints,
+          [dataPointTypeId]: {
+            ...baseDatasetJudgement.dataPoints[dataPointTypeId],
+            acceptedSource: AcceptedDataPointSource.Custom,
+            customValue: JSON.stringify(previousCustomValue),
+            reasonForCustomDataPoint: 'previously-saved-reason',
+          },
+        },
+      };
+      mountJudgeDialog({ datasetJudgement: judgementWithPreviousCustomAndReason });
+
+      cy.get('[data-test="reason-for-custom-datapoint-field"]').should('have.value', 'previously-saved-reason');
+    });
+
+    it('resets the reason textarea when navigating to a KPI without a previously accepted custom reason', () => {
+      const judgementWithMixedCustom: DatasetJudgementResponse = {
+        ...baseDatasetJudgement,
+        dataPoints: {
+          [dataPointTypeId]: {
+            ...baseDatasetJudgement.dataPoints[dataPointTypeId],
+            acceptedSource: AcceptedDataPointSource.Custom,
+            customValue: JSON.stringify({ value: 'accepted-custom-val', quality: 'Audited' }),
+            reasonForCustomDataPoint: 'should-be-cleared',
+          },
+          [secondDataPointTypeId]: {
+            dataPointType: secondDataPointTypeId,
+            dataPointId: secondDataPointId,
+            acceptedSource: undefined,
+            qaReports: [],
+          },
+        },
+      };
+      mountJudgeDialog({ datasetJudgement: judgementWithMixedCustom });
+
+      cy.get('[data-test="reason-for-custom-datapoint-field"]').should('have.value', 'should-be-cleared');
+
+      cy.get('[data-test="next-datapoint-select"]').click();
+      cy.get('.p-select-overlay').should('be.visible');
+      cy.contains('KPI Beta Label').click();
+      cy.get('[data-test="go-to-datapoint-button"]').click();
+
+      cy.get('[data-test="reason-for-custom-datapoint-field"]').should('have.value', '');
+    });
+  });
 });

--- a/dataland-frontend/tests/component/components/resources/datasetReview/JudgeDialog.cy.ts
+++ b/dataland-frontend/tests/component/components/resources/datasetReview/JudgeDialog.cy.ts
@@ -1480,8 +1480,8 @@ describe('JudgeDialog component tests', () => {
       cy.get('[data-test="ok-confirmation-modal-button"]').click();
 
       cy.wait('@patchJudgementDetail').then((interception) => {
-          expect(interception.request.body.acceptedSource).to.eq(AcceptedDataPointSource.Original);
-          expect(interception.request.body.reasonForCustomDataPoint).to.be.undefined;
+        expect(interception.request.body.acceptedSource).to.eq(AcceptedDataPointSource.Original);
+        expect(interception.request.body.reasonForCustomDataPoint).to.be.undefined;
       });
       cy.get('[data-test="reason-for-custom-datapoint-field"]').should('have.value', '');
     });
@@ -1509,8 +1509,8 @@ describe('JudgeDialog component tests', () => {
       cy.get('[data-test="accept-custom-button"]').click();
 
       cy.wait('@patchJudgementDetail').then((interception) => {
-          expect(interception.request.body.acceptedSource).to.eq(AcceptedDataPointSource.Custom);
-          expect(interception.request.body.reasonForCustomDataPoint).to.eq('my-custom-reason');
+        expect(interception.request.body.acceptedSource).to.eq(AcceptedDataPointSource.Custom);
+        expect(interception.request.body.reasonForCustomDataPoint).to.eq('my-custom-reason');
       });
     });
 

--- a/dataland-frontend/tests/component/components/resources/datasetReview/JudgeDialog.cy.ts
+++ b/dataland-frontend/tests/component/components/resources/datasetReview/JudgeDialog.cy.ts
@@ -1297,7 +1297,7 @@ describe('JudgeDialog component tests', () => {
       };
       mountJudgeDialog({ datasetJudgement: judgementWithCustomAccepted });
 
-      cy.get('[data-test="custom-datapoint-section"]').should('be.visible');
+      cy.get('[data-test="custom-datapoint-section"]').scrollIntoView().should('be.visible');
       cy.get('[data-test="original-datapoint-section"]').find('[data-test="accepted-check"]').should('not.exist');
       cy.get('[data-test="corrected-datapoint-section"]').find('[data-test="accepted-check"]').should('not.exist');
     });
@@ -1412,7 +1412,7 @@ describe('JudgeDialog component tests', () => {
       mountJudgeDialog();
 
       cy.get('[data-test="custom-datapoint-section"]').within(() => {
-        cy.get('[data-test="reason-for-custom-datapoint-field"]').should('be.visible');
+        cy.get('[data-test="reason-for-custom-datapoint-field"]').scrollIntoView().should('be.visible');
         cy.contains('Reason for custom data point').should('be.visible');
       });
     });
@@ -1443,7 +1443,7 @@ describe('JudgeDialog component tests', () => {
       cy.get('[data-test="accept-custom-button"]').click();
 
       cy.wait('@patchJudgementDetail');
-      cy.get('[data-test="confirmation-modal"]').should('not.be.visible');
+      cy.get('[data-test="confirmation-modal"]').should('not.exist');
     });
 
     it('does not show warning modal when accepting Original source with a blank reason', () => {
@@ -1453,7 +1453,7 @@ describe('JudgeDialog component tests', () => {
       cy.get('[data-test="accept-original-button"]').click();
 
       cy.wait('@patchJudgementDetail');
-      cy.get('[data-test="confirmation-modal"]').should('not.be.visible');
+      cy.get('[data-test="confirmation-modal"]').should('not.exist');
     });
 
     it('closes the warning modal and preserves the reason when clicking Go back', () => {
@@ -1465,7 +1465,7 @@ describe('JudgeDialog component tests', () => {
 
       cy.get('[data-test="cancel-confirmation-modal-button"]').click();
 
-      cy.get('[data-test="confirmation-modal"]').should('not.be.visible');
+      cy.get('[data-test="confirmation-modal"]').should('not.exist');
       cy.get('[data-test="reason-for-custom-datapoint-field"]').should('have.value', 'reason-to-preserve');
       cy.get('@patchJudgementDetail.all').should('have.length', 0);
     });

--- a/dataland-frontend/tests/e2e/specs/judgement/JudgementTestConfig.ts
+++ b/dataland-frontend/tests/e2e/specs/judgement/JudgementTestConfig.ts
@@ -33,6 +33,7 @@ export const QA_SCENARIO_CONFIG: QaScenarioConfig[] = [
     judgement: {
       acceptedSource: AcceptedDataPointSource.Custom,
       customValue: '400400400.23',
+      reasonForCustomDataPoint: 'Both the original and QA suggestion values were inconsistent with other data points.',
     },
   },
   {

--- a/dataland-frontend/tests/e2e/utils/CheckJudgement.ts
+++ b/dataland-frontend/tests/e2e/utils/CheckJudgement.ts
@@ -64,6 +64,14 @@ export function checkPatchDataPointsCalledCorrectly(interception: Interception, 
     expect(body.customDataPoint, 'customDataPoint in request body').to.not.be.undefined;
     expect(body.customDataPoint, 'customDataPoint in request body').to.not.be.null;
   }
+
+  if (judgement.reasonForCustomDataPoint == null) {
+    expect(body.reasonForCustomDataPoint ?? null, 'reasonForCustomDataPoint in request body').to.eq(null);
+  } else {
+    expect(body.reasonForCustomDataPoint, 'reasonForCustomDataPoint in request body').to.eq(
+      judgement.reasonForCustomDataPoint
+    );
+  }
 }
 
 /**
@@ -105,6 +113,12 @@ export function makeJudgementDecision(judgement: QaJudgement): void {
     cy.get('[data-test="custom-value-field"]').click();
     cy.get('[data-test="custom-value-field"]').clear();
     cy.get('[data-test="custom-value-field"]').type(judgement.customValue);
+  }
+
+  if (judgement.reasonForCustomDataPoint != null) {
+    cy.get('[data-test="reason-for-custom-datapoint-field"]').click();
+    cy.get('[data-test="reason-for-custom-datapoint-field"]').clear();
+    cy.get('[data-test="reason-for-custom-datapoint-field"]').type(judgement.reasonForCustomDataPoint);
   }
 
   if (judgement.acceptedSource === AcceptedDataPointSource.Original) {

--- a/dataland-frontend/tests/e2e/utils/CheckJudgementJson.ts
+++ b/dataland-frontend/tests/e2e/utils/CheckJudgementJson.ts
@@ -24,6 +24,7 @@ export interface QaJudgement {
   reporterUserIdOfAcceptedQaReport?: string;
   reporterUserNameOfAcceptedQaReport?: string;
   customValue?: string;
+  reasonForCustomDataPoint?: string;
 }
 
 export interface QaScenarioConfig {

--- a/dataland-qa-service/qaServiceOpenApi.json
+++ b/dataland-qa-service/qaServiceOpenApi.json
@@ -4383,7 +4383,7 @@
           "reasonForCustomDataPoint": {
             "type": "string",
             "description": "An optional comment explaining why a custom data point was created instead of accepting the original uploaded value or the QA bot suggestion. Only relevant when acceptedSource is Custom; null for all other sources.",
-            "example": "The original value was incorrect and the QA report claimed there was not data found."
+            "example": "The original value was incorrect and the QA report claimed there was no data found."
           }
         },
         "description": "Map with details for all datapoints in the dataset. The key is the datapoint type."
@@ -10081,7 +10081,7 @@
           "reasonForCustomDataPoint": {
             "type": "string",
             "description": "An optional comment explaining why a custom data point was created instead of accepting the original uploaded value or the QA bot suggestion. Only relevant when acceptedSource is Custom; null for all other sources.",
-            "example": "The original value was incorrect and the QA report claimed there was not data found."
+            "example": "The original value was incorrect and the QA report claimed there was no data found."
           }
         }
       },

--- a/dataland-qa-service/qaServiceOpenApi.json
+++ b/dataland-qa-service/qaServiceOpenApi.json
@@ -4350,7 +4350,9 @@
         "type": "object",
         "properties": {
           "dataPointType": {
-            "type": "string"
+            "type": "string",
+            "description": "The data point type of the provided data point.",
+            "example": "extendedEnumYesNoIsNfrdMandatory"
           },
           "dataPointId": {
             "type": "string",
@@ -4381,7 +4383,7 @@
           "reasonForCustomDataPoint": {
             "type": "string",
             "description": "An optional comment explaining why a custom data point was created instead of accepting the original uploaded value or the QA bot suggestion. Only relevant when acceptedSource is Custom; null for all other sources.",
-            "example": "The original value was missing and the QA suggestion was out of range."
+            "example": "The original value was incorrect and the QA report claimed there was not data found."
           }
         },
         "description": "Map with details for all datapoints in the dataset. The key is the datapoint type."
@@ -10079,7 +10081,7 @@
           "reasonForCustomDataPoint": {
             "type": "string",
             "description": "An optional comment explaining why a custom data point was created instead of accepting the original uploaded value or the QA bot suggestion. Only relevant when acceptedSource is Custom; null for all other sources.",
-            "example": "The original value was missing and the QA suggestion was out of range."
+            "example": "The original value was incorrect and the QA report claimed there was not data found."
           }
         }
       },

--- a/dataland-qa-service/qaServiceOpenApi.json
+++ b/dataland-qa-service/qaServiceOpenApi.json
@@ -4350,9 +4350,7 @@
         "type": "object",
         "properties": {
           "dataPointType": {
-            "type": "string",
-            "description": "The data point type of the provided data point.",
-            "example": "extendedEnumYesNoIsNfrdMandatory"
+            "type": "string"
           },
           "dataPointId": {
             "type": "string",
@@ -4379,6 +4377,11 @@
             "type": "string",
             "description": "Custom datapoints as json string to be uploaded.",
             "example": "{\"extendedDateFiscalYearEnd\":\" 2026-12-31 \"}"
+          },
+          "reasonForCustomDataPoint": {
+            "type": "string",
+            "description": "An optional comment explaining why a custom data point was created instead of accepting the original uploaded value or the QA bot suggestion. Only relevant when acceptedSource is Custom; null for all other sources.",
+            "example": "The original value was missing and the QA suggestion was out of range."
           }
         },
         "description": "Map with details for all datapoints in the dataset. The key is the datapoint type."
@@ -10072,6 +10075,11 @@
             "type": "string",
             "description": "The data point as a JSON string.",
             "example": "{\"value\":\"No\",\"quality\":\"Incomplete\",\"comment\":\"program neural circuit\",\"dataSource\":{\"page\":\"1026\",\"tagName\":\"web services\",\"fileName\":\"SustainabilityReport\",\"fileReference\":\"1902e40099c913ecf3715388cb2d9f7f84e6f02a19563db6930adb7b6cf22868\",\"publicationDate\":\"2024-01-07\"}}"
+          },
+          "reasonForCustomDataPoint": {
+            "type": "string",
+            "description": "An optional comment explaining why a custom data point was created instead of accepting the original uploaded value or the QA bot suggestion. Only relevant when acceptedSource is Custom; null for all other sources.",
+            "example": "The original value was missing and the QA suggestion was out of range."
           }
         }
       },

--- a/dataland-qa-service/src/main/kotlin/org/dataland/datalandqaservice/entities/DataPointJudgementEntity.kt
+++ b/dataland-qa-service/src/main/kotlin/org/dataland/datalandqaservice/entities/DataPointJudgementEntity.kt
@@ -34,6 +34,8 @@ class DataPointJudgementEntity(
     var reporterUserIdOfAcceptedQaReport: UUID?,
     @Column(columnDefinition = "TEXT", nullable = true)
     var customValue: String?,
+    @Column(columnDefinition = "TEXT", nullable = true)
+    var reasonForCustomDataPoint: String? = null,
     @JoinColumn(name = "dataset_judgement_id")
     @ManyToOne
     var datasetJudgement: DatasetJudgementEntity? = null,
@@ -49,5 +51,6 @@ class DataPointJudgementEntity(
             acceptedSource = acceptedSource,
             reporterUserIdOfAcceptedQaReport = reporterUserIdOfAcceptedQaReport,
             customValue = customValue,
+            reasonForCustomDataPoint = reasonForCustomDataPoint,
         )
 }

--- a/dataland-qa-service/src/main/kotlin/org/dataland/datalandqaservice/model/DataPointJudgement.kt
+++ b/dataland-qa-service/src/main/kotlin/org/dataland/datalandqaservice/model/DataPointJudgement.kt
@@ -19,6 +19,7 @@ import java.util.UUID
  * @property qaReports the QA report data points submitted for this data point type
  * @property acceptedSource which source was accepted for this data point
  * @property customValue the custom value accepted for this data point, if applicable
+ * @property reasonForCustomDataPoint an explanation for why a custom datapoint was needed
  */
 data class DataPointJudgement(
     @field:Schema(
@@ -50,4 +51,9 @@ data class DataPointJudgement(
         example = QaServiceOpenApiDescriptionsAndExamples.DATA_JUDGEMENT_CUSTOM_DATAPOINTS_EXAMPLE,
     )
     val customValue: String?,
+    @field:Schema(
+        description = QaServiceOpenApiDescriptionsAndExamples.REASON_FOR_CUSTOM_DATA_POINT_DESCRIPTION,
+        example = QaServiceOpenApiDescriptionsAndExamples.REASON_FOR_CUSTOM_DATA_POINT_EXAMPLE,
+    )
+    val reasonForCustomDataPoint: String?,
 )

--- a/dataland-qa-service/src/main/kotlin/org/dataland/datalandqaservice/model/reports/JudgementDetailsPatch.kt
+++ b/dataland-qa-service/src/main/kotlin/org/dataland/datalandqaservice/model/reports/JudgementDetailsPatch.kt
@@ -24,4 +24,9 @@ data class JudgementDetailsPatch(
         example = BackendOpenApiDescriptionsAndExamples.DATA_POINT_EXAMPLE,
     )
     var customDataPoint: String? = null,
+    @field:Schema(
+        description = QaServiceOpenApiDescriptionsAndExamples.REASON_FOR_CUSTOM_DATA_POINT_DESCRIPTION,
+        example = QaServiceOpenApiDescriptionsAndExamples.REASON_FOR_CUSTOM_DATA_POINT_EXAMPLE,
+    )
+    var reasonForCustomDataPoint: String? = null,
 )

--- a/dataland-qa-service/src/main/kotlin/org/dataland/datalandqaservice/services/DatasetJudgementService.kt
+++ b/dataland-qa-service/src/main/kotlin/org/dataland/datalandqaservice/services/DatasetJudgementService.kt
@@ -202,6 +202,7 @@ class DatasetJudgementService
                     dataPoint.apply {
                         this.acceptedSource = AcceptedDataPointSource.Original
                         this.reporterUserIdOfAcceptedQaReport = null
+                        this.reasonForCustomDataPoint = null
                     }
                 }
 
@@ -214,6 +215,7 @@ class DatasetJudgementService
                         this.acceptedSource = AcceptedDataPointSource.Qa
                         this.reporterUserIdOfAcceptedQaReport =
                             UUID.fromString(patch.reporterUserIdOfAcceptedQaReport)
+                        this.reasonForCustomDataPoint = null
                     }
                 }
 
@@ -222,6 +224,7 @@ class DatasetJudgementService
                     dataPoint.apply {
                         this.acceptedSource = AcceptedDataPointSource.Custom
                         this.reporterUserIdOfAcceptedQaReport = null
+                        this.reasonForCustomDataPoint = patch.reasonForCustomDataPoint
                     }
                 }
 

--- a/dataland-qa-service/src/test/kotlin/org/dataland/datalandqaservice/controller/DatasetJudgementControllerTest.kt
+++ b/dataland-qa-service/src/test/kotlin/org/dataland/datalandqaservice/controller/DatasetJudgementControllerTest.kt
@@ -123,7 +123,7 @@ class DatasetJudgementControllerTest {
     fun `patchJudgementDetails delegates to service with all params`() {
         val judgeId = UUID.randomUUID()
         val dataPointType = "dummyType"
-        val patch = JudgementDetailsPatch(AcceptedDataPointSource.Qa, UUID.randomUUID().toString(), null)
+        val patch = JudgementDetailsPatch(AcceptedDataPointSource.Qa, UUID.randomUUID().toString())
         val serviceResponse = mock<DatasetJudgementResponse>()
 
         whenever(

--- a/dataland-qa-service/src/test/kotlin/org/dataland/datalandqaservice/services/DatasetJudgementServicePatchTest.kt
+++ b/dataland-qa-service/src/test/kotlin/org/dataland/datalandqaservice/services/DatasetJudgementServicePatchTest.kt
@@ -1,0 +1,212 @@
+package org.dataland.datalandqaservice.services
+
+import org.dataland.datalandbackendutils.exceptions.ConflictApiException
+import org.dataland.datalandbackendutils.exceptions.InsufficientRightsApiException
+import org.dataland.datalandbackendutils.exceptions.InvalidInputApiException
+import org.dataland.datalandqaservice.model.reports.AcceptedDataPointSource
+import org.dataland.datalandqaservice.org.dataland.datalandqaservice.entities.DataPointJudgementEntity
+import org.dataland.datalandqaservice.org.dataland.datalandqaservice.model.reports.JudgementDetailsPatch
+import org.dataland.keycloakAdapter.auth.DatalandRealmRole
+import org.dataland.keycloakAdapter.utils.AuthenticationMock
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.any
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.util.UUID
+import org.dataland.datalandbackend.openApiClient.infrastructure.ClientException as BackendClientException
+
+class DatasetJudgementServicePatchTest : DatasetJudgementServiceTestBase() {
+    private fun patchAndGetDataPoint(
+        source: AcceptedDataPointSource?,
+        reporterUserId: String? = null,
+        customValue: String? = null,
+        reasonForCustomDataPoint: String? = null,
+        dataPointType: String = mockDatasetJudgementEntityForTest.DUMMY_DATA_POINT_TYPE,
+    ): DataPointJudgementEntity {
+        service.patchJudgementDetails(
+            UUID.randomUUID(),
+            dataPointType,
+            JudgementDetailsPatch(source, reporterUserId, customValue, reasonForCustomDataPoint),
+        )
+
+        return captureSavedJudgement()
+            .dataPoints
+            .first { it.dataPointType == dataPointType }
+    }
+
+    @Test
+    fun `patchJudgementDetails with Original sets acceptedSource and clears AcceptedQaReport source`() {
+        val saved = patchAndGetDataPoint(AcceptedDataPointSource.Original)
+
+        assertEquals(AcceptedDataPointSource.Original, saved.acceptedSource)
+        assertNull(saved.reporterUserIdOfAcceptedQaReport)
+    }
+
+    @Test
+    fun `patchJudgementDetails with Qa sets acceptedSource and AcceptedQaReport source`() {
+        val saved =
+            patchAndGetDataPoint(
+                AcceptedDataPointSource.Qa,
+                reporterUserId = mockDatasetJudgementEntityForTest.dummyUserId.toString(),
+            )
+
+        assertEquals(AcceptedDataPointSource.Qa, saved.acceptedSource)
+        assertEquals(mockDatasetJudgementEntityForTest.dummyUserId, saved.reporterUserIdOfAcceptedQaReport)
+    }
+
+    @Test
+    fun `patchJudgementDetails with Custom sets acceptedSource and clears AcceptedQaReport source`() {
+        val saved =
+            patchAndGetDataPoint(
+                AcceptedDataPointSource.Custom,
+                customValue = mockDatasetJudgementEntityForTest.CUSTOM_VALUE,
+            )
+
+        assertEquals(AcceptedDataPointSource.Custom, saved.acceptedSource)
+        assertNull(saved.reporterUserIdOfAcceptedQaReport)
+    }
+
+    @Test
+    fun `patchJudgementDetails with Custom and non-null reason stores reason on entity`() {
+        val saved =
+            patchAndGetDataPoint(
+                AcceptedDataPointSource.Custom,
+                customValue = mockDatasetJudgementEntityForTest.CUSTOM_VALUE,
+                reasonForCustomDataPoint = mockDatasetJudgementEntityForTest.REASON_FOR_CUSTOM_DATAPOINT,
+            )
+
+        assertEquals(AcceptedDataPointSource.Custom, saved.acceptedSource)
+        assertEquals(mockDatasetJudgementEntityForTest.REASON_FOR_CUSTOM_DATAPOINT, saved.reasonForCustomDataPoint)
+    }
+
+    @Test
+    fun `patchJudgementDetails with Custom and null reason stores null on entity`() {
+        val saved =
+            patchAndGetDataPoint(
+                AcceptedDataPointSource.Custom,
+                customValue = mockDatasetJudgementEntityForTest.CUSTOM_VALUE,
+                reasonForCustomDataPoint = null,
+            )
+
+        assertEquals(AcceptedDataPointSource.Custom, saved.acceptedSource)
+        assertNull(saved.reasonForCustomDataPoint)
+    }
+
+    @Test
+    fun `patchJudgementDetails with Original clears reasonForCustomDataPoint`() {
+        datasetJudgementEntity.dataPoints.first().apply {
+            reasonForCustomDataPoint = mockDatasetJudgementEntityForTest.REASON_FOR_CUSTOM_DATAPOINT
+        }
+
+        val saved = patchAndGetDataPoint(AcceptedDataPointSource.Original)
+
+        assertEquals(AcceptedDataPointSource.Original, saved.acceptedSource)
+        assertNull(saved.reasonForCustomDataPoint)
+    }
+
+    @Test
+    fun `patchJudgementDetails with Qa clears reasonForCustomDataPoint`() {
+        datasetJudgementEntity.dataPoints.first().apply {
+            reasonForCustomDataPoint = mockDatasetJudgementEntityForTest.REASON_FOR_CUSTOM_DATAPOINT
+        }
+
+        val saved =
+            patchAndGetDataPoint(
+                AcceptedDataPointSource.Qa,
+                reporterUserId = mockDatasetJudgementEntityForTest.dummyUserId.toString(),
+            )
+
+        assertEquals(AcceptedDataPointSource.Qa, saved.acceptedSource)
+        assertNull(saved.reasonForCustomDataPoint)
+    }
+
+    @Test
+    fun `patchJudgementDetails throws ConflictApiException when acceptedSource is custom and no customValue is provided`() {
+        assertThrows<ConflictApiException> {
+            service.patchJudgementDetails(
+                UUID.randomUUID(),
+                mockDatasetJudgementEntityForTest.DUMMY_DATA_POINT_TYPE,
+                JudgementDetailsPatch(AcceptedDataPointSource.Custom, null, null),
+            )
+        }
+    }
+
+    @Test
+    fun `patchJudgementDetails with only customValue validates and sets customValue`() {
+        val saved =
+            patchAndGetDataPoint(
+                source = null,
+                customValue = mockDatasetJudgementEntityForTest.CUSTOM_VALUE,
+            )
+
+        assertEquals(mockDatasetJudgementEntityForTest.CUSTOM_VALUE, saved.customValue)
+        verify(datasetJudgementSupportService)
+            .validateCustomDataPoint(
+                mockDatasetJudgementEntityForTest.CUSTOM_VALUE,
+                mockDatasetJudgementEntityForTest.DUMMY_DATA_POINT_TYPE,
+            )
+    }
+
+    @Test
+    fun `patchJudgementDetails with Qa without reporterUserIdOfAcceptedQaReport throws InvalidInputApiException`() {
+        assertThrows<InvalidInputApiException> {
+            service.patchJudgementDetails(
+                UUID.randomUUID(),
+                mockDatasetJudgementEntityForTest.DUMMY_DATA_POINT_TYPE,
+                JudgementDetailsPatch(
+                    AcceptedDataPointSource.Qa,
+                    null,
+                    null,
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `patchJudgementDetails throws InvalidInputApiException when dataPointType not in judgement`() {
+        assertThrows<InvalidInputApiException> {
+            service.patchJudgementDetails(
+                UUID.randomUUID(),
+                "unknown-type",
+                JudgementDetailsPatch(AcceptedDataPointSource.Original, null, null),
+            )
+        }
+    }
+
+    @Test
+    fun `patchJudgementDetails throws InsufficientRights when user is not judge`() {
+        AuthenticationMock.mockSecurityContext(
+            "other@example.com",
+            UUID.randomUUID().toString(),
+            setOf(DatalandRealmRole.ROLE_UPLOADER),
+        )
+
+        assertThrows<InsufficientRightsApiException> {
+            service.patchJudgementDetails(
+                UUID.randomUUID(),
+                mockDatasetJudgementEntityForTest.DUMMY_DATA_POINT_TYPE,
+                JudgementDetailsPatch(AcceptedDataPointSource.Original, null, null),
+            )
+        }
+    }
+
+    @Test
+    fun `patchJudgementDetails with Custom wraps BackendClientException into InvalidInputApiException`() {
+        whenever(datasetJudgementSupportService.validateCustomDataPoint(any(), any()))
+            .thenThrow(BackendClientException())
+
+        assertThrows<InvalidInputApiException> {
+            service.patchJudgementDetails(
+                UUID.randomUUID(),
+                mockDatasetJudgementEntityForTest.DUMMY_DATA_POINT_TYPE,
+                JudgementDetailsPatch(null, null, """{"value": 1}"""),
+            )
+        }.also { exception ->
+            assertTrue(exception.cause is BackendClientException)
+        }
+    }
+}

--- a/dataland-qa-service/src/test/kotlin/org/dataland/datalandqaservice/services/DatasetJudgementServiceTest.kt
+++ b/dataland-qa-service/src/test/kotlin/org/dataland/datalandqaservice/services/DatasetJudgementServiceTest.kt
@@ -114,12 +114,13 @@ class DatasetJudgementServiceTest {
         source: AcceptedDataPointSource?,
         reporterUserId: String? = null,
         customValue: String? = null,
+        reasonForCustomDataPoint: String? = null,
         dataPointType: String = mockDatasetJudgementEntityForTest.DUMMY_DATA_POINT_TYPE,
     ): DataPointJudgementEntity {
         service.patchJudgementDetails(
             UUID.randomUUID(),
             dataPointType,
-            JudgementDetailsPatch(source, reporterUserId, customValue),
+            JudgementDetailsPatch(source, reporterUserId, customValue, reasonForCustomDataPoint),
         )
 
         return captureSavedJudgement()
@@ -327,6 +328,77 @@ class DatasetJudgementServiceTest {
 
         assertEquals(AcceptedDataPointSource.Custom, saved.acceptedSource)
         assertNull(saved.reporterUserIdOfAcceptedQaReport)
+    }
+
+    @Test
+    fun `patchJudgementDetails with Custom and non-null reason stores reason on entity`() {
+        val saved =
+            patchAndGetDataPoint(
+                AcceptedDataPointSource.Custom,
+                customValue = mockDatasetJudgementEntityForTest.CUSTOM_VALUE,
+                reasonForCustomDataPoint = mockDatasetJudgementEntityForTest.REASON_FOR_CUSTOM_DATAPOINT,
+            )
+
+        assertEquals(AcceptedDataPointSource.Custom, saved.acceptedSource)
+        assertEquals(mockDatasetJudgementEntityForTest.REASON_FOR_CUSTOM_DATAPOINT, saved.reasonForCustomDataPoint)
+    }
+
+    @Test
+    fun `patchJudgementDetails with Custom and null reason stores null on entity`() {
+        val saved =
+            patchAndGetDataPoint(
+                AcceptedDataPointSource.Custom,
+                customValue = mockDatasetJudgementEntityForTest.CUSTOM_VALUE,
+                reasonForCustomDataPoint = null,
+            )
+
+        assertEquals(AcceptedDataPointSource.Custom, saved.acceptedSource)
+        assertNull(saved.reasonForCustomDataPoint)
+    }
+
+    @Test
+    fun `patchJudgementDetails with Original clears reasonForCustomDataPoint`() {
+        datasetJudgementEntity.dataPoints.first().apply {
+            reasonForCustomDataPoint = mockDatasetJudgementEntityForTest.REASON_FOR_CUSTOM_DATAPOINT
+        }
+
+        val saved = patchAndGetDataPoint(AcceptedDataPointSource.Original)
+
+        assertEquals(AcceptedDataPointSource.Original, saved.acceptedSource)
+        assertNull(saved.reasonForCustomDataPoint)
+    }
+
+    @Test
+    fun `patchJudgementDetails with Qa clears reasonForCustomDataPoint`() {
+        datasetJudgementEntity.dataPoints.first().apply {
+            reasonForCustomDataPoint = mockDatasetJudgementEntityForTest.REASON_FOR_CUSTOM_DATAPOINT
+        }
+
+        val saved =
+            patchAndGetDataPoint(
+                AcceptedDataPointSource.Qa,
+                reporterUserId = mockDatasetJudgementEntityForTest.dummyUserId.toString(),
+            )
+
+        assertEquals(AcceptedDataPointSource.Qa, saved.acceptedSource)
+        assertNull(saved.reasonForCustomDataPoint)
+    }
+
+    @Test
+    fun `getDatasetJudgementById includes reasonForCustomDataPoint when set and null when not set`() {
+        val judgementIdWithReasonForCustomDataPoint = UUID.randomUUID()
+        doReturn(mockDatasetJudgementEntityForTest.createDummyDatasetJudgementEntityWithCustomSource())
+            .whenever(datasetJudgementSupportService)
+            .getDatasetJudgementEntityById(judgementIdWithReasonForCustomDataPoint)
+
+        listOf(Pair(UUID.randomUUID(), null), Pair(judgementIdWithReasonForCustomDataPoint, mockDatasetJudgementEntityForTest.REASON_FOR_CUSTOM_DATAPOINT))
+            .forEach { (judgementId, expectedReason) ->
+                assertEquals(
+                    expectedReason,
+                    service.getDatasetJudgementById(judgementId)
+                        .dataPoints[mockDatasetJudgementEntityForTest.DUMMY_DATA_POINT_TYPE]
+                        ?.reasonForCustomDataPoint)
+            }
     }
 
     @Test

--- a/dataland-qa-service/src/test/kotlin/org/dataland/datalandqaservice/services/DatasetJudgementServiceTest.kt
+++ b/dataland-qa-service/src/test/kotlin/org/dataland/datalandqaservice/services/DatasetJudgementServiceTest.kt
@@ -391,8 +391,10 @@ class DatasetJudgementServiceTest {
             .whenever(datasetJudgementSupportService)
             .getDatasetJudgementEntityById(judgementIdWithReasonForCustomDataPoint)
 
-        listOf(Pair(UUID.randomUUID(), null), Pair(judgementIdWithReasonForCustomDataPoint, mockDatasetJudgementEntityForTest.REASON_FOR_CUSTOM_DATAPOINT))
-            .forEach { (judgementId, expectedReason) ->
+        listOf(
+            Pair(UUID.randomUUID(), null),
+            Pair(judgementIdWithReasonForCustomDataPoint, mockDatasetJudgementEntityForTest.REASON_FOR_CUSTOM_DATAPOINT)
+        ).forEach { (judgementId, expectedReason) ->
                 assertEquals(
                     expectedReason,
                     service.getDatasetJudgementById(judgementId)

--- a/dataland-qa-service/src/test/kotlin/org/dataland/datalandqaservice/services/DatasetJudgementServiceTest.kt
+++ b/dataland-qa-service/src/test/kotlin/org/dataland/datalandqaservice/services/DatasetJudgementServiceTest.kt
@@ -1,133 +1,26 @@
 package org.dataland.datalandqaservice.services
 
-import org.dataland.datalandbackend.openApiClient.api.DataPointControllerApi
 import org.dataland.datalandbackendutils.exceptions.ConflictApiException
 import org.dataland.datalandbackendutils.exceptions.InsufficientRightsApiException
 import org.dataland.datalandbackendutils.exceptions.InvalidInputApiException
 import org.dataland.datalandbackendutils.exceptions.ResourceNotFoundApiException
-import org.dataland.datalandbackendutils.model.KeycloakUserInfo
-import org.dataland.datalandbackendutils.services.KeycloakUserService
-import org.dataland.datalandqaservice.configurations.PreApprovalExemptFieldsConfig
 import org.dataland.datalandqaservice.model.reports.AcceptedDataPointSource
 import org.dataland.datalandqaservice.model.reports.QaReportDataPointVerdict
-import org.dataland.datalandqaservice.org.dataland.datalandqaservice.entities.DataPointJudgementEntity
 import org.dataland.datalandqaservice.org.dataland.datalandqaservice.entities.DataPointQaReportEntity
 import org.dataland.datalandqaservice.org.dataland.datalandqaservice.entities.DatasetJudgementEntity
 import org.dataland.datalandqaservice.org.dataland.datalandqaservice.model.DatasetJudgementResponse
 import org.dataland.datalandqaservice.org.dataland.datalandqaservice.model.DatasetJudgementState
-import org.dataland.datalandqaservice.org.dataland.datalandqaservice.model.reports.JudgementDetailsPatch
-import org.dataland.datalandqaservice.org.dataland.datalandqaservice.repositories.DatasetJudgementRepository
-import org.dataland.datalandqaservice.org.dataland.datalandqaservice.services.DataPointQaReviewManager
-import org.dataland.datalandqaservice.org.dataland.datalandqaservice.services.DatasetJudgementCreationService
-import org.dataland.datalandqaservice.org.dataland.datalandqaservice.services.DatasetJudgementFinalizationService
-import org.dataland.datalandqaservice.org.dataland.datalandqaservice.services.DatasetJudgementService
-import org.dataland.datalandqaservice.org.dataland.datalandqaservice.services.DatasetJudgementSupportService
-import org.dataland.datalandqaservice.org.dataland.datalandqaservice.services.PreApprovalService
-import org.dataland.datalandqaservice.org.dataland.datalandqaservice.services.QaReviewManager
-import org.dataland.datalandqaservice.utils.MockDatasetJudgementEntityForTest
 import org.dataland.keycloakAdapter.auth.DatalandRealmRole
 import org.dataland.keycloakAdapter.utils.AuthenticationMock
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNull
-import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.any
-import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
-import org.mockito.kotlin.mock
-import org.mockito.kotlin.reset
-import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.util.UUID
-import org.dataland.datalandbackend.openApiClient.infrastructure.ClientException as BackendClientException
 
-class DatasetJudgementServiceTest {
-    private val datasetJudgementRepository = mock<DatasetJudgementRepository>()
-    private val datasetJudgementSupportService = mock<DatasetJudgementSupportService>()
-    private val keycloakUserService = mock<KeycloakUserService>()
-    private val datasetJudgementFinalizationService =
-        DatasetJudgementFinalizationService(
-            mock<DataPointControllerApi>(),
-            mock<DataPointQaReviewManager>(),
-            mock<QaReviewManager>(),
-        )
-
-    private val creationServiceClass =
-        DatasetJudgementCreationService(
-            datasetJudgementSupportService,
-            keycloakUserService,
-            PreApprovalService(autoPreApprovalEnabled = false, exemptFieldsConfig = PreApprovalExemptFieldsConfig()),
-        )
-
-    private val service =
-        DatasetJudgementService(
-            datasetJudgementRepository,
-            datasetJudgementSupportService,
-            creationServiceClass,
-            datasetJudgementFinalizationService,
-        )
-
-    private val mockDatasetJudgementEntityForTest = MockDatasetJudgementEntityForTest
-    private val datasetJudgementEntity = mockDatasetJudgementEntityForTest.createDummyDatasetJudgementEntity()
-    private val dummyMetaData = mockDatasetJudgementEntityForTest.createDummyMetaData()
-
-    @BeforeEach
-    fun setup() {
-        reset(
-            datasetJudgementRepository,
-            datasetJudgementSupportService,
-        )
-
-        AuthenticationMock.mockSecurityContext(
-            "data.admin@example.com",
-            mockDatasetJudgementEntityForTest.dummyUserId.toString(),
-            setOf(DatalandRealmRole.ROLE_ADMIN),
-        )
-
-        doReturn(datasetJudgementEntity)
-            .whenever(datasetJudgementSupportService)
-            .getDatasetJudgementEntityById(any())
-
-        whenever(datasetJudgementRepository.save(any<DatasetJudgementEntity>()))
-            .thenAnswer { it.arguments[0] as DatasetJudgementEntity }
-
-        doReturn(
-            KeycloakUserInfo(
-                mockDatasetJudgementEntityForTest.DUMMY_USER_EMAIL,
-                mockDatasetJudgementEntityForTest.dummyUserId.toString(),
-                mockDatasetJudgementEntityForTest.DUMMY_USER_FIRST_NAME,
-                mockDatasetJudgementEntityForTest.DUMMY_USER_LAST_NAME,
-            ),
-        ).whenever(keycloakUserService)
-            .getUser(any())
-    }
-
-    private fun captureSavedJudgement(): DatasetJudgementEntity {
-        val captor = argumentCaptor<DatasetJudgementEntity>()
-        verify(datasetJudgementRepository).save(captor.capture())
-        return captor.firstValue
-    }
-
-    private fun patchAndGetDataPoint(
-        source: AcceptedDataPointSource?,
-        reporterUserId: String? = null,
-        customValue: String? = null,
-        reasonForCustomDataPoint: String? = null,
-        dataPointType: String = mockDatasetJudgementEntityForTest.DUMMY_DATA_POINT_TYPE,
-    ): DataPointJudgementEntity {
-        service.patchJudgementDetails(
-            UUID.randomUUID(),
-            dataPointType,
-            JudgementDetailsPatch(source, reporterUserId, customValue, reasonForCustomDataPoint),
-        )
-
-        return captureSavedJudgement()
-            .dataPoints
-            .first { it.dataPointType == dataPointType }
-    }
-
+class DatasetJudgementServiceTest : DatasetJudgementServiceTestBase() {
     private fun assertMatches(
         entity: DatasetJudgementEntity,
         response: DatasetJudgementResponse,
@@ -176,6 +69,27 @@ class DatasetJudgementServiceTest {
 
         assertThrows<ResourceNotFoundApiException> {
             service.getDatasetJudgementById(mockDatasetJudgementEntityForTest.dummyDatasetId)
+        }
+    }
+
+    @Test
+    fun `getDatasetJudgementById includes reasonForCustomDataPoint when set and null when not set`() {
+        val judgementIdWithReasonForCustomDataPoint = UUID.randomUUID()
+        doReturn(mockDatasetJudgementEntityForTest.createDummyDatasetJudgementEntityWithCustomSource())
+            .whenever(datasetJudgementSupportService)
+            .getDatasetJudgementEntityById(judgementIdWithReasonForCustomDataPoint)
+
+        listOf(
+            Pair(UUID.randomUUID(), null),
+            Pair(judgementIdWithReasonForCustomDataPoint, mockDatasetJudgementEntityForTest.REASON_FOR_CUSTOM_DATAPOINT),
+        ).forEach { (judgementId, expectedReason) ->
+            assertEquals(
+                expectedReason,
+                service
+                    .getDatasetJudgementById(judgementId)
+                    .dataPoints[mockDatasetJudgementEntityForTest.DUMMY_DATA_POINT_TYPE]
+                    ?.reasonForCustomDataPoint,
+            )
         }
     }
 
@@ -295,199 +209,6 @@ class DatasetJudgementServiceTest {
 
         assertThrows<ConflictApiException> {
             service.postDatasetJudgement(UUID.randomUUID())
-        }
-    }
-
-    @Test
-    fun `patchJudgementDetails with Original sets acceptedSource and clears AcceptedQaReport source`() {
-        val saved = patchAndGetDataPoint(AcceptedDataPointSource.Original)
-
-        assertEquals(AcceptedDataPointSource.Original, saved.acceptedSource)
-        assertNull(saved.reporterUserIdOfAcceptedQaReport)
-    }
-
-    @Test
-    fun `patchJudgementDetails with Qa sets acceptedSource and AcceptedQaReport source`() {
-        val saved =
-            patchAndGetDataPoint(
-                AcceptedDataPointSource.Qa,
-                reporterUserId = mockDatasetJudgementEntityForTest.dummyUserId.toString(),
-            )
-
-        assertEquals(AcceptedDataPointSource.Qa, saved.acceptedSource)
-        assertEquals(mockDatasetJudgementEntityForTest.dummyUserId, saved.reporterUserIdOfAcceptedQaReport)
-    }
-
-    @Test
-    fun `patchJudgementDetails with Custom sets acceptedSource and clears AcceptedQaReport source`() {
-        val saved =
-            patchAndGetDataPoint(
-                AcceptedDataPointSource.Custom,
-                customValue = mockDatasetJudgementEntityForTest.CUSTOM_VALUE,
-            )
-
-        assertEquals(AcceptedDataPointSource.Custom, saved.acceptedSource)
-        assertNull(saved.reporterUserIdOfAcceptedQaReport)
-    }
-
-    @Test
-    fun `patchJudgementDetails with Custom and non-null reason stores reason on entity`() {
-        val saved =
-            patchAndGetDataPoint(
-                AcceptedDataPointSource.Custom,
-                customValue = mockDatasetJudgementEntityForTest.CUSTOM_VALUE,
-                reasonForCustomDataPoint = mockDatasetJudgementEntityForTest.REASON_FOR_CUSTOM_DATAPOINT,
-            )
-
-        assertEquals(AcceptedDataPointSource.Custom, saved.acceptedSource)
-        assertEquals(mockDatasetJudgementEntityForTest.REASON_FOR_CUSTOM_DATAPOINT, saved.reasonForCustomDataPoint)
-    }
-
-    @Test
-    fun `patchJudgementDetails with Custom and null reason stores null on entity`() {
-        val saved =
-            patchAndGetDataPoint(
-                AcceptedDataPointSource.Custom,
-                customValue = mockDatasetJudgementEntityForTest.CUSTOM_VALUE,
-                reasonForCustomDataPoint = null,
-            )
-
-        assertEquals(AcceptedDataPointSource.Custom, saved.acceptedSource)
-        assertNull(saved.reasonForCustomDataPoint)
-    }
-
-    @Test
-    fun `patchJudgementDetails with Original clears reasonForCustomDataPoint`() {
-        datasetJudgementEntity.dataPoints.first().apply {
-            reasonForCustomDataPoint = mockDatasetJudgementEntityForTest.REASON_FOR_CUSTOM_DATAPOINT
-        }
-
-        val saved = patchAndGetDataPoint(AcceptedDataPointSource.Original)
-
-        assertEquals(AcceptedDataPointSource.Original, saved.acceptedSource)
-        assertNull(saved.reasonForCustomDataPoint)
-    }
-
-    @Test
-    fun `patchJudgementDetails with Qa clears reasonForCustomDataPoint`() {
-        datasetJudgementEntity.dataPoints.first().apply {
-            reasonForCustomDataPoint = mockDatasetJudgementEntityForTest.REASON_FOR_CUSTOM_DATAPOINT
-        }
-
-        val saved =
-            patchAndGetDataPoint(
-                AcceptedDataPointSource.Qa,
-                reporterUserId = mockDatasetJudgementEntityForTest.dummyUserId.toString(),
-            )
-
-        assertEquals(AcceptedDataPointSource.Qa, saved.acceptedSource)
-        assertNull(saved.reasonForCustomDataPoint)
-    }
-
-    @Test
-    fun `getDatasetJudgementById includes reasonForCustomDataPoint when set and null when not set`() {
-        val judgementIdWithReasonForCustomDataPoint = UUID.randomUUID()
-        doReturn(mockDatasetJudgementEntityForTest.createDummyDatasetJudgementEntityWithCustomSource())
-            .whenever(datasetJudgementSupportService)
-            .getDatasetJudgementEntityById(judgementIdWithReasonForCustomDataPoint)
-
-        listOf(
-            Pair(UUID.randomUUID(), null),
-            Pair(judgementIdWithReasonForCustomDataPoint, mockDatasetJudgementEntityForTest.REASON_FOR_CUSTOM_DATAPOINT),
-        ).forEach { (judgementId, expectedReason) ->
-            assertEquals(
-                expectedReason,
-                service
-                    .getDatasetJudgementById(judgementId)
-                    .dataPoints[mockDatasetJudgementEntityForTest.DUMMY_DATA_POINT_TYPE]
-                    ?.reasonForCustomDataPoint,
-            )
-        }
-    }
-
-    @Test
-    fun `patchJudgementDetails throws ConflictApiException when acceptedSource is custom and no customValue is provided`() {
-        assertThrows<ConflictApiException> {
-            service.patchJudgementDetails(
-                UUID.randomUUID(),
-                mockDatasetJudgementEntityForTest.DUMMY_DATA_POINT_TYPE,
-                JudgementDetailsPatch(AcceptedDataPointSource.Custom, null, null),
-            )
-        }
-    }
-
-    @Test
-    fun `patchJudgementDetails with only customValue validates and sets customValue`() {
-        val saved =
-            patchAndGetDataPoint(
-                source = null,
-                customValue = mockDatasetJudgementEntityForTest.CUSTOM_VALUE,
-            )
-
-        assertEquals(mockDatasetJudgementEntityForTest.CUSTOM_VALUE, saved.customValue)
-        verify(datasetJudgementSupportService)
-            .validateCustomDataPoint(
-                mockDatasetJudgementEntityForTest.CUSTOM_VALUE,
-                mockDatasetJudgementEntityForTest.DUMMY_DATA_POINT_TYPE,
-            )
-    }
-
-    @Test
-    fun `patchJudgementDetails with Qa without reporterUserIdOfAcceptedQaReport throws InvalidInputApiException`() {
-        assertThrows<InvalidInputApiException> {
-            service.patchJudgementDetails(
-                UUID.randomUUID(),
-                mockDatasetJudgementEntityForTest.DUMMY_DATA_POINT_TYPE,
-                JudgementDetailsPatch(
-                    AcceptedDataPointSource.Qa,
-                    null,
-                    null,
-                ),
-            )
-        }
-    }
-
-    @Test
-    fun `patchJudgementDetails throws InvalidInputApiException when dataPointType not in judgement`() {
-        assertThrows<InvalidInputApiException> {
-            service.patchJudgementDetails(
-                UUID.randomUUID(),
-                "unknown-type",
-                JudgementDetailsPatch(AcceptedDataPointSource.Original, null, null),
-            )
-        }
-    }
-
-    @Test
-    fun `patchJudgementDetails throws InsufficientRights when user is not judge`() {
-        AuthenticationMock.mockSecurityContext(
-            "other@example.com",
-            UUID.randomUUID().toString(),
-            setOf(DatalandRealmRole.ROLE_UPLOADER),
-        )
-
-        assertThrows<InsufficientRightsApiException> {
-            service.patchJudgementDetails(
-                UUID.randomUUID(),
-                mockDatasetJudgementEntityForTest.DUMMY_DATA_POINT_TYPE,
-                JudgementDetailsPatch(AcceptedDataPointSource.Original, null, null),
-            )
-        }
-    }
-
-    @Test
-    fun `patchJudgementDetails with Custom wraps BackendClientException into InvalidInputApiException`() {
-        whenever(datasetJudgementSupportService.validateCustomDataPoint(any(), any()))
-            .thenThrow(BackendClientException())
-
-        assertThrows<InvalidInputApiException> {
-            service.patchJudgementDetails(
-                UUID.randomUUID(),
-                mockDatasetJudgementEntityForTest.DUMMY_DATA_POINT_TYPE,
-                JudgementDetailsPatch(null, null, """{"value": 1}"""),
-            )
-        }.also { exception ->
-            assertTrue(exception.cause is BackendClientException)
         }
     }
 }

--- a/dataland-qa-service/src/test/kotlin/org/dataland/datalandqaservice/services/DatasetJudgementServiceTest.kt
+++ b/dataland-qa-service/src/test/kotlin/org/dataland/datalandqaservice/services/DatasetJudgementServiceTest.kt
@@ -393,14 +393,16 @@ class DatasetJudgementServiceTest {
 
         listOf(
             Pair(UUID.randomUUID(), null),
-            Pair(judgementIdWithReasonForCustomDataPoint, mockDatasetJudgementEntityForTest.REASON_FOR_CUSTOM_DATAPOINT)
+            Pair(judgementIdWithReasonForCustomDataPoint, mockDatasetJudgementEntityForTest.REASON_FOR_CUSTOM_DATAPOINT),
         ).forEach { (judgementId, expectedReason) ->
-                assertEquals(
-                    expectedReason,
-                    service.getDatasetJudgementById(judgementId)
-                        .dataPoints[mockDatasetJudgementEntityForTest.DUMMY_DATA_POINT_TYPE]
-                        ?.reasonForCustomDataPoint)
-            }
+            assertEquals(
+                expectedReason,
+                service
+                    .getDatasetJudgementById(judgementId)
+                    .dataPoints[mockDatasetJudgementEntityForTest.DUMMY_DATA_POINT_TYPE]
+                    ?.reasonForCustomDataPoint,
+            )
+        }
     }
 
     @Test

--- a/dataland-qa-service/src/test/kotlin/org/dataland/datalandqaservice/services/DatasetJudgementServiceTestBase.kt
+++ b/dataland-qa-service/src/test/kotlin/org/dataland/datalandqaservice/services/DatasetJudgementServiceTestBase.kt
@@ -1,0 +1,94 @@
+package org.dataland.datalandqaservice.services
+
+import org.dataland.datalandbackend.openApiClient.api.DataPointControllerApi
+import org.dataland.datalandbackendutils.model.KeycloakUserInfo
+import org.dataland.datalandbackendutils.services.KeycloakUserService
+import org.dataland.datalandqaservice.configurations.PreApprovalExemptFieldsConfig
+import org.dataland.datalandqaservice.org.dataland.datalandqaservice.entities.DatasetJudgementEntity
+import org.dataland.datalandqaservice.org.dataland.datalandqaservice.repositories.DatasetJudgementRepository
+import org.dataland.datalandqaservice.org.dataland.datalandqaservice.services.DataPointQaReviewManager
+import org.dataland.datalandqaservice.org.dataland.datalandqaservice.services.DatasetJudgementCreationService
+import org.dataland.datalandqaservice.org.dataland.datalandqaservice.services.DatasetJudgementFinalizationService
+import org.dataland.datalandqaservice.org.dataland.datalandqaservice.services.DatasetJudgementService
+import org.dataland.datalandqaservice.org.dataland.datalandqaservice.services.DatasetJudgementSupportService
+import org.dataland.datalandqaservice.org.dataland.datalandqaservice.services.PreApprovalService
+import org.dataland.datalandqaservice.org.dataland.datalandqaservice.services.QaReviewManager
+import org.dataland.datalandqaservice.utils.MockDatasetJudgementEntityForTest
+import org.dataland.keycloakAdapter.auth.DatalandRealmRole
+import org.dataland.keycloakAdapter.utils.AuthenticationMock
+import org.junit.jupiter.api.BeforeEach
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.reset
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+open class DatasetJudgementServiceTestBase {
+    protected val datasetJudgementRepository = mock<DatasetJudgementRepository>()
+    protected val datasetJudgementSupportService = mock<DatasetJudgementSupportService>()
+    protected val keycloakUserService = mock<KeycloakUserService>()
+    protected val datasetJudgementFinalizationService =
+        DatasetJudgementFinalizationService(
+            mock<DataPointControllerApi>(),
+            mock<DataPointQaReviewManager>(),
+            mock<QaReviewManager>(),
+        )
+
+    protected val creationServiceClass =
+        DatasetJudgementCreationService(
+            datasetJudgementSupportService,
+            keycloakUserService,
+            PreApprovalService(autoPreApprovalEnabled = false, exemptFieldsConfig = PreApprovalExemptFieldsConfig()),
+        )
+
+    protected val service =
+        DatasetJudgementService(
+            datasetJudgementRepository,
+            datasetJudgementSupportService,
+            creationServiceClass,
+            datasetJudgementFinalizationService,
+        )
+
+    protected val mockDatasetJudgementEntityForTest = MockDatasetJudgementEntityForTest
+    protected val datasetJudgementEntity = mockDatasetJudgementEntityForTest.createDummyDatasetJudgementEntity()
+    protected val dummyMetaData = mockDatasetJudgementEntityForTest.createDummyMetaData()
+
+    @BeforeEach
+    fun setup() {
+        reset(
+            datasetJudgementRepository,
+            datasetJudgementSupportService,
+        )
+
+        AuthenticationMock.mockSecurityContext(
+            "data.admin@example.com",
+            mockDatasetJudgementEntityForTest.dummyUserId.toString(),
+            setOf(DatalandRealmRole.ROLE_ADMIN),
+        )
+
+        doReturn(datasetJudgementEntity)
+            .whenever(datasetJudgementSupportService)
+            .getDatasetJudgementEntityById(any())
+
+        whenever(datasetJudgementRepository.save(any<DatasetJudgementEntity>()))
+            .thenAnswer { it.arguments[0] as DatasetJudgementEntity }
+
+        doReturn(
+            KeycloakUserInfo(
+                mockDatasetJudgementEntityForTest.DUMMY_USER_EMAIL,
+                mockDatasetJudgementEntityForTest.dummyUserId.toString(),
+                mockDatasetJudgementEntityForTest.DUMMY_USER_FIRST_NAME,
+                mockDatasetJudgementEntityForTest.DUMMY_USER_LAST_NAME,
+            ),
+        ).whenever(keycloakUserService)
+            .getUser(any())
+    }
+
+    protected fun captureSavedJudgement(): DatasetJudgementEntity {
+        val captor = argumentCaptor<DatasetJudgementEntity>()
+        verify(datasetJudgementRepository).save(captor.capture())
+        return captor.firstValue
+    }
+}

--- a/dataland-qa-service/src/test/kotlin/org/dataland/datalandqaservice/services/DatasetJudgementServiceTestBase.kt
+++ b/dataland-qa-service/src/test/kotlin/org/dataland/datalandqaservice/services/DatasetJudgementServiceTestBase.kt
@@ -13,6 +13,7 @@ import org.dataland.datalandqaservice.org.dataland.datalandqaservice.services.Da
 import org.dataland.datalandqaservice.org.dataland.datalandqaservice.services.DatasetJudgementSupportService
 import org.dataland.datalandqaservice.org.dataland.datalandqaservice.services.PreApprovalService
 import org.dataland.datalandqaservice.org.dataland.datalandqaservice.services.QaReviewManager
+import org.dataland.datalandqaservice.org.dataland.datalandqaservice.services.SignificanceCheckService
 import org.dataland.datalandqaservice.utils.MockDatasetJudgementEntityForTest
 import org.dataland.keycloakAdapter.auth.DatalandRealmRole
 import org.dataland.keycloakAdapter.utils.AuthenticationMock
@@ -40,7 +41,12 @@ open class DatasetJudgementServiceTestBase {
         DatasetJudgementCreationService(
             datasetJudgementSupportService,
             keycloakUserService,
-            PreApprovalService(autoPreApprovalEnabled = false, exemptFieldsConfig = PreApprovalExemptFieldsConfig()),
+            PreApprovalService(
+                autoPreApprovalEnabled = false,
+                exemptFieldsConfig = PreApprovalExemptFieldsConfig(),
+                significanceCheckService = SignificanceCheckService(),
+                datasetJudgementSupportService = datasetJudgementSupportService,
+            ),
         )
 
     protected val service =

--- a/dataland-qa-service/src/test/kotlin/org/dataland/datalandqaservice/services/PreApprovalServiceTest.kt
+++ b/dataland-qa-service/src/test/kotlin/org/dataland/datalandqaservice/services/PreApprovalServiceTest.kt
@@ -47,6 +47,7 @@ class PreApprovalServiceTest {
             acceptedSource = null,
             reporterUserIdOfAcceptedQaReport = null,
             customValue = null,
+            reasonForCustomDataPoint = null,
         )
 
     private fun runWorkflow(

--- a/dataland-qa-service/src/test/kotlin/org/dataland/datalandqaservice/utils/MockDatasetJudgementEntityForTest.kt
+++ b/dataland-qa-service/src/test/kotlin/org/dataland/datalandqaservice/utils/MockDatasetJudgementEntityForTest.kt
@@ -3,6 +3,7 @@ package org.dataland.datalandqaservice.utils
 import org.dataland.datalandbackend.openApiClient.model.DataMetaInformation
 import org.dataland.datalandbackend.openApiClient.model.DataTypeEnum
 import org.dataland.datalandbackend.openApiClient.model.QaStatus
+import org.dataland.datalandqaservice.model.reports.AcceptedDataPointSource
 import org.dataland.datalandqaservice.model.reports.QaReportDataPointVerdict
 import org.dataland.datalandqaservice.org.dataland.datalandqaservice.entities.DataPointJudgementEntity
 import org.dataland.datalandqaservice.org.dataland.datalandqaservice.entities.DataPointQaReportEntity
@@ -23,6 +24,7 @@ object MockDatasetJudgementEntityForTest {
     val dummyDatapointId = UUID.randomUUID().toString()
     val qaReportId = UUID.randomUUID().toString()
     const val CUSTOM_VALUE = """{"value": 42}"""
+    const val REASON_FOR_CUSTOM_DATAPOINT = "The original value was missing and the QA suggestion was out of range."
 
     fun createDummyDatasetJudgementEntity(): DatasetJudgementEntity =
         DatasetJudgementEntity(
@@ -63,6 +65,39 @@ object MockDatasetJudgementEntityForTest {
                         acceptedSource = null,
                         reporterUserIdOfAcceptedQaReport = null,
                         customValue = null,
+                        reasonForCustomDataPoint = null,
+                        datasetJudgement = null,
+                    ),
+                ),
+        )
+
+    fun createDummyDatasetJudgementEntityWithCustomSource(): DatasetJudgementEntity =
+        DatasetJudgementEntity(
+            dataSetJudgementId = UUID.randomUUID(),
+            datasetId = dummyDatasetId,
+            companyId = dummyCompanyId,
+            dataType = DataTypeEnum.sfdr,
+            reportingPeriod = "2026",
+            qaJudgeUserId = dummyUserId,
+            qaJudgeUserName = DUMMY_USER_NAME,
+            qaReporters =
+                mutableListOf(
+                    QaReporter(
+                        reporterUserId = dummyUserId,
+                        reporterUserName = DUMMY_USER_NAME,
+                        reporterEmailAddress = DUMMY_USER_EMAIL,
+                    ),
+                ),
+            dataPoints =
+                mutableListOf(
+                    DataPointJudgementEntity(
+                        dataPointType = DUMMY_DATA_POINT_TYPE,
+                        dataPointId = UUID.randomUUID().toString(),
+                        qaReports = mutableListOf(),
+                        acceptedSource = AcceptedDataPointSource.Custom,
+                        reporterUserIdOfAcceptedQaReport = null,
+                        customValue = CUSTOM_VALUE,
+                        reasonForCustomDataPoint = REASON_FOR_CUSTOM_DATAPOINT,
                         datasetJudgement = null,
                     ),
                 ),


### PR DESCRIPTION
# Pull Request \<Title>
`<Description here>`
## Things to do during Peer Review
Please check all boxes before the Pull Request is merged. In case you skip a box, describe in the PRs description (that means: here) why the check is skipped.
- [x] The GitHub Actions for the CI are green. This is enforced by GitHub. 
- [x] The PR has been peer-reviewed
  - [x] The code has been manually inspected by someone who did not implement the feature
  - [x] The changes have been inspected for possible breaking API changes (changed data models, endpoints, response codes, exception handling, ...). If there are any discuss them with the team.
  - [x] If this PR includes work on the frontend, at least one `@ts-nocheck` is removed. Additionally, there should not be any `@ts-nocheck` in files modified by this PR. If no `@ts-nocheck` are left: Celebrate :tada: :confetti_ball: type-safety and remove this entry. 
- [x] The PR actually implements what is described in the JIRA-Issue
- [x] Make sure you understand the entire workflow from the user’s perspective, and test/review it accordingly. If anything is unclear, please reach out to the dev team.
- [x] At least one test exists testing the new feature
  - [x] Make sure all newly added functionality (especially user facing) is tested
  - [x] Make sure that new test files are included in a test container and actually run in the CI
- [x] At least 3 consecutive CI runs are successfully executed to ensure that there are no flaky tests.
- [x] Documentation is updated as required. If unsure whether or what to update, ask a fellow developer.
- [x] If there was a database entity class added, there must also be a migration script for creating the corresponding database if flyway is already used by the service
- [ ] IF there are changes done to the framework data models or to a database entity class, the following steps were completed in order
  - [ ] A fresh clone of dataland.com is generated (see Wiki page on "OTC" for details)
  - [ ] The feature branch is deployed to clone with `Reset non-user related Docker Volumes & Re-populate` turned off
  - [ ] It's verified that the CD run is green
  - [ ] The new feature is manually used/tested/observed on the clone server. Testing of the new feature should (also) be done by a second, independent reviewer from the dev team
  - [ ] The feature branch is deployed to one of the dev servers with `Reset non-user related Docker Volumes & Re-populate` turned on, and it's verified that the CD run is green
- [x] ELSE, the new version is deployed to one of the dev servers using this branch
  - [x] Run with setting `Reset non-user related Docker Volumes & Re-populate` turned on 
  - [x] It's verified that this version actually is the one deployed (check gitinfo for branch name and commit id!)
  - [x] It's verified that the CD run is green
  - [x] The new feature is manually used/tested/observed on dev server. Testing of the new feature should (also) be done by a second, independent reviewer from the dev team
- [x] Confirm that the latest version (use the /gitinfo endpoint) of the feature branch is deployed to one of the dev servers (no longer enforced by GitHub)
- [x] Ensure that the release notes are written in a way that is understandable to a non-technical audience.
