### PR TITLE
DALA-7426 Fix CI memory

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -404,12 +404,14 @@ jobs:
       - name: Stop memory monitor
         if: always()
         run: ./testing/monitor-memory.sh stop
-      - name: Upload memory monitor log
+      - name: Upload memory monitor logs
         if: always()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: memory-monitor-${{ matrix.testGroup }}
-          path: log/memory-monitor-${{ matrix.testGroup }}.log
+          path: |
+            log/memory-monitor-${{ matrix.testGroup }}.log
+            log/disk-usage.log
           retention-days: 7
       - name: Upload JaCoCo Exec Results
         if: always()

--- a/testing/monitor-memory.sh
+++ b/testing/monitor-memory.sh
@@ -132,8 +132,8 @@ sample_disk() {
     df -ih 2>/dev/null || true
     printf '\n'
 
-    printf 'Snapchot of /dev/root usage:\n'
-    du -h -d 1 /dev/root 2>/dev/null || true
+    printf 'Snapshot of /dev/root (/) usage:\n'
+    du -h -d 1 / 2>/dev/null | sort -h | tail -10 || true
     printf '\n'
 
     printf "Docker system disk usage:\n"

--- a/testing/monitor-memory.sh
+++ b/testing/monitor-memory.sh
@@ -127,9 +127,15 @@ sample_disk() {
     printf '=%.0s' {1..80}; printf '\n'
     df -h 2>/dev/null || true
     printf '\n'
+
+    printf "Inode usage"
+    df -ih 2>/dev/null || true
+    printf '\n'
+
     printf "Docker system disk usage:\n"
     docker system df 2>/dev/null || true
     printf '\n'
+
   } >> "$diskfile"
 }
 

--- a/testing/monitor-memory.sh
+++ b/testing/monitor-memory.sh
@@ -128,8 +128,12 @@ sample_disk() {
     df -h 2>/dev/null || true
     printf '\n'
 
-    printf "Inode usage"
+    printf "Inode usage: \n"
     df -ih 2>/dev/null || true
+    printf '\n'
+
+    printf 'Snapchot of /dev/root usage:\n'
+    du -h -d 1 /dev/root 2>/dev/null || true
     printf '\n'
 
     printf "Docker system disk usage:\n"

--- a/testing/monitor-memory.sh
+++ b/testing/monitor-memory.sh
@@ -116,24 +116,51 @@ sample_once() {
   printf "\n"
 }
 
+sample_disk() {
+  local diskfile="$1"
+  local ts
+  ts=$(date '+%Y-%m-%d %H:%M:%S.%3N')
+
+  {
+    printf '=%.0s' {1..80}; printf '\n'
+    printf "DISK USAGE SNAPSHOT — %s\n" "$ts"
+    printf '=%.0s' {1..80}; printf '\n'
+    df -h 2>/dev/null || true
+    printf '\n'
+    printf "Docker system disk usage:\n"
+    docker system df 2>/dev/null || true
+    printf '\n'
+  } >> "$diskfile"
+}
+
 monitor_loop() {
   local logfile="$1"
+  local diskfile
+  diskfile="$(dirname "$logfile")/disk-usage.log"
+
   mkdir -p "$(dirname "$logfile")"
   {
     echo "Memory monitor started at $(date '+%Y-%m-%d %H:%M:%S')"
-    echo "Log file: $logfile"
+    echo "Log file:  $logfile"
+    echo "Disk file: $diskfile"
     echo ""
     print_header
   } >> "$logfile"
 
+  {
+    echo "Disk usage monitor started at $(date '+%Y-%m-%d %H:%M:%S')"
+    echo ""
+  } >> "$diskfile"
+
   while true; do
     { sample_once >> "$logfile"; } 2>> "$logfile" || true
-    sleep 5
+    { sample_disk "$diskfile"; } 2>> "$diskfile" || true
+    sleep 2
   done
 }
 
 cmd_start() {
-  local logfile="${1:-$DEFAULT_LOG_DIR/memory-monitor-$(date '+%Y%m%d_%H%M%S').log}"
+  local logfile="${1:-$DEFAULT_LOG_DIR/memory-monitor.log}"
   # Resolve to absolute path so the background process can find it regardless of cwd
   if [[ "$logfile" != /* ]]; then
     logfile="$(pwd)/$logfile"


### PR DESCRIPTION
# Pull Request \<Title>
`<Description here>`
## Things to do during Peer Review
Please check all boxes before the Pull Request is merged. In case you skip a box, describe in the PRs description (that means: here) why the check is skipped.
- [x] The GitHub Actions for the CI are green. This is enforced by GitHub. 
- [ ] The PR has been peer-reviewed
  - [ ] The code has been manually inspected by someone who did not implement the feature
  - [ ] The changes have been inspected for possible breaking API changes (changed data models, endpoints, response codes, exception handling, ...). If there are any discuss them with the team.
  - [ ] If this PR includes work on the frontend, at least one `@ts-nocheck` is removed. Additionally, there should not be any `@ts-nocheck` in files modified by this PR. If no `@ts-nocheck` are left: Celebrate :tada: :confetti_ball: type-safety and remove this entry. 
- [ ] The PR actually implements what is described in the JIRA-Issue
- [ ] Make sure you understand the entire workflow from the user’s perspective, and test/review it accordingly. If anything is unclear, please reach out to the dev team.
- [ ] At least one test exists testing the new feature
  - [ ] Make sure all newly added functionality (especially user facing) is tested
  - [ ] Make sure that new test files are included in a test container and actually run in the CI
- [ ] At least 3 consecutive CI runs are successfully executed to ensure that there are no flaky tests.
- [ ] Documentation is updated as required. If unsure whether or what to update, ask a fellow developer.
- [ ] If there was a database entity class added, there must also be a migration script for creating the corresponding database if flyway is already used by the service
- [ ] IF there are changes done to the framework data models or to a database entity class, the following steps were completed in order
  - [ ] A fresh clone of dataland.com is generated (see Wiki page on "OTC" for details)
  - [ ] The feature branch is deployed to clone with `Reset non-user related Docker Volumes & Re-populate` turned off
  - [ ] It's verified that the CD run is green
  - [ ] The new feature is manually used/tested/observed on the clone server. Testing of the new feature should (also) be done by a second, independent reviewer from the dev team
  - [ ] The feature branch is deployed to one of the dev servers with `Reset non-user related Docker Volumes & Re-populate` turned on, and it's verified that the CD run is green
- [ ] ELSE, the new version is deployed to one of the dev servers using this branch
  - [ ] Run with setting `Reset non-user related Docker Volumes & Re-populate` turned on 
  - [ ] It's verified that this version actually is the one deployed (check gitinfo for branch name and commit id!)
  - [ ] It's verified that the CD run is green
  - [ ] The new feature is manually used/tested/observed on dev server. Testing of the new feature should (also) be done by a second, independent reviewer from the dev team
- [ ] Confirm that the latest version (use the /gitinfo endpoint) of the feature branch is deployed to one of the dev servers (no longer enforced by GitHub)
- [ ] Ensure that the release notes are written in a way that is understandable to a non-technical audience.
