### PR TITLE
Dala 7241 automatic preapproval include exceptions for strong deviations from previous dataset

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -25,6 +25,7 @@
     // devcontainer from the host
     "ghcr.io/devcontainers/features/docker-in-docker:2": {
       "version": "latest",
+      "moby": false,
     },
     "ghcr.io/devcontainers/features/java": {
       "version": "21",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -25,7 +25,6 @@
     // devcontainer from the host
     "ghcr.io/devcontainers/features/docker-in-docker:2": {
       "version": "latest",
-      "moby": false,
     },
     "ghcr.io/devcontainers/features/java": {
       "version": "21",

--- a/dataland-qa-service/src/main/kotlin/org/dataland/datalandqaservice/services/DatasetJudgementSupportService.kt
+++ b/dataland-qa-service/src/main/kotlin/org/dataland/datalandqaservice/services/DatasetJudgementSupportService.kt
@@ -1,9 +1,12 @@
 package org.dataland.datalandqaservice.org.dataland.datalandqaservice.services
 
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
 import org.dataland.datalandbackend.openApiClient.api.DataPointControllerApi
 import org.dataland.datalandbackend.openApiClient.api.MetaDataControllerApi
 import org.dataland.datalandbackend.openApiClient.model.DataMetaInformation
 import org.dataland.datalandbackend.openApiClient.model.DataPointToValidate
+import org.dataland.datalandbackend.openApiClient.model.DataTypeEnum
 import org.dataland.datalandqaservice.org.dataland.datalandqaservice.entities.DataPointQaReportEntity
 import org.dataland.datalandqaservice.org.dataland.datalandqaservice.entities.DatasetJudgementEntity
 import org.dataland.datalandqaservice.org.dataland.datalandqaservice.repositories.DataPointQaReportRepository
@@ -16,6 +19,7 @@ import java.util.UUID
 /**
  * Service to support data point judgement operations.
  */
+@Suppress("TooManyFunctions")
 @Service
 class DatasetJudgementSupportService
     @Autowired
@@ -25,6 +29,7 @@ class DatasetJudgementSupportService
         private val specificationControllerApi: SpecificationControllerApi,
         private val dataPointQaReportRepository: DataPointQaReportRepository,
         private val datasetJudgementRepository: DatasetJudgementRepository,
+        private val objectMapper: ObjectMapper,
     ) {
         /**
          * Retrieves meta data of a dataset.
@@ -103,4 +108,56 @@ class DatasetJudgementSupportService
          */
         fun getDatasetJudgementEntityById(datasetJudgementId: UUID): DatasetJudgementEntity? =
             datasetJudgementRepository.findById(datasetJudgementId).orElse(null)
+
+        /**
+         * Retrieves the data point type to data point id map for the currently live dataset
+         * of the given company and framework.
+         *
+         * Returns the contained data points for the latest active dataset across all reporting
+         * periods, or null if no active dataset exists for that company and framework.
+         *
+         * @param companyId The company identifier.
+         * @param dataType The framework / data type.
+         * @return Map of data point type to data point id, or null if no live dataset is found.
+         */
+        fun getLatestActiveDataPoints(
+            companyId: UUID,
+            dataType: DataTypeEnum,
+        ): Map<String, String>? {
+            val activeDatasets =
+                metaDataControllerApi.getListOfDataMetaInfo(
+                    companyId = companyId.toString(),
+                    dataType = dataType,
+                    showOnlyActive = true,
+                )
+            val latestDataset = activeDatasets.maxByOrNull { it.reportingPeriod } ?: return null
+            return metaDataControllerApi.getContainedDataPoints(latestDataset.dataId)
+        }
+
+        /**
+         * Fetches and returns the value node of a data point by its id.
+         *
+         * The stored data point JSON contains a "value" field alongside metadata such as quality
+         * and comment. This method extracts and returns only the "value" node.
+         *
+         * Returns null if the "value" field is absent or is an explicit JSON null.
+         *
+         * @param dataPointId The data point id.
+         * @return The value [JsonNode], or null if absent or null.
+         */
+        fun getDataPointValueNode(dataPointId: String): JsonNode? {
+            val dataPointJson = dataPointControllerApi.getDataPoint(dataPointId).dataPoint
+            val rootNode = objectMapper.readTree(dataPointJson)
+            val valueNode = rootNode["value"] ?: return null
+            return if (valueNode.isNull) null else valueNode
+        }
+
+        /**
+         * Resolves the data point base type id of a data point type from the specification service.
+         *
+         * @param dataPointType The data point type identifier.
+         * @return The base type id string (e.g. "extendedDecimal", "extendedInteger", "extendedEnumYesNo").
+         */
+        fun resolveBaseTypeId(dataPointType: String): String =
+            specificationControllerApi.getDataPointTypeSpecification(dataPointType).dataPointBaseType.id
     }

--- a/dataland-qa-service/src/main/kotlin/org/dataland/datalandqaservice/services/DatasetJudgementSupportService.kt
+++ b/dataland-qa-service/src/main/kotlin/org/dataland/datalandqaservice/services/DatasetJudgementSupportService.kt
@@ -120,7 +120,7 @@ class DatasetJudgementSupportService
          * @param dataType The framework / data type.
          * @return Map of data point type to data point id, or null if no live dataset is found.
          */
-        fun getLatestActiveDataPoints(
+        fun getDataPointsOfLatestActiveDataset(
             companyId: UUID,
             dataType: DataTypeEnum,
         ): Map<String, String>? {

--- a/dataland-qa-service/src/main/kotlin/org/dataland/datalandqaservice/services/PreApprovalService.kt
+++ b/dataland-qa-service/src/main/kotlin/org/dataland/datalandqaservice/services/PreApprovalService.kt
@@ -54,7 +54,7 @@ class PreApprovalService(
         if (!autoPreApprovalEnabled) return datasetJudgementEntity
 
         val liveDataPoints =
-            datasetJudgementSupportService.getLatestActiveDataPoints(
+            datasetJudgementSupportService.getDataPointsOfLatestActiveDataset(
                 datasetJudgementEntity.companyId,
                 datasetJudgementEntity.dataType,
             )
@@ -72,20 +72,6 @@ class PreApprovalService(
                     dataPointEligible &&
                     !selectedByRandomSampling &&
                     passesSignificanceCheck
-            logger.info(
-                "Automatic preapproval decision: datasetId={}, companyId={}, framework={}, dataPointType={}, " +
-                    "allQaReportsAccepted={}, dataPointEligible={}, selectedByRandomSampling={}, " +
-                    "passesSignificanceCheck={}, preApproved={}",
-                datasetJudgementEntity.datasetId,
-                datasetJudgementEntity.companyId,
-                datasetJudgementEntity.dataType,
-                dataPoint.dataPointType,
-                allQaReportsAccepted,
-                dataPointEligible,
-                selectedByRandomSampling,
-                passesSignificanceCheck,
-                allChecksPass,
-            )
 
             if (allChecksPass) {
                 dataPoint.acceptedSource = AcceptedDataPointSource.Original
@@ -173,7 +159,7 @@ class PreApprovalService(
             return true
         }
 
-        val originalValue = datasetJudgementSupportService.getDataPointValueNode(dataPoint.dataPointId)
+        val newValue = datasetJudgementSupportService.getDataPointValueNode(dataPoint.dataPointId)
         val liveValue = datasetJudgementSupportService.getDataPointValueNode(liveDataPointId)
 
         val baseTypeId = datasetJudgementSupportService.resolveBaseTypeId(dataPoint.dataPointType)
@@ -181,7 +167,7 @@ class PreApprovalService(
 
         val hasSignificantChange =
             significanceCheckService.hasSignificantChange(
-                originalValue = originalValue,
+                newValue = newValue,
                 liveValue = liveValue,
                 valueType = valueType,
                 dataPointType = dataPoint.dataPointType,
@@ -189,23 +175,6 @@ class PreApprovalService(
             )
 
         val passesSignificanceCheck = !hasSignificantChange
-
-        logger.info(
-            "Automatic preapproval significance check completed. " +
-                "dataType={}, dataPointType={}, dataPointId={}, liveDataPointId={}, baseTypeId={}, valueType={}, " +
-                "originalValuePresent={}, liveValuePresent={}, hasSignificantChange={}, passesSignificanceCheck={}",
-            dataType,
-            dataPoint.dataPointType,
-            dataPoint.dataPointId,
-            liveDataPointId,
-            baseTypeId,
-            valueType,
-            originalValue != null && !originalValue.isNull,
-            liveValue != null && !liveValue.isNull,
-            hasSignificantChange,
-            passesSignificanceCheck,
-        )
-
         return passesSignificanceCheck
     }
 }

--- a/dataland-qa-service/src/main/kotlin/org/dataland/datalandqaservice/services/PreApprovalService.kt
+++ b/dataland-qa-service/src/main/kotlin/org/dataland/datalandqaservice/services/PreApprovalService.kt
@@ -10,6 +10,7 @@ import org.dataland.datalandqaservice.org.dataland.datalandqaservice.model.PreAp
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import kotlin.random.Random
+import org.slf4j.LoggerFactory
 
 /**
  * Service responsible for automatically pre-approving data points in a dataset judgement.
@@ -22,6 +23,9 @@ class PreApprovalService(
     private val significanceCheckService: SignificanceCheckService,
     private val datasetJudgementSupportService: DatasetJudgementSupportService,
 ) {
+    companion object {
+        private val logger = LoggerFactory.getLogger(PreApprovalService::class.java)
+    }
     private var _config: PreApprovalConfig = PreApprovalConfig()
     val config: PreApprovalConfig
         get() = _config
@@ -135,7 +139,27 @@ class PreApprovalService(
         dataType: DataTypeEnum,
         liveDataPoints: Map<String, String>?,
     ): Boolean {
-        val liveDataPointId = liveDataPoints?.get(dataPoint.dataPointType) ?: return true
+        if (liveDataPoints == null) {
+            logger.info(
+                "Automatic preapproval significance check skipped: no live dataset found. dataType={}, dataPointType={}, dataPointId={}",
+                dataType,
+                dataPoint.dataPointType,
+                dataPoint.dataPointId,
+            )
+            return true
+        }
+
+        val liveDataPointId = liveDataPoints[dataPoint.dataPointType]
+        if (liveDataPointId == null) {
+            logger.info(
+                "Automatic preapproval significance check skipped: data point type not present in live dataset. " +
+                        "dataType={}, dataPointType={}, dataPointId={}",
+                dataType,
+                dataPoint.dataPointType,
+                dataPoint.dataPointId,
+            )
+            return true
+        }
 
         val originalValue = datasetJudgementSupportService.getDataPointValueNode(dataPoint.dataPointId)
         val liveValue = datasetJudgementSupportService.getDataPointValueNode(liveDataPointId)
@@ -152,6 +176,24 @@ class PreApprovalService(
                 framework = dataType,
             )
 
-        return !hasSignificantChange
+        val passesSignificanceCheck = !hasSignificantChange
+
+        logger.info(
+            "Automatic preapproval significance check completed. " +
+                    "dataType={}, dataPointType={}, dataPointId={}, liveDataPointId={}, baseTypeId={}, valueType={}, " +
+                    "originalValuePresent={}, liveValuePresent={}, hasSignificantChange={}, passesSignificanceCheck={}",
+            dataType,
+            dataPoint.dataPointType,
+            dataPoint.dataPointId,
+            liveDataPointId,
+            baseTypeId,
+            valueType,
+            originalValue != null && !originalValue.isNull,
+            liveValue != null && !liveValue.isNull,
+            hasSignificantChange,
+            passesSignificanceCheck,
+        )
+
+        return passesSignificanceCheck
     }
 }

--- a/dataland-qa-service/src/main/kotlin/org/dataland/datalandqaservice/services/PreApprovalService.kt
+++ b/dataland-qa-service/src/main/kotlin/org/dataland/datalandqaservice/services/PreApprovalService.kt
@@ -160,24 +160,15 @@ class PreApprovalService(
         dataType: DataTypeEnum,
         liveDataPoints: Map<String, String>?,
     ): Boolean {
-        if (liveDataPoints == null) {
-            logger.info(
-                "Automatic preapproval significance check skipped: no live dataset found. dataType={}, dataPointType={}, dataPointId={}",
-                dataType,
-                dataPoint.dataPointType,
-                dataPoint.dataPointId,
-            )
-            return true
-        }
-
-        val liveDataPointId = liveDataPoints[dataPoint.dataPointType]
+        val liveDataPointId = liveDataPoints?.get(dataPoint.dataPointType)
         if (liveDataPointId == null) {
             logger.info(
-                "Automatic preapproval significance check skipped: data point type not present in live dataset. " +
-                    "dataType={}, dataPointType={}, dataPointId={}",
+                "Automatic preapproval significance check skipped. " +
+                    "dataType={}, dataPointType={}, dataPointId={}, liveDatasetPresent={}",
                 dataType,
                 dataPoint.dataPointType,
                 dataPoint.dataPointId,
+                liveDataPoints != null,
             )
             return true
         }

--- a/dataland-qa-service/src/main/kotlin/org/dataland/datalandqaservice/services/PreApprovalService.kt
+++ b/dataland-qa-service/src/main/kotlin/org/dataland/datalandqaservice/services/PreApprovalService.kt
@@ -59,17 +59,42 @@ class PreApprovalService(
             )
 
         datasetJudgementEntity.dataPoints.forEach { dataPoint ->
+            val allQaReportsAccepted = areAllQaReportsAccepted(dataPoint)
+            val dataPointEligible = isDataPointEligible(dataPoint, datasetJudgementEntity.dataType)
+            val selectedByRandomSampling = isRandomDrawBelowSamplingProbability()
+
+            val passesSignificanceCheck =
+                passesSignificanceCheck(dataPoint, datasetJudgementEntity.dataType, liveDataPoints)
 
             val allChecksPass =
-                areAllQaReportsAccepted(dataPoint) &&
-                    isDataPointEligible(dataPoint, datasetJudgementEntity.dataType) &&
-                    !isRandomDrawBelowSamplingProbability() &&
-                    passesSignificanceCheck(dataPoint, datasetJudgementEntity.dataType, liveDataPoints)
+                allQaReportsAccepted &&
+                        dataPointEligible &&
+                        !selectedByRandomSampling &&
+                        passesSignificanceCheck
+            if (!passesSignificanceCheck) {
+                logger.info("### DID NOT PASS SIGNIFICANCE CHECK, LARGE DEVIATION DETECTED, SKIPPING PRE-APPROVAL ###")
+            }
+            logger.info(
+                "Automatic preapproval decision: datasetId={}, companyId={}, framework={}, dataPointType={}, " +
+                        "allQaReportsAccepted={}, dataPointEligible={}, selectedByRandomSampling={}, " +
+                        "passesSignificanceCheck={}, preApproved={}",
+                datasetJudgementEntity.datasetId,
+                datasetJudgementEntity.companyId,
+                datasetJudgementEntity.dataType,
+                dataPoint.dataPointType,
+                allQaReportsAccepted,
+                dataPointEligible,
+                selectedByRandomSampling,
+                passesSignificanceCheck,
+                allChecksPass,
+            )
 
             if (allChecksPass) {
                 dataPoint.acceptedSource = AcceptedDataPointSource.Original
             }
         }
+
+
 
         return datasetJudgementEntity
     }

--- a/dataland-qa-service/src/main/kotlin/org/dataland/datalandqaservice/services/PreApprovalService.kt
+++ b/dataland-qa-service/src/main/kotlin/org/dataland/datalandqaservice/services/PreApprovalService.kt
@@ -7,10 +7,10 @@ import org.dataland.datalandqaservice.model.reports.QaReportDataPointVerdict
 import org.dataland.datalandqaservice.org.dataland.datalandqaservice.entities.DataPointJudgementEntity
 import org.dataland.datalandqaservice.org.dataland.datalandqaservice.entities.DatasetJudgementEntity
 import org.dataland.datalandqaservice.org.dataland.datalandqaservice.model.PreApprovalConfig
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import kotlin.random.Random
-import org.slf4j.LoggerFactory
 
 /**
  * Service responsible for automatically pre-approving data points in a dataset judgement.
@@ -26,6 +26,7 @@ class PreApprovalService(
     companion object {
         private val logger = LoggerFactory.getLogger(PreApprovalService::class.java)
     }
+
     private var _config: PreApprovalConfig = PreApprovalConfig()
     val config: PreApprovalConfig
         get() = _config
@@ -68,16 +69,13 @@ class PreApprovalService(
 
             val allChecksPass =
                 allQaReportsAccepted &&
-                        dataPointEligible &&
-                        !selectedByRandomSampling &&
-                        passesSignificanceCheck
-            if (!passesSignificanceCheck) {
-                logger.info("### DID NOT PASS SIGNIFICANCE CHECK, LARGE DEVIATION DETECTED, SKIPPING PRE-APPROVAL ###")
-            }
+                    dataPointEligible &&
+                    !selectedByRandomSampling &&
+                    passesSignificanceCheck
             logger.info(
                 "Automatic preapproval decision: datasetId={}, companyId={}, framework={}, dataPointType={}, " +
-                        "allQaReportsAccepted={}, dataPointEligible={}, selectedByRandomSampling={}, " +
-                        "passesSignificanceCheck={}, preApproved={}",
+                    "allQaReportsAccepted={}, dataPointEligible={}, selectedByRandomSampling={}, " +
+                    "passesSignificanceCheck={}, preApproved={}",
                 datasetJudgementEntity.datasetId,
                 datasetJudgementEntity.companyId,
                 datasetJudgementEntity.dataType,
@@ -93,8 +91,6 @@ class PreApprovalService(
                 dataPoint.acceptedSource = AcceptedDataPointSource.Original
             }
         }
-
-
 
         return datasetJudgementEntity
     }
@@ -178,7 +174,7 @@ class PreApprovalService(
         if (liveDataPointId == null) {
             logger.info(
                 "Automatic preapproval significance check skipped: data point type not present in live dataset. " +
-                        "dataType={}, dataPointType={}, dataPointId={}",
+                    "dataType={}, dataPointType={}, dataPointId={}",
                 dataType,
                 dataPoint.dataPointType,
                 dataPoint.dataPointId,
@@ -205,8 +201,8 @@ class PreApprovalService(
 
         logger.info(
             "Automatic preapproval significance check completed. " +
-                    "dataType={}, dataPointType={}, dataPointId={}, liveDataPointId={}, baseTypeId={}, valueType={}, " +
-                    "originalValuePresent={}, liveValuePresent={}, hasSignificantChange={}, passesSignificanceCheck={}",
+                "dataType={}, dataPointType={}, dataPointId={}, liveDataPointId={}, baseTypeId={}, valueType={}, " +
+                "originalValuePresent={}, liveValuePresent={}, hasSignificantChange={}, passesSignificanceCheck={}",
             dataType,
             dataPoint.dataPointType,
             dataPoint.dataPointId,

--- a/dataland-qa-service/src/main/kotlin/org/dataland/datalandqaservice/services/PreApprovalService.kt
+++ b/dataland-qa-service/src/main/kotlin/org/dataland/datalandqaservice/services/PreApprovalService.kt
@@ -143,12 +143,15 @@ class PreApprovalService(
         val baseTypeId = datasetJudgementSupportService.resolveBaseTypeId(dataPoint.dataPointType)
         val valueType = significanceCheckService.resolveValueType(baseTypeId)
 
-        return !significanceCheckService.checkForSignificantChange(
-            originalValue = originalValue,
-            liveValue = liveValue,
-            valueType = valueType,
-            dataPointType = dataPoint.dataPointType,
-            framework = dataType,
-        )
+        val hasSignificantChange =
+            significanceCheckService.hasSignificantChange(
+                originalValue = originalValue,
+                liveValue = liveValue,
+                valueType = valueType,
+                dataPointType = dataPoint.dataPointType,
+                framework = dataType,
+            )
+
+        return !hasSignificantChange
     }
 }

--- a/dataland-qa-service/src/main/kotlin/org/dataland/datalandqaservice/services/PreApprovalService.kt
+++ b/dataland-qa-service/src/main/kotlin/org/dataland/datalandqaservice/services/PreApprovalService.kt
@@ -19,6 +19,8 @@ class PreApprovalService(
     @Value("\${dataland.qa-service.auto-preapproval-qa-accepted-datapoints}")
     private val autoPreApprovalEnabled: Boolean,
     private val exemptFieldsConfig: PreApprovalExemptFieldsConfig,
+    private val significanceCheckService: SignificanceCheckService,
+    private val datasetJudgementSupportService: DatasetJudgementSupportService,
 ) {
     private var _config: PreApprovalConfig = PreApprovalConfig()
     val config: PreApprovalConfig
@@ -36,20 +38,29 @@ class PreApprovalService(
      * Pre-approves data points of a given DatasetJudgementEntity.
      *
      * If the feature flag is disabled, the given DatasetJudgementEntity is returned unchanged.
-     * If the feature flag is enabled, data points that pass several checks are pre-approved:
-     * - all QA reports have the verdict QaAccepted
-     * - data point is not on list of exempt fields
-     * -
+     * If the feature flag is enabled, data points that pass all of the following checks are
+     * pre-approved by setting their acceptedSource to Original:
+     * - All QA reports for the data point have the verdict QaAccepted.
+     * - The data point is not on the exempt fields list for the framework.
+     * - The data point is not excluded by random sampling.
+     * - The change in value compared to the currently live dataset is not significant.
      */
     fun preApproveDataPoints(datasetJudgementEntity: DatasetJudgementEntity): DatasetJudgementEntity {
         if (!autoPreApprovalEnabled) return datasetJudgementEntity
+
+        val liveDataPoints =
+            datasetJudgementSupportService.getLatestActiveDataPoints(
+                datasetJudgementEntity.companyId,
+                datasetJudgementEntity.dataType,
+            )
 
         datasetJudgementEntity.dataPoints.forEach { dataPoint ->
 
             val allChecksPass =
                 areAllQaReportsAccepted(dataPoint) &&
                     isDataPointEligible(dataPoint, datasetJudgementEntity.dataType) &&
-                    !isRandomDrawBelowSamplingProbability()
+                    !isRandomDrawBelowSamplingProbability() &&
+                    passesSignificanceCheck(dataPoint, datasetJudgementEntity.dataType, liveDataPoints)
 
             if (allChecksPass) {
                 dataPoint.acceptedSource = AcceptedDataPointSource.Original
@@ -100,5 +111,44 @@ class PreApprovalService(
     private fun isRandomDrawBelowSamplingProbability(): Boolean {
         val samplingProbability = _config.samplingProbability
         return Random.nextDouble() < samplingProbability
+    }
+
+    /**
+     * Checks whether the change in a data point's value compared to the currently live dataset
+     * is not significant enough to suppress pre-approval.
+     *
+     * Returns true (allow pre-approval) in any of the following cases:
+     * - No live dataset exists for the company and framework.
+     * - The live dataset does not contain this data point type.
+     * - Either the original or the live value is null.
+     * - The change is below the significance threshold for the data point's value type.
+     *
+     * Returns false (suppress pre-approval) only when the change is considered significant.
+     *
+     * @param dataPoint the data point under review
+     * @param dataType the framework of the dataset being reviewed
+     * @param liveDataPoints map of data point type to data point id for the live dataset, or null
+     * @return `true` if pre-approval should be allowed, `false` if it should be suppressed
+     */
+    private fun passesSignificanceCheck(
+        dataPoint: DataPointJudgementEntity,
+        dataType: DataTypeEnum,
+        liveDataPoints: Map<String, String>?,
+    ): Boolean {
+        val liveDataPointId = liveDataPoints?.get(dataPoint.dataPointType) ?: return true
+
+        val originalValue = datasetJudgementSupportService.getDataPointValueNode(dataPoint.dataPointId)
+        val liveValue = datasetJudgementSupportService.getDataPointValueNode(liveDataPointId)
+
+        val baseTypeId = datasetJudgementSupportService.resolveBaseTypeId(dataPoint.dataPointType)
+        val valueType = significanceCheckService.resolveValueType(baseTypeId)
+
+        return !significanceCheckService.checkForSignificantChange(
+            originalValue = originalValue,
+            liveValue = liveValue,
+            valueType = valueType,
+            dataPointType = dataPoint.dataPointType,
+            framework = dataType,
+        )
     }
 }

--- a/dataland-qa-service/src/main/kotlin/org/dataland/datalandqaservice/services/SignificanceCheckService.kt
+++ b/dataland-qa-service/src/main/kotlin/org/dataland/datalandqaservice/services/SignificanceCheckService.kt
@@ -24,6 +24,14 @@ import java.math.RoundingMode
  */
 @Service
 class SignificanceCheckService {
+    /**
+     * Categorizes data point value types for significance threshold evaluation.
+     *
+     * - BOOLEAN: Any change is considered significant.
+     * - DECIMAL: Relative change is evaluated against [DECIMAL_RELATIVE_THRESHOLD].
+     * - INTEGER: Absolute change is evaluated against [INTEGER_ABSOLUTE_THRESHOLD].
+     * - UNSUPPORTED: Unknown types that are never considered significant.
+     */
     enum class ValueType { BOOLEAN, DECIMAL, INTEGER, UNSUPPORTED }
 
     companion object {
@@ -105,20 +113,21 @@ class SignificanceCheckService {
     ): Boolean {
         val original = newValue.decimalValueOrNull()
         val live = liveValue.decimalValueOrNull()
-        if (original == null || live == null) return false
+        if (original == null || live == null) {
+            return false
+        }
         val threshold = getDecimalThreshold(dataPointType, framework)
 
-        if (live.compareTo(BigDecimal.ZERO) == 0) {
-            return original.compareTo(BigDecimal.ZERO) != 0
+        return if (live.compareTo(BigDecimal.ZERO) == 0) {
+            original.compareTo(BigDecimal.ZERO) != 0
+        } else {
+            val relativeChange =
+                original
+                    .subtract(live)
+                    .abs()
+                    .divide(live.abs(), DECIMAL_DIVISION_SCALE, RoundingMode.HALF_UP)
+            relativeChange > threshold
         }
-
-        val relativeChange =
-            original
-                .subtract(live)
-                .abs()
-                .divide(live.abs(), DECIMAL_DIVISION_SCALE, RoundingMode.HALF_UP)
-
-        return relativeChange > threshold
     }
 
     private fun isIntegerChangeSignificant(

--- a/dataland-qa-service/src/main/kotlin/org/dataland/datalandqaservice/services/SignificanceCheckService.kt
+++ b/dataland-qa-service/src/main/kotlin/org/dataland/datalandqaservice/services/SignificanceCheckService.kt
@@ -146,11 +146,9 @@ class SignificanceCheckService {
         return original.subtract(live).abs() > threshold
     }
 
-    private fun JsonNode.decimalValueOrNull(): BigDecimal? =
-        if (isNumber) decimalValue() else null
+    private fun JsonNode.decimalValueOrNull(): BigDecimal? = if (isNumber) decimalValue() else null
 
-    private fun JsonNode.bigIntegerValueOrNull(): BigInteger? =
-        if (isIntegralNumber) bigIntegerValue() else null
+    private fun JsonNode.bigIntegerValueOrNull(): BigInteger? = if (isIntegralNumber) bigIntegerValue() else null
 
     private fun getDecimalThreshold(
         dataPointType: String,
@@ -163,8 +161,5 @@ class SignificanceCheckService {
     private fun getIntegerThreshold(
         dataPointType: String,
         framework: DataTypeEnum,
-    ): BigInteger =
-        individualIntegerThresholds[framework]?.get(dataPointType) ?: INTEGER_ABSOLUTE_THRESHOLD
-
-
+    ): BigInteger = individualIntegerThresholds[framework]?.get(dataPointType) ?: INTEGER_ABSOLUTE_THRESHOLD
 }

--- a/dataland-qa-service/src/main/kotlin/org/dataland/datalandqaservice/services/SignificanceCheckService.kt
+++ b/dataland-qa-service/src/main/kotlin/org/dataland/datalandqaservice/services/SignificanceCheckService.kt
@@ -16,8 +16,8 @@ import java.math.RoundingMode
  *
  * Thresholds are hardcoded per value type and can only be changed via redeployment:
  * - Boolean: any change is significant.
- * - Decimal: a relative change of more than the defined DECIMAL_RELATIVE_THRESHOLD is significant.
- * - Integer: an absolute change of more than the defined INTEGER_ABSOLUTE_THRESHOLD is significant.
+ * - Decimal: a relative change of more than the defined [DECIMAL_RELATIVE_THRESHOLD] is significant.
+ * - Integer: an absolute change of more than the defined [INTEGER_ABSOLUTE_THRESHOLD] is significant.
  *
  * Individual per-data-point threshold overrides per framework can be registered via
  * [individualDecimalThresholds] and [individualIntegerThresholds] if needed.
@@ -98,12 +98,12 @@ class SignificanceCheckService {
     }
 
     private fun isDecimalChangeSignificant(
-        originalValue: JsonNode,
+        newValue: JsonNode,
         liveValue: JsonNode,
         dataPointType: String,
         framework: DataTypeEnum,
     ): Boolean {
-        val original = originalValue.decimalValueOrNull()
+        val original = newValue.decimalValueOrNull()
         val live = liveValue.decimalValueOrNull()
         if (original == null || live == null) return false
         val threshold = getDecimalThreshold(dataPointType, framework)
@@ -122,12 +122,12 @@ class SignificanceCheckService {
     }
 
     private fun isIntegerChangeSignificant(
-        originalValue: JsonNode,
+        newValue: JsonNode,
         liveValue: JsonNode,
         dataPointType: String,
         framework: DataTypeEnum,
     ): Boolean {
-        val original = originalValue.bigIntegerValueOrNull()
+        val original = newValue.bigIntegerValueOrNull()
         val live = liveValue.bigIntegerValueOrNull()
         if (original == null || live == null) return false
         val threshold = getIntegerThreshold(dataPointType, framework)

--- a/dataland-qa-service/src/main/kotlin/org/dataland/datalandqaservice/services/SignificanceCheckService.kt
+++ b/dataland-qa-service/src/main/kotlin/org/dataland/datalandqaservice/services/SignificanceCheckService.kt
@@ -16,31 +16,25 @@ import java.math.RoundingMode
  *
  * Thresholds are hardcoded per value type and can only be changed via redeployment:
  * - Boolean: any change is significant.
- * - Decimal: a relative change of more than 50% is significant.
- * - Integer: an absolute change of more than 5 is significant.
+ * - Decimal: a relative change of more than the defined DECIMAL_RELATIVE_THRESHOLD is significant.
+ * - Integer: an absolute change of more than the defined INTEGER_ABSOLUTE_THRESHOLD is significant.
  *
  * Individual per-data-point threshold overrides per framework can be registered via
  * [individualDecimalThresholds] and [individualIntegerThresholds] if needed.
  */
 @Service
 class SignificanceCheckService {
-    /**
-     * The value type category of a data point, derived from its data point base type specification.
-     */
     enum class ValueType { BOOLEAN, DECIMAL, INTEGER, UNSUPPORTED }
 
     companion object {
-        /** Relative change threshold for Decimal fields: a change of more than 50% is significant. */
         const val DECIMAL_RELATIVE_THRESHOLD = 0.5
 
-        /** Absolute change threshold for Integer fields: a change of more than 5 is significant. */
         val INTEGER_ABSOLUTE_THRESHOLD: BigInteger = BigInteger.valueOf(5)
 
         private val DECIMAL_BASE_TYPE_IDS = setOf("extendedDecimal")
         private val INTEGER_BASE_TYPE_IDS = setOf("extendedInteger")
         private val BOOLEAN_BASE_TYPE_IDS = setOf("extendedEnumYesNo")
 
-        /** Scale used for the intermediate division when computing relative decimal change. */
         private const val DECIMAL_DIVISION_SCALE = 10
     }
 
@@ -77,7 +71,7 @@ class SignificanceCheckService {
      * - Either value is null or an explicit JSON null.
      * - The value type is [ValueType.UNSUPPORTED].
      *
-     * @param originalValue The value node of the data point in the dataset under review.
+     * @param newValue The value node of the data point in the dataset under review.
      * @param liveValue The value node of the same data point in the currently live dataset.
      * @param valueType The value type category of the data point.
      * @param dataPointType The data point type identifier (used for per-data-point threshold lookups).
@@ -85,20 +79,20 @@ class SignificanceCheckService {
      * @return true if the change is significant and auto pre-approval should be suppressed; false otherwise.
      */
     fun hasSignificantChange(
-        originalValue: JsonNode?,
+        newValue: JsonNode?,
         liveValue: JsonNode?,
         valueType: ValueType,
         dataPointType: String,
         framework: DataTypeEnum,
     ): Boolean {
-        val original = originalValue?.takeUnless { it.isNull }
+        val newVal = newValue?.takeUnless { it.isNull }
         val live = liveValue?.takeUnless { it.isNull }
-        if (original == null || live == null) return false
+        if (newVal == null || live == null) return false
 
         return when (valueType) {
-            ValueType.BOOLEAN -> original.asText() != live.asText()
-            ValueType.DECIMAL -> isDecimalChangeSignificant(original, live, dataPointType, framework)
-            ValueType.INTEGER -> isIntegerChangeSignificant(original, live, dataPointType, framework)
+            ValueType.BOOLEAN -> newVal.asText() != live.asText()
+            ValueType.DECIMAL -> isDecimalChangeSignificant(newVal, live, dataPointType, framework)
+            ValueType.INTEGER -> isIntegerChangeSignificant(newVal, live, dataPointType, framework)
             ValueType.UNSUPPORTED -> false
         }
     }
@@ -114,14 +108,6 @@ class SignificanceCheckService {
         if (original == null || live == null) return false
         val threshold = getDecimalThreshold(dataPointType, framework)
 
-        return isRelativeDecimalChangeAboveThreshold(original, live, threshold)
-    }
-
-    private fun isRelativeDecimalChangeAboveThreshold(
-        original: BigDecimal,
-        live: BigDecimal,
-        threshold: BigDecimal,
-    ): Boolean {
         if (live.compareTo(BigDecimal.ZERO) == 0) {
             return original.compareTo(BigDecimal.ZERO) != 0
         }

--- a/dataland-qa-service/src/main/kotlin/org/dataland/datalandqaservice/services/SignificanceCheckService.kt
+++ b/dataland-qa-service/src/main/kotlin/org/dataland/datalandqaservice/services/SignificanceCheckService.kt
@@ -84,24 +84,23 @@ class SignificanceCheckService {
      * @param framework The framework of the dataset (used for per-data-point threshold lookups).
      * @return true if the change is significant and auto pre-approval should be suppressed; false otherwise.
      */
-    fun checkForSignificantChange(
+    fun hasSignificantChange(
         originalValue: JsonNode?,
         liveValue: JsonNode?,
         valueType: ValueType,
         dataPointType: String,
         framework: DataTypeEnum,
     ): Boolean {
-        if (isNullOrJsonNull(originalValue) || isNullOrJsonNull(liveValue)) return false
+        val original = originalValue?.takeUnless { it.isNull } ?: return false
+        val live = liveValue?.takeUnless { it.isNull } ?: return false
 
         return when (valueType) {
-            ValueType.BOOLEAN -> originalValue!!.asText() != liveValue!!.asText()
-            ValueType.DECIMAL -> isDecimalChangeSignificant(originalValue!!, liveValue!!, dataPointType, framework)
-            ValueType.INTEGER -> isIntegerChangeSignificant(originalValue!!, liveValue!!, dataPointType, framework)
+            ValueType.BOOLEAN -> original.asText() != live.asText()
+            ValueType.DECIMAL -> isDecimalChangeSignificant(original, live, dataPointType, framework)
+            ValueType.INTEGER -> isIntegerChangeSignificant(original, live, dataPointType, framework)
             ValueType.UNSUPPORTED -> false
         }
     }
-
-    private fun isNullOrJsonNull(value: JsonNode?): Boolean = value == null || value.isNull
 
     private fun isDecimalChangeSignificant(
         originalValue: JsonNode,
@@ -109,18 +108,29 @@ class SignificanceCheckService {
         dataPointType: String,
         framework: DataTypeEnum,
     ): Boolean {
-        if (!originalValue.isNumber || !liveValue.isNumber) return false
-        val original = originalValue.decimalValue()
-        val live = liveValue.decimalValue()
-        val threshold =
-            BigDecimal.valueOf(
-                individualDecimalThresholds[framework]?.get(dataPointType) ?: DECIMAL_RELATIVE_THRESHOLD,
-            )
-        return if (live.compareTo(BigDecimal.ZERO) == 0) {
-            original.compareTo(BigDecimal.ZERO) != 0
-        } else {
-            (original - live).abs().divide(live.abs(), DECIMAL_DIVISION_SCALE, RoundingMode.HALF_UP) > threshold
+        val original = originalValue.decimalValueOrNull() ?: return false
+        val live = liveValue.decimalValueOrNull() ?: return false
+        val threshold = getDecimalThreshold(dataPointType, framework)
+
+        return isRelativeDecimalChangeAboveThreshold(original, live, threshold)
+    }
+
+    private fun isRelativeDecimalChangeAboveThreshold(
+        original: BigDecimal,
+        live: BigDecimal,
+        threshold: BigDecimal,
+    ): Boolean {
+        if (live.compareTo(BigDecimal.ZERO) == 0) {
+            return original.compareTo(BigDecimal.ZERO) != 0
         }
+
+        val relativeChange =
+            original
+                .subtract(live)
+                .abs()
+                .divide(live.abs(), DECIMAL_DIVISION_SCALE, RoundingMode.HALF_UP)
+
+        return relativeChange > threshold
     }
 
     private fun isIntegerChangeSignificant(
@@ -129,10 +139,32 @@ class SignificanceCheckService {
         dataPointType: String,
         framework: DataTypeEnum,
     ): Boolean {
-        if (!originalValue.isIntegralNumber || !liveValue.isIntegralNumber) return false
-        val original = originalValue.bigIntegerValue()
-        val live = liveValue.bigIntegerValue()
-        val threshold = individualIntegerThresholds[framework]?.get(dataPointType) ?: INTEGER_ABSOLUTE_THRESHOLD
-        return (original - live).abs() > threshold
+        val original = originalValue.bigIntegerValueOrNull() ?: return false
+        val live = liveValue.bigIntegerValueOrNull() ?: return false
+        val threshold = getIntegerThreshold(dataPointType, framework)
+
+        return original.subtract(live).abs() > threshold
     }
+
+    private fun JsonNode.decimalValueOrNull(): BigDecimal? =
+        if (isNumber) decimalValue() else null
+
+    private fun JsonNode.bigIntegerValueOrNull(): BigInteger? =
+        if (isIntegralNumber) bigIntegerValue() else null
+
+    private fun getDecimalThreshold(
+        dataPointType: String,
+        framework: DataTypeEnum,
+    ): BigDecimal =
+        BigDecimal.valueOf(
+            individualDecimalThresholds[framework]?.get(dataPointType) ?: DECIMAL_RELATIVE_THRESHOLD,
+        )
+
+    private fun getIntegerThreshold(
+        dataPointType: String,
+        framework: DataTypeEnum,
+    ): BigInteger =
+        individualIntegerThresholds[framework]?.get(dataPointType) ?: INTEGER_ABSOLUTE_THRESHOLD
+
+
 }

--- a/dataland-qa-service/src/main/kotlin/org/dataland/datalandqaservice/services/SignificanceCheckService.kt
+++ b/dataland-qa-service/src/main/kotlin/org/dataland/datalandqaservice/services/SignificanceCheckService.kt
@@ -1,0 +1,138 @@
+package org.dataland.datalandqaservice.org.dataland.datalandqaservice.services
+
+import com.fasterxml.jackson.databind.JsonNode
+import org.dataland.datalandbackend.openApiClient.model.DataTypeEnum
+import org.springframework.stereotype.Service
+import java.math.BigDecimal
+import java.math.BigInteger
+import java.math.RoundingMode
+
+/**
+ * Pure service for checking whether the change between two data point values is considered
+ * significant according to hardcoded thresholds per value type.
+ *
+ * A significant change suppresses automatic pre-approval for that data point, requiring manual
+ * review by a QA judge instead.
+ *
+ * Thresholds are hardcoded per value type and can only be changed via redeployment:
+ * - Boolean: any change is significant.
+ * - Decimal: a relative change of more than 50% is significant.
+ * - Integer: an absolute change of more than 5 is significant.
+ *
+ * Individual per-data-point threshold overrides per framework can be registered via
+ * [individualDecimalThresholds] and [individualIntegerThresholds] if needed.
+ */
+@Service
+class SignificanceCheckService {
+    /**
+     * The value type category of a data point, derived from its data point base type specification.
+     */
+    enum class ValueType { BOOLEAN, DECIMAL, INTEGER, UNSUPPORTED }
+
+    companion object {
+        /** Relative change threshold for Decimal fields: a change of more than 50% is significant. */
+        const val DECIMAL_RELATIVE_THRESHOLD = 0.5
+
+        /** Absolute change threshold for Integer fields: a change of more than 5 is significant. */
+        val INTEGER_ABSOLUTE_THRESHOLD: BigInteger = BigInteger.valueOf(5)
+
+        private val DECIMAL_BASE_TYPE_IDS = setOf("extendedDecimal")
+        private val INTEGER_BASE_TYPE_IDS = setOf("extendedInteger")
+        private val BOOLEAN_BASE_TYPE_IDS = setOf("extendedEnumYesNo")
+
+        /** Scale used for the intermediate division when computing relative decimal change. */
+        private const val DECIMAL_DIVISION_SCALE = 10
+    }
+
+    /**
+     * Per-data-point relative threshold overrides for Decimal fields, keyed by framework and
+     * data point type. If absent, [DECIMAL_RELATIVE_THRESHOLD] is used.
+     */
+    private val individualDecimalThresholds: Map<DataTypeEnum, Map<String, Double>> = emptyMap()
+
+    /**
+     * Per-data-point absolute threshold overrides for Integer fields, keyed by framework and
+     * data point type. If absent, [INTEGER_ABSOLUTE_THRESHOLD] is used.
+     */
+    private val individualIntegerThresholds: Map<DataTypeEnum, Map<String, BigInteger>> = emptyMap()
+
+    /**
+     * Resolves a data point base type id (from the specification service) to a [ValueType] category.
+     *
+     * @param baseTypeId The id of the data point base type (e.g. "extendedDecimal").
+     * @return The corresponding [ValueType].
+     */
+    fun resolveValueType(baseTypeId: String): ValueType =
+        when (baseTypeId) {
+            in DECIMAL_BASE_TYPE_IDS -> ValueType.DECIMAL
+            in INTEGER_BASE_TYPE_IDS -> ValueType.INTEGER
+            in BOOLEAN_BASE_TYPE_IDS -> ValueType.BOOLEAN
+            else -> ValueType.UNSUPPORTED
+        }
+
+    /**
+     * Checks whether the change between the original and live value of a data point is significant.
+     *
+     * Returns false (not significant — allow pre-approval) in the following cases:
+     * - Either value is null or an explicit JSON null.
+     * - The value type is [ValueType.UNSUPPORTED].
+     *
+     * @param originalValue The value node of the data point in the dataset under review.
+     * @param liveValue The value node of the same data point in the currently live dataset.
+     * @param valueType The value type category of the data point.
+     * @param dataPointType The data point type identifier (used for per-data-point threshold lookups).
+     * @param framework The framework of the dataset (used for per-data-point threshold lookups).
+     * @return true if the change is significant and auto pre-approval should be suppressed; false otherwise.
+     */
+    fun checkForSignificantChange(
+        originalValue: JsonNode?,
+        liveValue: JsonNode?,
+        valueType: ValueType,
+        dataPointType: String,
+        framework: DataTypeEnum,
+    ): Boolean {
+        if (isNullOrJsonNull(originalValue) || isNullOrJsonNull(liveValue)) return false
+
+        return when (valueType) {
+            ValueType.BOOLEAN -> originalValue!!.asText() != liveValue!!.asText()
+            ValueType.DECIMAL -> isDecimalChangeSignificant(originalValue!!, liveValue!!, dataPointType, framework)
+            ValueType.INTEGER -> isIntegerChangeSignificant(originalValue!!, liveValue!!, dataPointType, framework)
+            ValueType.UNSUPPORTED -> false
+        }
+    }
+
+    private fun isNullOrJsonNull(value: JsonNode?): Boolean = value == null || value.isNull
+
+    private fun isDecimalChangeSignificant(
+        originalValue: JsonNode,
+        liveValue: JsonNode,
+        dataPointType: String,
+        framework: DataTypeEnum,
+    ): Boolean {
+        if (!originalValue.isNumber || !liveValue.isNumber) return false
+        val original = originalValue.decimalValue()
+        val live = liveValue.decimalValue()
+        val threshold =
+            BigDecimal.valueOf(
+                individualDecimalThresholds[framework]?.get(dataPointType) ?: DECIMAL_RELATIVE_THRESHOLD,
+            )
+        return if (live.compareTo(BigDecimal.ZERO) == 0) {
+            original.compareTo(BigDecimal.ZERO) != 0
+        } else {
+            (original - live).abs().divide(live.abs(), DECIMAL_DIVISION_SCALE, RoundingMode.HALF_UP) > threshold
+        }
+    }
+
+    private fun isIntegerChangeSignificant(
+        originalValue: JsonNode,
+        liveValue: JsonNode,
+        dataPointType: String,
+        framework: DataTypeEnum,
+    ): Boolean {
+        if (!originalValue.isIntegralNumber || !liveValue.isIntegralNumber) return false
+        val original = originalValue.bigIntegerValue()
+        val live = liveValue.bigIntegerValue()
+        val threshold = individualIntegerThresholds[framework]?.get(dataPointType) ?: INTEGER_ABSOLUTE_THRESHOLD
+        return (original - live).abs() > threshold
+    }
+}

--- a/dataland-qa-service/src/main/kotlin/org/dataland/datalandqaservice/services/SignificanceCheckService.kt
+++ b/dataland-qa-service/src/main/kotlin/org/dataland/datalandqaservice/services/SignificanceCheckService.kt
@@ -91,8 +91,9 @@ class SignificanceCheckService {
         dataPointType: String,
         framework: DataTypeEnum,
     ): Boolean {
-        val original = originalValue?.takeUnless { it.isNull } ?: return false
-        val live = liveValue?.takeUnless { it.isNull } ?: return false
+        val original = originalValue?.takeUnless { it.isNull }
+        val live = liveValue?.takeUnless { it.isNull }
+        if (original == null || live == null) return false
 
         return when (valueType) {
             ValueType.BOOLEAN -> original.asText() != live.asText()
@@ -108,8 +109,9 @@ class SignificanceCheckService {
         dataPointType: String,
         framework: DataTypeEnum,
     ): Boolean {
-        val original = originalValue.decimalValueOrNull() ?: return false
-        val live = liveValue.decimalValueOrNull() ?: return false
+        val original = originalValue.decimalValueOrNull()
+        val live = liveValue.decimalValueOrNull()
+        if (original == null || live == null) return false
         val threshold = getDecimalThreshold(dataPointType, framework)
 
         return isRelativeDecimalChangeAboveThreshold(original, live, threshold)
@@ -139,8 +141,9 @@ class SignificanceCheckService {
         dataPointType: String,
         framework: DataTypeEnum,
     ): Boolean {
-        val original = originalValue.bigIntegerValueOrNull() ?: return false
-        val live = liveValue.bigIntegerValueOrNull() ?: return false
+        val original = originalValue.bigIntegerValueOrNull()
+        val live = liveValue.bigIntegerValueOrNull()
+        if (original == null || live == null) return false
         val threshold = getIntegerThreshold(dataPointType, framework)
 
         return original.subtract(live).abs() > threshold

--- a/dataland-qa-service/src/test/kotlin/org/dataland/datalandqaservice/services/DatasetJudgementServiceTest.kt
+++ b/dataland-qa-service/src/test/kotlin/org/dataland/datalandqaservice/services/DatasetJudgementServiceTest.kt
@@ -24,6 +24,7 @@ import org.dataland.datalandqaservice.org.dataland.datalandqaservice.services.Da
 import org.dataland.datalandqaservice.org.dataland.datalandqaservice.services.DatasetJudgementSupportService
 import org.dataland.datalandqaservice.org.dataland.datalandqaservice.services.PreApprovalService
 import org.dataland.datalandqaservice.org.dataland.datalandqaservice.services.QaReviewManager
+import org.dataland.datalandqaservice.org.dataland.datalandqaservice.services.SignificanceCheckService
 import org.dataland.datalandqaservice.utils.MockDatasetJudgementEntityForTest
 import org.dataland.keycloakAdapter.auth.DatalandRealmRole
 import org.dataland.keycloakAdapter.utils.AuthenticationMock
@@ -58,7 +59,12 @@ class DatasetJudgementServiceTest {
         DatasetJudgementCreationService(
             datasetJudgementSupportService,
             keycloakUserService,
-            PreApprovalService(autoPreApprovalEnabled = false, exemptFieldsConfig = PreApprovalExemptFieldsConfig()),
+            PreApprovalService(
+                autoPreApprovalEnabled = false,
+                exemptFieldsConfig = PreApprovalExemptFieldsConfig(),
+                significanceCheckService = SignificanceCheckService(),
+                datasetJudgementSupportService = datasetJudgementSupportService,
+            ),
         )
 
     private val service =

--- a/dataland-qa-service/src/test/kotlin/org/dataland/datalandqaservice/services/DatasetJudgementSupportServiceTest.kt
+++ b/dataland-qa-service/src/test/kotlin/org/dataland/datalandqaservice/services/DatasetJudgementSupportServiceTest.kt
@@ -1,5 +1,6 @@
 package org.dataland.datalandqaservice.services
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import org.dataland.datalandbackend.openApiClient.api.DataPointControllerApi
 import org.dataland.datalandbackend.openApiClient.api.MetaDataControllerApi
 import org.dataland.datalandbackend.openApiClient.model.DataMetaInformation
@@ -39,6 +40,7 @@ class DatasetJudgementSupportServiceTest {
             specificationControllerApi,
             dataPointQaReportRepository,
             datasetJudgementRepository,
+            ObjectMapper(),
         )
 
     @Test

--- a/dataland-qa-service/src/test/kotlin/org/dataland/datalandqaservice/services/DatasetJudgementSupportServiceTest.kt
+++ b/dataland-qa-service/src/test/kotlin/org/dataland/datalandqaservice/services/DatasetJudgementSupportServiceTest.kt
@@ -282,7 +282,13 @@ class DatasetJudgementSupportServiceTest {
     @Test
     fun `getDataPointValueNode returns value node when value field is present`() {
         val dataPointId = "dp-1"
-        val uploadedDataPoint = UploadedDataPoint(dataPoint = """{"value":"Yes"}""", dataPointType = "dummyType", companyId = "c1", reportingPeriod = "2024")
+        val uploadedDataPoint =
+            UploadedDataPoint(
+                dataPoint = """{"value":"Yes"}""",
+                dataPointType = "dummyType",
+                companyId = "c1",
+                reportingPeriod = "2024",
+            )
 
         whenever(dataPointControllerApi.getDataPoint(dataPointId)).thenReturn(uploadedDataPoint)
 
@@ -295,7 +301,13 @@ class DatasetJudgementSupportServiceTest {
     @Test
     fun `getDataPointValueNode returns null when value field is absent`() {
         val dataPointId = "dp-2"
-        val uploadedDataPoint = UploadedDataPoint(dataPoint = """{"foo":"bar"}""", dataPointType = "dummyType", companyId = "c1", reportingPeriod = "2024")
+        val uploadedDataPoint =
+            UploadedDataPoint(
+                dataPoint = """{"foo":"bar"}""",
+                dataPointType = "dummyType",
+                companyId = "c1",
+                reportingPeriod = "2024",
+            )
 
         whenever(dataPointControllerApi.getDataPoint(dataPointId)).thenReturn(uploadedDataPoint)
 
@@ -308,7 +320,13 @@ class DatasetJudgementSupportServiceTest {
     @Test
     fun `getDataPointValueNode returns null when value field is JSON null`() {
         val dataPointId = "dp-3"
-        val uploadedDataPoint = UploadedDataPoint(dataPoint = """{"value":null}""", dataPointType = "dummyType", companyId = "c1", reportingPeriod = "2024")
+        val uploadedDataPoint =
+            UploadedDataPoint(
+                dataPoint = """{"value":null}""",
+                dataPointType = "dummyType",
+                companyId = "c1",
+                reportingPeriod = "2024",
+            )
 
         whenever(dataPointControllerApi.getDataPoint(dataPointId)).thenReturn(uploadedDataPoint)
 
@@ -342,5 +360,4 @@ class DatasetJudgementSupportServiceTest {
         assertEquals(expectedBaseTypeId, result)
         verify(specificationControllerApi).getDataPointTypeSpecification(dataPointType)
     }
-
 }

--- a/dataland-qa-service/src/test/kotlin/org/dataland/datalandqaservice/services/DatasetJudgementSupportServiceTest.kt
+++ b/dataland-qa-service/src/test/kotlin/org/dataland/datalandqaservice/services/DatasetJudgementSupportServiceTest.kt
@@ -220,4 +220,61 @@ class DatasetJudgementSupportServiceTest {
         assertEquals(expectedType, result)
         verify(dataPointQaReportRepository).findDataPointTypeUsingId(qaReportId.toString())
     }
+
+    @Test
+    fun `getLatestActiveDataPoints returns null when no active dataset exists`() {
+        whenever(
+            metaDataControllerApi.getListOfDataMetaInfo(
+                companyId = "company-id",
+                dataType = DataTypeEnum.sfdr,
+                showOnlyActive = true,
+            ),
+        ).thenReturn(emptyList())
+
+        val result =
+            service.getLatestActiveDataPoints(
+                companyId = UUID.randomUUID(),
+                dataType = DataTypeEnum.sfdr,
+            )
+
+        assertEquals(null, result)
+    }
+
+    @Test
+    fun `getLatestActiveDataPoints returns contained datapoints of latest active dataset`() {
+        val companyId = UUID.randomUUID()
+        val olderDataset =
+            DataMetaInformation(
+                dataId = "dataset-2023",
+                companyId = companyId.toString(),
+                dataType = DataTypeEnum.sfdr,
+                uploadTime = 1L,
+                reportingPeriod = "2023",
+                currentlyActive = true,
+                qaStatus = QaStatus.Accepted,
+            )
+        val newerDataset =
+            olderDataset.copy(
+                dataId = "dataset-2024",
+                reportingPeriod = "2024",
+            )
+        val expected = mapOf("someType" to "someDataPointId")
+
+        whenever(
+            metaDataControllerApi.getListOfDataMetaInfo(
+                companyId = companyId.toString(),
+                dataType = DataTypeEnum.sfdr,
+                showOnlyActive = true,
+            ),
+        ).thenReturn(listOf(olderDataset, newerDataset))
+
+        whenever(metaDataControllerApi.getContainedDataPoints("dataset-2024"))
+            .thenReturn(expected)
+
+        val result = service.getLatestActiveDataPoints(companyId, DataTypeEnum.sfdr)
+
+        assertEquals(expected, result)
+        verify(metaDataControllerApi).getContainedDataPoints("dataset-2024")
+    }
+
 }

--- a/dataland-qa-service/src/test/kotlin/org/dataland/datalandqaservice/services/DatasetJudgementSupportServiceTest.kt
+++ b/dataland-qa-service/src/test/kotlin/org/dataland/datalandqaservice/services/DatasetJudgementSupportServiceTest.kt
@@ -255,9 +255,10 @@ class DatasetJudgementSupportServiceTest {
                 currentlyActive = true,
                 qaStatus = QaStatus.Accepted,
             )
+        val arbitraryDatasetId = "dataset-2024"
         val newerDataset =
             olderDataset.copy(
-                dataId = "dataset-2024",
+                dataId = arbitraryDatasetId,
                 reportingPeriod = "2024",
             )
         val expected = mapOf("someType" to "someDataPointId")
@@ -270,13 +271,13 @@ class DatasetJudgementSupportServiceTest {
             ),
         ).thenReturn(listOf(olderDataset, newerDataset))
 
-        whenever(metaDataControllerApi.getContainedDataPoints("dataset-2024"))
+        whenever(metaDataControllerApi.getContainedDataPoints(arbitraryDatasetId))
             .thenReturn(expected)
 
         val result = service.getLatestActiveDataPoints(companyId, DataTypeEnum.sfdr)
 
         assertEquals(expected, result)
-        verify(metaDataControllerApi).getContainedDataPoints("dataset-2024")
+        verify(metaDataControllerApi).getContainedDataPoints(arbitraryDatasetId)
     }
 
     @Test

--- a/dataland-qa-service/src/test/kotlin/org/dataland/datalandqaservice/services/DatasetJudgementSupportServiceTest.kt
+++ b/dataland-qa-service/src/test/kotlin/org/dataland/datalandqaservice/services/DatasetJudgementSupportServiceTest.kt
@@ -8,6 +8,7 @@ import org.dataland.datalandbackend.openApiClient.model.DataPointMetaInformation
 import org.dataland.datalandbackend.openApiClient.model.DataPointToValidate
 import org.dataland.datalandbackend.openApiClient.model.DataTypeEnum
 import org.dataland.datalandbackend.openApiClient.model.QaStatus
+import org.dataland.datalandbackend.openApiClient.model.UploadedDataPoint
 import org.dataland.datalandqaservice.model.reports.QaReportDataPointVerdict
 import org.dataland.datalandqaservice.org.dataland.datalandqaservice.entities.DataPointQaReportEntity
 import org.dataland.datalandqaservice.org.dataland.datalandqaservice.repositories.DataPointQaReportRepository
@@ -17,6 +18,7 @@ import org.dataland.datalandspecificationservice.openApiClient.api.Specification
 import org.dataland.datalandspecificationservice.openApiClient.model.DataPointTypeSpecification
 import org.dataland.datalandspecificationservice.openApiClient.model.IdWithRef
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.mock
@@ -275,6 +277,70 @@ class DatasetJudgementSupportServiceTest {
 
         assertEquals(expected, result)
         verify(metaDataControllerApi).getContainedDataPoints("dataset-2024")
+    }
+
+    @Test
+    fun `getDataPointValueNode returns value node when value field is present`() {
+        val dataPointId = "dp-1"
+        val uploadedDataPoint = UploadedDataPoint(dataPoint = """{"value":"Yes"}""", dataPointType = "dummyType", companyId = "c1", reportingPeriod = "2024")
+
+        whenever(dataPointControllerApi.getDataPoint(dataPointId)).thenReturn(uploadedDataPoint)
+
+        val result = service.getDataPointValueNode(dataPointId)
+
+        assertEquals("Yes", result?.asText())
+        verify(dataPointControllerApi).getDataPoint(dataPointId)
+    }
+
+    @Test
+    fun `getDataPointValueNode returns null when value field is absent`() {
+        val dataPointId = "dp-2"
+        val uploadedDataPoint = UploadedDataPoint(dataPoint = """{"foo":"bar"}""", dataPointType = "dummyType", companyId = "c1", reportingPeriod = "2024")
+
+        whenever(dataPointControllerApi.getDataPoint(dataPointId)).thenReturn(uploadedDataPoint)
+
+        val result = service.getDataPointValueNode(dataPointId)
+
+        assertNull(result)
+        verify(dataPointControllerApi).getDataPoint(dataPointId)
+    }
+
+    @Test
+    fun `getDataPointValueNode returns null when value field is JSON null`() {
+        val dataPointId = "dp-3"
+        val uploadedDataPoint = UploadedDataPoint(dataPoint = """{"value":null}""", dataPointType = "dummyType", companyId = "c1", reportingPeriod = "2024")
+
+        whenever(dataPointControllerApi.getDataPoint(dataPointId)).thenReturn(uploadedDataPoint)
+
+        val result = service.getDataPointValueNode(dataPointId)
+
+        assertNull(result)
+        verify(dataPointControllerApi).getDataPoint(dataPointId)
+    }
+
+    @Test
+    fun `resolveBaseTypeId delegates to SpecificationControllerApi and returns base type id`() {
+        val dataPointType = "dummyType"
+        val expectedBaseTypeId = "extendedDecimal"
+        val ref = "dummy ref"
+
+        val spec =
+            DataPointTypeSpecification(
+                dataPointType = IdWithRef(id = dataPointType, ref = ref),
+                name = "Some name",
+                businessDefinition = "Some business definition",
+                dataPointBaseType = IdWithRef(id = expectedBaseTypeId, ref = ref),
+                usedBy = emptyList(),
+                constraints = null,
+                calculationRules = emptyList(),
+            )
+
+        whenever(specificationControllerApi.getDataPointTypeSpecification(dataPointType)).thenReturn(spec)
+
+        val result = service.resolveBaseTypeId(dataPointType)
+
+        assertEquals(expectedBaseTypeId, result)
+        verify(specificationControllerApi).getDataPointTypeSpecification(dataPointType)
     }
 
 }

--- a/dataland-qa-service/src/test/kotlin/org/dataland/datalandqaservice/services/DatasetJudgementSupportServiceTest.kt
+++ b/dataland-qa-service/src/test/kotlin/org/dataland/datalandqaservice/services/DatasetJudgementSupportServiceTest.kt
@@ -234,7 +234,7 @@ class DatasetJudgementSupportServiceTest {
         ).thenReturn(emptyList())
 
         val result =
-            service.getLatestActiveDataPoints(
+            service.getDataPointsOfLatestActiveDataset(
                 companyId = UUID.randomUUID(),
                 dataType = DataTypeEnum.sfdr,
             )
@@ -274,7 +274,7 @@ class DatasetJudgementSupportServiceTest {
         whenever(metaDataControllerApi.getContainedDataPoints(arbitraryDatasetId))
             .thenReturn(expected)
 
-        val result = service.getLatestActiveDataPoints(companyId, DataTypeEnum.sfdr)
+        val result = service.getDataPointsOfLatestActiveDataset(companyId, DataTypeEnum.sfdr)
 
         assertEquals(expected, result)
         verify(metaDataControllerApi).getContainedDataPoints(arbitraryDatasetId)

--- a/dataland-qa-service/src/test/kotlin/org/dataland/datalandqaservice/services/PreApprovalServiceTest.kt
+++ b/dataland-qa-service/src/test/kotlin/org/dataland/datalandqaservice/services/PreApprovalServiceTest.kt
@@ -280,11 +280,6 @@ class PreApprovalServiceTest {
         }
     }
 
-    // --- Significance check integration tests ---
-    //
-    // All tests in this nested class use datasets where all QA reports are QaAccepted.
-    // They verify that the significance gate works correctly with the end-to-end PreApprovalService.
-
     @Nested
     inner class SignificanceCheckTests {
         private val dataPointType = "extendedDecimalField"
@@ -344,7 +339,6 @@ class PreApprovalServiceTest {
 
         @Test
         fun `significant decimal change suppresses preapproval`() {
-            // live=100, original=200 -> 100% relative change > 50% threshold -> significant
             val service =
                 buildServiceWithLiveDataset(
                     originalValueNode = DecimalNode(BigDecimal.valueOf(200)),
@@ -357,7 +351,6 @@ class PreApprovalServiceTest {
 
         @Test
         fun `non-significant decimal change allows preapproval`() {
-            // live=100, original=110 -> 10% relative change < 50% threshold -> not significant
             val service =
                 buildServiceWithLiveDataset(
                     originalValueNode = DecimalNode(BigDecimal.valueOf(110)),
@@ -370,7 +363,6 @@ class PreApprovalServiceTest {
 
         @Test
         fun `significant integer change suppresses preapproval`() {
-            // |15 - 5| = 10 > 5 threshold -> significant
             val service =
                 buildServiceWithLiveDataset(
                     originalValueNode = IntNode(15),
@@ -383,7 +375,6 @@ class PreApprovalServiceTest {
 
         @Test
         fun `non-significant integer change allows preapproval`() {
-            // |7 - 5| = 2 < 5 threshold -> not significant
             val service =
                 buildServiceWithLiveDataset(
                     originalValueNode = IntNode(7),
@@ -396,7 +387,6 @@ class PreApprovalServiceTest {
 
         @Test
         fun `significant boolean change suppresses preapproval`() {
-            // Yes -> No: any boolean change is significant
             val service =
                 buildServiceWithLiveDataset(
                     originalValueNode = TextNode("Yes"),
@@ -409,7 +399,6 @@ class PreApprovalServiceTest {
 
         @Test
         fun `non-significant boolean (same value) allows preapproval`() {
-            // Yes -> Yes: no change -> not significant
             val service =
                 buildServiceWithLiveDataset(
                     originalValueNode = TextNode("Yes"),
@@ -422,7 +411,6 @@ class PreApprovalServiceTest {
 
         @Test
         fun `original non-null but live value null allows preapproval`() {
-            // Null live value -> significance check returns false (not significant) -> allow
             val service =
                 buildServiceWithLiveDataset(
                     originalValueNode = DecimalNode(BigDecimal.valueOf(100)),
@@ -435,13 +423,12 @@ class PreApprovalServiceTest {
 
         @Test
         fun `datapoint type not present in live dataset allows preapproval`() {
-            // The live dataset does not contain this data point type at all
             val service =
                 buildServiceWithLiveDataset(
                     originalValueNode = DecimalNode(BigDecimal.valueOf(100)),
                     liveValueNode = DecimalNode(BigDecimal.valueOf(200)),
                     baseTypeId = "extendedDecimal",
-                    liveDataPointMap = emptyMap(), // type not in live dataset
+                    liveDataPointMap = emptyMap(),
                 )
 
             assertEquals(AcceptedDataPointSource.Original, runSignificanceWorkflow(service))

--- a/dataland-qa-service/src/test/kotlin/org/dataland/datalandqaservice/services/PreApprovalServiceTest.kt
+++ b/dataland-qa-service/src/test/kotlin/org/dataland/datalandqaservice/services/PreApprovalServiceTest.kt
@@ -1,5 +1,10 @@
 package org.dataland.datalandqaservice.services
 
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.node.DecimalNode
+import com.fasterxml.jackson.databind.node.IntNode
+import com.fasterxml.jackson.databind.node.NullNode
+import com.fasterxml.jackson.databind.node.TextNode
 import org.dataland.datalandbackend.openApiClient.model.DataTypeEnum
 import org.dataland.datalandqaservice.configurations.PreApprovalExemptFieldsConfig
 import org.dataland.datalandqaservice.model.reports.AcceptedDataPointSource
@@ -7,17 +12,24 @@ import org.dataland.datalandqaservice.model.reports.QaReportDataPointVerdict
 import org.dataland.datalandqaservice.org.dataland.datalandqaservice.entities.DataPointJudgementEntity
 import org.dataland.datalandqaservice.org.dataland.datalandqaservice.entities.DataPointQaReportEntity
 import org.dataland.datalandqaservice.org.dataland.datalandqaservice.model.PreApprovalConfig
+import org.dataland.datalandqaservice.org.dataland.datalandqaservice.services.DatasetJudgementSupportService
 import org.dataland.datalandqaservice.org.dataland.datalandqaservice.services.PreApprovalService
+import org.dataland.datalandqaservice.org.dataland.datalandqaservice.services.SignificanceCheckService
 import org.dataland.datalandqaservice.utils.MockDatasetJudgementEntityForTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import java.math.BigDecimal
 import java.util.UUID
 
 class PreApprovalServiceTest {
     private val dummyReporter1 = UUID.randomUUID().toString()
     private val dummyReporter2 = UUID.randomUUID().toString()
+    private val significanceCheckService = SignificanceCheckService()
 
     private fun buildQaReport(
         reporterUserId: String,
@@ -39,14 +51,39 @@ class PreApprovalServiceTest {
     private fun buildDataPointJudgementEntity(
         qaReports: List<DataPointQaReportEntity>,
         dataPointType: String = MockDatasetJudgementEntityForTest.DUMMY_DATA_POINT_TYPE,
+        dataPointId: String = UUID.randomUUID().toString(),
     ): DataPointJudgementEntity =
         DataPointJudgementEntity(
             dataPointType = dataPointType,
-            dataPointId = UUID.randomUUID().toString(),
+            dataPointId = dataPointId,
             qaReports = qaReports.toMutableList(),
             acceptedSource = null,
             reporterUserIdOfAcceptedQaReport = null,
             customValue = null,
+        )
+
+    /**
+     * Creates a mock [DatasetJudgementSupportService] that returns no live dataset.
+     * Use this for tests that cover pre-existing behaviour unrelated to significance checks.
+     */
+    private fun mockSupportServiceWithNoLiveDataset(): DatasetJudgementSupportService =
+        mock<DatasetJudgementSupportService>().also {
+            whenever(it.getLatestActiveDataPoints(any(), any())).thenReturn(null)
+        }
+
+    /**
+     * Builds a [PreApprovalService] pre-configured to skip the significance check
+     * (no live dataset). Use this for all tests that verify pre-existing behaviour.
+     */
+    private fun buildServiceWithoutLiveDataset(
+        autoPreApprovalEnabled: Boolean,
+        exemptFieldsConfig: PreApprovalExemptFieldsConfig = PreApprovalExemptFieldsConfig(),
+    ): PreApprovalService =
+        PreApprovalService(
+            autoPreApprovalEnabled = autoPreApprovalEnabled,
+            exemptFieldsConfig = exemptFieldsConfig,
+            significanceCheckService = significanceCheckService,
+            datasetJudgementSupportService = mockSupportServiceWithNoLiveDataset(),
         )
 
     private fun runWorkflow(
@@ -69,7 +106,7 @@ class PreApprovalServiceTest {
     inner class ReportConsensusTests {
         @Test
         fun `No preapproval when environment variable is set to false`() {
-            val service = PreApprovalService(autoPreApprovalEnabled = false, exemptFieldsConfig = PreApprovalExemptFieldsConfig())
+            val service = buildServiceWithoutLiveDataset(autoPreApprovalEnabled = false)
             val reports = listOf(buildQaReport(dummyReporter1, QaReportDataPointVerdict.QaAccepted))
 
             assertNull(runWorkflow(service, reports))
@@ -77,7 +114,7 @@ class PreApprovalServiceTest {
 
         @Test
         fun `Preapproval works when environment variable is true, there is only 1 reporter and report is QaAccepted`() {
-            val service = PreApprovalService(autoPreApprovalEnabled = true, exemptFieldsConfig = PreApprovalExemptFieldsConfig())
+            val service = buildServiceWithoutLiveDataset(autoPreApprovalEnabled = true)
             val reports = listOf(buildQaReport(dummyReporter1, QaReportDataPointVerdict.QaAccepted))
 
             assertEquals(AcceptedDataPointSource.Original, runWorkflow(service, reports))
@@ -85,7 +122,7 @@ class PreApprovalServiceTest {
 
         @Test
         fun `Preapproval works when environment variable is true, there are 2 reporter and all reports are QaAccepted`() {
-            val service = PreApprovalService(autoPreApprovalEnabled = true, exemptFieldsConfig = PreApprovalExemptFieldsConfig())
+            val service = buildServiceWithoutLiveDataset(autoPreApprovalEnabled = true)
             val reports =
                 listOf(
                     buildQaReport(dummyReporter1, QaReportDataPointVerdict.QaAccepted),
@@ -97,7 +134,7 @@ class PreApprovalServiceTest {
 
         @Test
         fun `No preapproval when there are two reports with mixed verdicts`() {
-            val service = PreApprovalService(autoPreApprovalEnabled = true, exemptFieldsConfig = PreApprovalExemptFieldsConfig())
+            val service = buildServiceWithoutLiveDataset(autoPreApprovalEnabled = true)
             val reports =
                 listOf(
                     buildQaReport(dummyReporter1, QaReportDataPointVerdict.QaAccepted),
@@ -109,7 +146,7 @@ class PreApprovalServiceTest {
 
         @Test
         fun `No preapproval when there are no QA reports`() {
-            val service = PreApprovalService(autoPreApprovalEnabled = true, exemptFieldsConfig = PreApprovalExemptFieldsConfig())
+            val service = buildServiceWithoutLiveDataset(autoPreApprovalEnabled = true)
 
             assertNull(runWorkflow(service, emptyList()))
         }
@@ -121,7 +158,7 @@ class PreApprovalServiceTest {
         fun `No preapproval for exempt field even if all reports are QaAccepted`() {
             val exemptField = "exempt-field-type"
             val service =
-                PreApprovalService(
+                buildServiceWithoutLiveDataset(
                     autoPreApprovalEnabled = true,
                     exemptFieldsConfig = PreApprovalExemptFieldsConfig(mapOf(DataTypeEnum.sfdr to setOf(exemptField))),
                 )
@@ -134,7 +171,7 @@ class PreApprovalServiceTest {
         fun `Preapproval works for non-exempt field when all reports are QaAccepted`() {
             val nonExemptField = "non-exempt-field-type"
             val service =
-                PreApprovalService(
+                buildServiceWithoutLiveDataset(
                     autoPreApprovalEnabled = true,
                     exemptFieldsConfig = PreApprovalExemptFieldsConfig(mapOf(DataTypeEnum.sfdr to setOf("some-exempt-field-type"))),
                 )
@@ -146,7 +183,7 @@ class PreApprovalServiceTest {
         @Test
         fun `All qualifying fields are auto-accepted when exempt fields list is empty`() {
             val service =
-                PreApprovalService(
+                buildServiceWithoutLiveDataset(
                     autoPreApprovalEnabled = true,
                     exemptFieldsConfig = PreApprovalExemptFieldsConfig(emptyMap()),
                 )
@@ -160,7 +197,7 @@ class PreApprovalServiceTest {
             val exemptField = "exempt-field-type"
             val nonExemptField = "non-exempt-field-type"
             val service =
-                PreApprovalService(
+                buildServiceWithoutLiveDataset(
                     autoPreApprovalEnabled = true,
                     exemptFieldsConfig = PreApprovalExemptFieldsConfig(mapOf(DataTypeEnum.sfdr to setOf(exemptField))),
                 )
@@ -182,7 +219,7 @@ class PreApprovalServiceTest {
         @Test
         fun `Qualifying fields are auto-accepted when exempt fields list contains only non-existent fields`() {
             val service =
-                PreApprovalService(
+                buildServiceWithoutLiveDataset(
                     autoPreApprovalEnabled = true,
                     exemptFieldsConfig = PreApprovalExemptFieldsConfig(mapOf(DataTypeEnum.sfdr to setOf("non-existent-field"))),
                 )
@@ -195,7 +232,7 @@ class PreApprovalServiceTest {
         fun `Exempt field in one framework does not block preapproval for the same field in another framework`() {
             val fieldName = "shared-field-type"
             val service =
-                PreApprovalService(
+                buildServiceWithoutLiveDataset(
                     autoPreApprovalEnabled = true,
                     exemptFieldsConfig = PreApprovalExemptFieldsConfig(mapOf(DataTypeEnum.vsme to setOf(fieldName))),
                 )
@@ -209,7 +246,7 @@ class PreApprovalServiceTest {
     inner class SamplingTests {
         @Test
         fun `Sampling probability 1 - no datapoints are preapproved`() {
-            val service = PreApprovalService(autoPreApprovalEnabled = true, exemptFieldsConfig = PreApprovalExemptFieldsConfig())
+            val service = buildServiceWithoutLiveDataset(autoPreApprovalEnabled = true)
             service.patchConfig(PreApprovalConfig(samplingProbability = 1.0))
             val reports = listOf(buildQaReport(dummyReporter1, QaReportDataPointVerdict.QaAccepted))
 
@@ -218,7 +255,7 @@ class PreApprovalServiceTest {
 
         @Test
         fun `Sampling probability 0, datapoint is not on exempt list and has report QaAccepted - datapoint gets preapproved`() {
-            val service = PreApprovalService(autoPreApprovalEnabled = true, exemptFieldsConfig = PreApprovalExemptFieldsConfig())
+            val service = buildServiceWithoutLiveDataset(autoPreApprovalEnabled = true)
             service.patchConfig(PreApprovalConfig(samplingProbability = 0.0))
             val reports = listOf(buildQaReport(dummyReporter1, QaReportDataPointVerdict.QaAccepted))
 
@@ -227,7 +264,7 @@ class PreApprovalServiceTest {
 
         @Test
         fun `getConfig returns samplingProbability`() {
-            val service = PreApprovalService(autoPreApprovalEnabled = true, exemptFieldsConfig = PreApprovalExemptFieldsConfig())
+            val service = buildServiceWithoutLiveDataset(autoPreApprovalEnabled = true)
             service.patchConfig(PreApprovalConfig(samplingProbability = 0.42))
 
             assertEquals(0.42, service.config.samplingProbability)
@@ -235,11 +272,177 @@ class PreApprovalServiceTest {
 
         @Test
         fun `patchConfig updates samplingProbability and returns updated config`() {
-            val service = PreApprovalService(autoPreApprovalEnabled = true, exemptFieldsConfig = PreApprovalExemptFieldsConfig())
+            val service = buildServiceWithoutLiveDataset(autoPreApprovalEnabled = true)
             val updated = service.patchConfig(PreApprovalConfig(samplingProbability = 0.7))
 
             assertEquals(0.7, updated.samplingProbability)
             assertEquals(0.7, service.config.samplingProbability)
+        }
+    }
+
+    // --- Significance check integration tests ---
+    //
+    // All tests in this nested class use datasets where all QA reports are QaAccepted.
+    // They verify that the significance gate works correctly with the end-to-end PreApprovalService.
+
+    @Nested
+    inner class SignificanceCheckTests {
+        private val dataPointType = "extendedDecimalField"
+        private val originalDataPointId = UUID.randomUUID().toString()
+        private val liveDataPointId = UUID.randomUUID().toString()
+
+        private fun buildServiceWithLiveDataset(
+            originalValueNode: JsonNode?,
+            liveValueNode: JsonNode?,
+            baseTypeId: String,
+            dpType: String = dataPointType,
+            liveDataPointMap: Map<String, String> = mapOf(dpType to liveDataPointId),
+        ): PreApprovalService {
+            val supportServiceMock = mock<DatasetJudgementSupportService>()
+            whenever(supportServiceMock.getLatestActiveDataPoints(any(), any())).thenReturn(liveDataPointMap)
+            whenever(supportServiceMock.getDataPointValueNode(originalDataPointId)).thenReturn(originalValueNode)
+            whenever(supportServiceMock.getDataPointValueNode(liveDataPointId)).thenReturn(liveValueNode)
+            whenever(supportServiceMock.resolveBaseTypeId(dpType)).thenReturn(baseTypeId)
+            return PreApprovalService(
+                autoPreApprovalEnabled = true,
+                exemptFieldsConfig = PreApprovalExemptFieldsConfig(),
+                significanceCheckService = significanceCheckService,
+                datasetJudgementSupportService = supportServiceMock,
+            )
+        }
+
+        private fun runSignificanceWorkflow(
+            service: PreApprovalService,
+            dpType: String = dataPointType,
+        ): AcceptedDataPointSource? {
+            val reports = listOf(buildQaReport(dummyReporter1, QaReportDataPointVerdict.QaAccepted))
+            val dataPoint =
+                buildDataPointJudgementEntity(
+                    qaReports = reports,
+                    dataPointType = dpType,
+                    dataPointId = originalDataPointId,
+                )
+            val entity = MockDatasetJudgementEntityForTest.createDummyDatasetJudgementEntity()
+            entity.dataPoints.clear()
+            entity.dataPoints.add(dataPoint)
+            return service
+                .preApproveDataPoints(entity)
+                .dataPoints
+                .first()
+                .acceptedSource
+        }
+
+        @Test
+        fun `no live dataset - preapproval proceeds as normal`() {
+            val service = buildServiceWithoutLiveDataset(autoPreApprovalEnabled = true)
+            val reports = listOf(buildQaReport(dummyReporter1, QaReportDataPointVerdict.QaAccepted))
+
+            assertEquals(AcceptedDataPointSource.Original, runWorkflow(service, reports))
+        }
+
+        @Test
+        fun `significant decimal change suppresses preapproval`() {
+            // live=100, original=200 -> 100% relative change > 50% threshold -> significant
+            val service =
+                buildServiceWithLiveDataset(
+                    originalValueNode = DecimalNode(BigDecimal.valueOf(200)),
+                    liveValueNode = DecimalNode(BigDecimal.valueOf(100)),
+                    baseTypeId = "extendedDecimal",
+                )
+
+            assertNull(runSignificanceWorkflow(service))
+        }
+
+        @Test
+        fun `non-significant decimal change allows preapproval`() {
+            // live=100, original=110 -> 10% relative change < 50% threshold -> not significant
+            val service =
+                buildServiceWithLiveDataset(
+                    originalValueNode = DecimalNode(BigDecimal.valueOf(110)),
+                    liveValueNode = DecimalNode(BigDecimal.valueOf(100)),
+                    baseTypeId = "extendedDecimal",
+                )
+
+            assertEquals(AcceptedDataPointSource.Original, runSignificanceWorkflow(service))
+        }
+
+        @Test
+        fun `significant integer change suppresses preapproval`() {
+            // |15 - 5| = 10 > 5 threshold -> significant
+            val service =
+                buildServiceWithLiveDataset(
+                    originalValueNode = IntNode(15),
+                    liveValueNode = IntNode(5),
+                    baseTypeId = "extendedInteger",
+                )
+
+            assertNull(runSignificanceWorkflow(service))
+        }
+
+        @Test
+        fun `non-significant integer change allows preapproval`() {
+            // |7 - 5| = 2 < 5 threshold -> not significant
+            val service =
+                buildServiceWithLiveDataset(
+                    originalValueNode = IntNode(7),
+                    liveValueNode = IntNode(5),
+                    baseTypeId = "extendedInteger",
+                )
+
+            assertEquals(AcceptedDataPointSource.Original, runSignificanceWorkflow(service))
+        }
+
+        @Test
+        fun `significant boolean change suppresses preapproval`() {
+            // Yes -> No: any boolean change is significant
+            val service =
+                buildServiceWithLiveDataset(
+                    originalValueNode = TextNode("Yes"),
+                    liveValueNode = TextNode("No"),
+                    baseTypeId = "extendedEnumYesNo",
+                )
+
+            assertNull(runSignificanceWorkflow(service))
+        }
+
+        @Test
+        fun `non-significant boolean (same value) allows preapproval`() {
+            // Yes -> Yes: no change -> not significant
+            val service =
+                buildServiceWithLiveDataset(
+                    originalValueNode = TextNode("Yes"),
+                    liveValueNode = TextNode("Yes"),
+                    baseTypeId = "extendedEnumYesNo",
+                )
+
+            assertEquals(AcceptedDataPointSource.Original, runSignificanceWorkflow(service))
+        }
+
+        @Test
+        fun `original non-null but live value null allows preapproval`() {
+            // Null live value -> significance check returns false (not significant) -> allow
+            val service =
+                buildServiceWithLiveDataset(
+                    originalValueNode = DecimalNode(BigDecimal.valueOf(100)),
+                    liveValueNode = NullNode.instance,
+                    baseTypeId = "extendedDecimal",
+                )
+
+            assertEquals(AcceptedDataPointSource.Original, runSignificanceWorkflow(service))
+        }
+
+        @Test
+        fun `datapoint type not present in live dataset allows preapproval`() {
+            // The live dataset does not contain this data point type at all
+            val service =
+                buildServiceWithLiveDataset(
+                    originalValueNode = DecimalNode(BigDecimal.valueOf(100)),
+                    liveValueNode = DecimalNode(BigDecimal.valueOf(200)),
+                    baseTypeId = "extendedDecimal",
+                    liveDataPointMap = emptyMap(), // type not in live dataset
+                )
+
+            assertEquals(AcceptedDataPointSource.Original, runSignificanceWorkflow(service))
         }
     }
 }

--- a/dataland-qa-service/src/test/kotlin/org/dataland/datalandqaservice/services/PreApprovalServiceTest.kt
+++ b/dataland-qa-service/src/test/kotlin/org/dataland/datalandqaservice/services/PreApprovalServiceTest.kt
@@ -308,7 +308,9 @@ class PreApprovalServiceTest {
                 exemptFieldsConfig = PreApprovalExemptFieldsConfig(),
                 significanceCheckService = significanceCheckService,
                 datasetJudgementSupportService = supportServiceMock,
-            )
+            ).also {
+                it.patchConfig(PreApprovalConfig(samplingProbability = 0.0))
+            }
         }
 
         private fun runSignificanceWorkflow(

--- a/dataland-qa-service/src/test/kotlin/org/dataland/datalandqaservice/services/PreApprovalServiceTest.kt
+++ b/dataland-qa-service/src/test/kotlin/org/dataland/datalandqaservice/services/PreApprovalServiceTest.kt
@@ -68,7 +68,7 @@ class PreApprovalServiceTest {
      */
     private fun mockSupportServiceWithNoLiveDataset(): DatasetJudgementSupportService =
         mock<DatasetJudgementSupportService>().also {
-            whenever(it.getLatestActiveDataPoints(any(), any())).thenReturn(null)
+            whenever(it.getDataPointsOfLatestActiveDataset(any(), any())).thenReturn(null)
         }
 
     /**
@@ -294,7 +294,7 @@ class PreApprovalServiceTest {
             liveDataPointMap: Map<String, String> = mapOf(dpType to liveDataPointId),
         ): PreApprovalService {
             val supportServiceMock = mock<DatasetJudgementSupportService>()
-            whenever(supportServiceMock.getLatestActiveDataPoints(any(), any())).thenReturn(liveDataPointMap)
+            whenever(supportServiceMock.getDataPointsOfLatestActiveDataset(any(), any())).thenReturn(liveDataPointMap)
             whenever(supportServiceMock.getDataPointValueNode(originalDataPointId)).thenReturn(originalValueNode)
             whenever(supportServiceMock.getDataPointValueNode(liveDataPointId)).thenReturn(liveValueNode)
             whenever(supportServiceMock.resolveBaseTypeId(dpType)).thenReturn(baseTypeId)

--- a/dataland-qa-service/src/test/kotlin/org/dataland/datalandqaservice/services/SignificanceCheckServiceTest.kt
+++ b/dataland-qa-service/src/test/kotlin/org/dataland/datalandqaservice/services/SignificanceCheckServiceTest.kt
@@ -7,6 +7,8 @@ import com.fasterxml.jackson.databind.node.NullNode
 import com.fasterxml.jackson.databind.node.TextNode
 import org.dataland.datalandbackend.openApiClient.model.DataTypeEnum
 import org.dataland.datalandqaservice.org.dataland.datalandqaservice.services.SignificanceCheckService
+import org.dataland.datalandqaservice.org.dataland.datalandqaservice.services.SignificanceCheckService.Companion.DECIMAL_RELATIVE_THRESHOLD
+import org.dataland.datalandqaservice.org.dataland.datalandqaservice.services.SignificanceCheckService.Companion.INTEGER_ABSOLUTE_THRESHOLD
 import org.dataland.datalandqaservice.org.dataland.datalandqaservice.services.SignificanceCheckService.ValueType
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -19,6 +21,19 @@ class SignificanceCheckServiceTest {
     private val service = SignificanceCheckService()
     private val dummyFramework = DataTypeEnum.sfdr
     private val dummyDataPointType = "some-datapoint-type"
+
+    private val baseDecimalValue = BigDecimal.valueOf(100.0)
+    private val baseIntegerValue = 10
+
+    private fun createDecimalNodeWithRelativeMultiplier(
+        baseValue: BigDecimal,
+        multiplier: Double,
+    ): JsonNode = DecimalNode(baseValue.multiply(BigDecimal.valueOf(multiplier)))
+
+    private fun createIntegerNodeWithAbsoluteOffset(
+        baseValue: Int,
+        absoluteOffset: Int,
+    ): JsonNode = IntNode(baseValue + absoluteOffset)
 
     @Nested
     inner class ResolveValueTypeTests {
@@ -52,7 +67,7 @@ class SignificanceCheckServiceTest {
         fun `original value null returns false`() {
             assertFalse(
                 service.hasSignificantChange(
-                    originalValue = null,
+                    newValue = null,
                     liveValue = TextNode("Yes"),
                     valueType = ValueType.BOOLEAN,
                     dataPointType = dummyDataPointType,
@@ -65,7 +80,7 @@ class SignificanceCheckServiceTest {
         fun `live value null returns false`() {
             assertFalse(
                 service.hasSignificantChange(
-                    originalValue = TextNode("Yes"),
+                    newValue = TextNode("Yes"),
                     liveValue = null,
                     valueType = ValueType.BOOLEAN,
                     dataPointType = dummyDataPointType,
@@ -78,7 +93,7 @@ class SignificanceCheckServiceTest {
         fun `original value JSON null returns false`() {
             assertFalse(
                 service.hasSignificantChange(
-                    originalValue = NullNode.instance,
+                    newValue = NullNode.instance,
                     liveValue = TextNode("Yes"),
                     valueType = ValueType.BOOLEAN,
                     dataPointType = dummyDataPointType,
@@ -91,7 +106,7 @@ class SignificanceCheckServiceTest {
         fun `live value JSON null returns false`() {
             assertFalse(
                 service.hasSignificantChange(
-                    originalValue = TextNode("Yes"),
+                    newValue = TextNode("Yes"),
                     liveValue = NullNode.instance,
                     valueType = ValueType.BOOLEAN,
                     dataPointType = dummyDataPointType,
@@ -104,7 +119,7 @@ class SignificanceCheckServiceTest {
         fun `both null returns false`() {
             assertFalse(
                 service.hasSignificantChange(
-                    originalValue = null,
+                    newValue = null,
                     liveValue = null,
                     valueType = ValueType.BOOLEAN,
                     dataPointType = dummyDataPointType,
@@ -120,7 +135,7 @@ class SignificanceCheckServiceTest {
         fun `boolean change from Yes to No is significant`() {
             assertTrue(
                 service.hasSignificantChange(
-                    originalValue = TextNode("Yes"),
+                    newValue = TextNode("Yes"),
                     liveValue = TextNode("No"),
                     valueType = ValueType.BOOLEAN,
                     dataPointType = dummyDataPointType,
@@ -133,7 +148,7 @@ class SignificanceCheckServiceTest {
         fun `boolean change from No to Yes is significant`() {
             assertTrue(
                 service.hasSignificantChange(
-                    originalValue = TextNode("No"),
+                    newValue = TextNode("No"),
                     liveValue = TextNode("Yes"),
                     valueType = ValueType.BOOLEAN,
                     dataPointType = dummyDataPointType,
@@ -146,7 +161,7 @@ class SignificanceCheckServiceTest {
         fun `same boolean value Yes to Yes is not significant`() {
             assertFalse(
                 service.hasSignificantChange(
-                    originalValue = TextNode("Yes"),
+                    newValue = TextNode("Yes"),
                     liveValue = TextNode("Yes"),
                     valueType = ValueType.BOOLEAN,
                     dataPointType = dummyDataPointType,
@@ -159,7 +174,7 @@ class SignificanceCheckServiceTest {
         fun `same boolean value No to No is not significant`() {
             assertFalse(
                 service.hasSignificantChange(
-                    originalValue = TextNode("No"),
+                    newValue = TextNode("No"),
                     liveValue = TextNode("No"),
                     valueType = ValueType.BOOLEAN,
                     dataPointType = dummyDataPointType,
@@ -171,14 +186,12 @@ class SignificanceCheckServiceTest {
 
     @Nested
     inner class DecimalSignificanceTests {
-        private fun decimal(value: Double): JsonNode = DecimalNode(BigDecimal.valueOf(value))
-
         @Test
-        fun `decimal change above 50 percent relative threshold is significant`() {
+        fun `decimal increase above threshold is significant`() {
             assertTrue(
                 service.hasSignificantChange(
-                    originalValue = decimal(200.0),
-                    liveValue = decimal(100.0),
+                    newValue = createDecimalNodeWithRelativeMultiplier(baseDecimalValue, 1.0 + DECIMAL_RELATIVE_THRESHOLD * 1.05),
+                    liveValue = DecimalNode(baseDecimalValue),
                     valueType = ValueType.DECIMAL,
                     dataPointType = dummyDataPointType,
                     framework = dummyFramework,
@@ -187,11 +200,11 @@ class SignificanceCheckServiceTest {
         }
 
         @Test
-        fun `decimal change exactly at 50 percent relative threshold is not significant`() {
+        fun `decimal increase at threshold is not significant `() {
             assertFalse(
                 service.hasSignificantChange(
-                    originalValue = decimal(150.0),
-                    liveValue = decimal(100.0),
+                    newValue = createDecimalNodeWithRelativeMultiplier(baseDecimalValue, 1.0 + DECIMAL_RELATIVE_THRESHOLD),
+                    liveValue = DecimalNode(baseDecimalValue),
                     valueType = ValueType.DECIMAL,
                     dataPointType = dummyDataPointType,
                     framework = dummyFramework,
@@ -200,11 +213,50 @@ class SignificanceCheckServiceTest {
         }
 
         @Test
-        fun `decimal change below 50 percent relative threshold is not significant`() {
+        fun `decimal increase below threshold is not significant`() {
             assertFalse(
                 service.hasSignificantChange(
-                    originalValue = decimal(110.0),
-                    liveValue = decimal(100.0),
+                    newValue = createDecimalNodeWithRelativeMultiplier(baseDecimalValue, 1.0 + DECIMAL_RELATIVE_THRESHOLD * 0.95),
+                    liveValue = DecimalNode(baseDecimalValue),
+                    valueType = ValueType.DECIMAL,
+                    dataPointType = dummyDataPointType,
+                    framework = dummyFramework,
+                ),
+            )
+        }
+
+        @Test
+        fun `decimal decrease above threshold is significant`() {
+            assertTrue(
+                service.hasSignificantChange(
+                    newValue = createDecimalNodeWithRelativeMultiplier(baseDecimalValue, 1.0 - DECIMAL_RELATIVE_THRESHOLD * 1.05),
+                    liveValue = DecimalNode(baseDecimalValue),
+                    valueType = ValueType.DECIMAL,
+                    dataPointType = dummyDataPointType,
+                    framework = dummyFramework,
+                ),
+            )
+        }
+
+        @Test
+        fun `decimal decrease at threshold is not significant`() {
+            assertFalse(
+                service.hasSignificantChange(
+                    newValue = createDecimalNodeWithRelativeMultiplier(baseDecimalValue, 1.0 - DECIMAL_RELATIVE_THRESHOLD),
+                    liveValue = DecimalNode(baseDecimalValue),
+                    valueType = ValueType.DECIMAL,
+                    dataPointType = dummyDataPointType,
+                    framework = dummyFramework,
+                ),
+            )
+        }
+
+        @Test
+        fun `decimal decrease below threshold is not significant`() {
+            assertFalse(
+                service.hasSignificantChange(
+                    newValue = createDecimalNodeWithRelativeMultiplier(baseDecimalValue, 1.0 - DECIMAL_RELATIVE_THRESHOLD * 0.95),
+                    liveValue = DecimalNode(baseDecimalValue),
                     valueType = ValueType.DECIMAL,
                     dataPointType = dummyDataPointType,
                     framework = dummyFramework,
@@ -216,8 +268,8 @@ class SignificanceCheckServiceTest {
         fun `decimal unchanged is not significant`() {
             assertFalse(
                 service.hasSignificantChange(
-                    originalValue = decimal(100.0),
-                    liveValue = decimal(100.0),
+                    newValue = DecimalNode(baseDecimalValue),
+                    liveValue = DecimalNode(baseDecimalValue),
                     valueType = ValueType.DECIMAL,
                     dataPointType = dummyDataPointType,
                     framework = dummyFramework,
@@ -226,11 +278,11 @@ class SignificanceCheckServiceTest {
         }
 
         @Test
-        fun `decimal live value zero and non-zero original is significant`() {
+        fun `decimal live value zero and non-zero new value is significant`() {
             assertTrue(
                 service.hasSignificantChange(
-                    originalValue = decimal(10.0),
-                    liveValue = decimal(0.0),
+                    newValue = DecimalNode(baseDecimalValue),
+                    liveValue = DecimalNode(BigDecimal.ZERO),
                     valueType = ValueType.DECIMAL,
                     dataPointType = dummyDataPointType,
                     framework = dummyFramework,
@@ -242,21 +294,8 @@ class SignificanceCheckServiceTest {
         fun `decimal both values zero is not significant`() {
             assertFalse(
                 service.hasSignificantChange(
-                    originalValue = decimal(0.0),
-                    liveValue = decimal(0.0),
-                    valueType = ValueType.DECIMAL,
-                    dataPointType = dummyDataPointType,
-                    framework = dummyFramework,
-                ),
-            )
-        }
-
-        @Test
-        fun `decimal decrease above 50 percent is significant`() {
-            assertTrue(
-                service.hasSignificantChange(
-                    originalValue = decimal(40.0),
-                    liveValue = decimal(100.0),
+                    newValue = DecimalNode(BigDecimal.ZERO),
+                    liveValue = DecimalNode(BigDecimal.ZERO),
                     valueType = ValueType.DECIMAL,
                     dataPointType = dummyDataPointType,
                     framework = dummyFramework,
@@ -267,14 +306,12 @@ class SignificanceCheckServiceTest {
 
     @Nested
     inner class IntegerSignificanceTests {
-        private fun integer(value: Int): JsonNode = IntNode(value)
-
         @Test
-        fun `integer change above absolute threshold of 5 is significant`() {
+        fun `integer increase above threshold is significant`() {
             assertTrue(
                 service.hasSignificantChange(
-                    originalValue = integer(12),
-                    liveValue = integer(5),
+                    newValue = createIntegerNodeWithAbsoluteOffset(baseIntegerValue, INTEGER_ABSOLUTE_THRESHOLD.toInt() + 1),
+                    liveValue = IntNode(baseIntegerValue),
                     valueType = ValueType.INTEGER,
                     dataPointType = dummyDataPointType,
                     framework = dummyFramework,
@@ -283,11 +320,11 @@ class SignificanceCheckServiceTest {
         }
 
         @Test
-        fun `integer change exactly at threshold of 5 is not significant`() {
+        fun `integer increase at threshold is not significant`() {
             assertFalse(
                 service.hasSignificantChange(
-                    originalValue = integer(10),
-                    liveValue = integer(5),
+                    newValue = createIntegerNodeWithAbsoluteOffset(baseIntegerValue, INTEGER_ABSOLUTE_THRESHOLD.toInt()),
+                    liveValue = IntNode(baseIntegerValue),
                     valueType = ValueType.INTEGER,
                     dataPointType = dummyDataPointType,
                     framework = dummyFramework,
@@ -296,11 +333,50 @@ class SignificanceCheckServiceTest {
         }
 
         @Test
-        fun `integer change below absolute threshold of 5 is not significant`() {
+        fun `integer increase below threshold is not significant`() {
             assertFalse(
                 service.hasSignificantChange(
-                    originalValue = integer(7),
-                    liveValue = integer(5),
+                    newValue = createIntegerNodeWithAbsoluteOffset(baseIntegerValue, INTEGER_ABSOLUTE_THRESHOLD.toInt() - 1),
+                    liveValue = IntNode(baseIntegerValue),
+                    valueType = ValueType.INTEGER,
+                    dataPointType = dummyDataPointType,
+                    framework = dummyFramework,
+                ),
+            )
+        }
+
+        @Test
+        fun `integer decrease above threshold is significant`() {
+            assertTrue(
+                service.hasSignificantChange(
+                    newValue = createIntegerNodeWithAbsoluteOffset(baseIntegerValue, -(INTEGER_ABSOLUTE_THRESHOLD.toInt() + 1)),
+                    liveValue = IntNode(baseIntegerValue),
+                    valueType = ValueType.INTEGER,
+                    dataPointType = dummyDataPointType,
+                    framework = dummyFramework,
+                ),
+            )
+        }
+
+        @Test
+        fun `integer decrease at threshold is not significant`() {
+            assertFalse(
+                service.hasSignificantChange(
+                    newValue = createIntegerNodeWithAbsoluteOffset(baseIntegerValue, -INTEGER_ABSOLUTE_THRESHOLD.toInt()),
+                    liveValue = IntNode(baseIntegerValue),
+                    valueType = ValueType.INTEGER,
+                    dataPointType = dummyDataPointType,
+                    framework = dummyFramework,
+                ),
+            )
+        }
+
+        @Test
+        fun `integer decrease below threshold is not significant`() {
+            assertFalse(
+                service.hasSignificantChange(
+                    newValue = createIntegerNodeWithAbsoluteOffset(baseIntegerValue, -(INTEGER_ABSOLUTE_THRESHOLD.toInt() - 1)),
+                    liveValue = IntNode(baseIntegerValue),
                     valueType = ValueType.INTEGER,
                     dataPointType = dummyDataPointType,
                     framework = dummyFramework,
@@ -312,21 +388,8 @@ class SignificanceCheckServiceTest {
         fun `integer unchanged is not significant`() {
             assertFalse(
                 service.hasSignificantChange(
-                    originalValue = integer(42),
-                    liveValue = integer(42),
-                    valueType = ValueType.INTEGER,
-                    dataPointType = dummyDataPointType,
-                    framework = dummyFramework,
-                ),
-            )
-        }
-
-        @Test
-        fun `negative integer change above threshold is significant`() {
-            assertTrue(
-                service.hasSignificantChange(
-                    originalValue = integer(1),
-                    liveValue = integer(10),
+                    newValue = IntNode(baseIntegerValue),
+                    liveValue = IntNode(baseIntegerValue),
                     valueType = ValueType.INTEGER,
                     dataPointType = dummyDataPointType,
                     framework = dummyFramework,
@@ -341,7 +404,7 @@ class SignificanceCheckServiceTest {
         fun `unsupported type is never significant`() {
             assertFalse(
                 service.hasSignificantChange(
-                    originalValue = TextNode("someValue"),
+                    newValue = TextNode("someValue"),
                     liveValue = TextNode("otherValue"),
                     valueType = ValueType.UNSUPPORTED,
                     dataPointType = dummyDataPointType,

--- a/dataland-qa-service/src/test/kotlin/org/dataland/datalandqaservice/services/SignificanceCheckServiceTest.kt
+++ b/dataland-qa-service/src/test/kotlin/org/dataland/datalandqaservice/services/SignificanceCheckServiceTest.kt
@@ -1,0 +1,374 @@
+package org.dataland.datalandqaservice.services
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.node.DecimalNode
+import com.fasterxml.jackson.databind.node.IntNode
+import com.fasterxml.jackson.databind.node.NullNode
+import com.fasterxml.jackson.databind.node.TextNode
+import org.dataland.datalandbackend.openApiClient.model.DataTypeEnum
+import org.dataland.datalandqaservice.org.dataland.datalandqaservice.services.SignificanceCheckService
+import org.dataland.datalandqaservice.org.dataland.datalandqaservice.services.SignificanceCheckService.ValueType
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+
+class SignificanceCheckServiceTest {
+    private val service = SignificanceCheckService()
+    private val dummyFramework = DataTypeEnum.sfdr
+    private val dummyDataPointType = "some-datapoint-type"
+
+    // --- resolveValueType ---
+
+    @Nested
+    inner class ResolveValueTypeTests {
+        @Test
+        fun `extendedDecimal resolves to DECIMAL`() {
+            assertEquals(ValueType.DECIMAL, service.resolveValueType("extendedDecimal"))
+        }
+
+        @Test
+        fun `extendedInteger resolves to INTEGER`() {
+            assertEquals(ValueType.INTEGER, service.resolveValueType("extendedInteger"))
+        }
+
+        @Test
+        fun `extendedEnumYesNo resolves to BOOLEAN`() {
+            assertEquals(ValueType.BOOLEAN, service.resolveValueType("extendedEnumYesNo"))
+        }
+
+        @Test
+        fun `unknown base type id resolves to UNSUPPORTED`() {
+            assertEquals(ValueType.UNSUPPORTED, service.resolveValueType("extendedEnumYesNoNa"))
+            assertEquals(ValueType.UNSUPPORTED, service.resolveValueType("extendedCurrency"))
+            assertEquals(ValueType.UNSUPPORTED, service.resolveValueType("plainDate"))
+            assertEquals(ValueType.UNSUPPORTED, service.resolveValueType("some-unknown-type"))
+        }
+    }
+
+    // --- checkForSignificantChange: null handling ---
+
+    @Nested
+    inner class NullValueTests {
+        @Test
+        fun `original value null returns false`() {
+            assertFalse(
+                service.checkForSignificantChange(
+                    originalValue = null,
+                    liveValue = TextNode("Yes"),
+                    valueType = ValueType.BOOLEAN,
+                    dataPointType = dummyDataPointType,
+                    framework = dummyFramework,
+                ),
+            )
+        }
+
+        @Test
+        fun `live value null returns false`() {
+            assertFalse(
+                service.checkForSignificantChange(
+                    originalValue = TextNode("Yes"),
+                    liveValue = null,
+                    valueType = ValueType.BOOLEAN,
+                    dataPointType = dummyDataPointType,
+                    framework = dummyFramework,
+                ),
+            )
+        }
+
+        @Test
+        fun `original value JSON null returns false`() {
+            assertFalse(
+                service.checkForSignificantChange(
+                    originalValue = NullNode.instance,
+                    liveValue = TextNode("Yes"),
+                    valueType = ValueType.BOOLEAN,
+                    dataPointType = dummyDataPointType,
+                    framework = dummyFramework,
+                ),
+            )
+        }
+
+        @Test
+        fun `live value JSON null returns false`() {
+            assertFalse(
+                service.checkForSignificantChange(
+                    originalValue = TextNode("Yes"),
+                    liveValue = NullNode.instance,
+                    valueType = ValueType.BOOLEAN,
+                    dataPointType = dummyDataPointType,
+                    framework = dummyFramework,
+                ),
+            )
+        }
+
+        @Test
+        fun `both null returns false`() {
+            assertFalse(
+                service.checkForSignificantChange(
+                    originalValue = null,
+                    liveValue = null,
+                    valueType = ValueType.BOOLEAN,
+                    dataPointType = dummyDataPointType,
+                    framework = dummyFramework,
+                ),
+            )
+        }
+    }
+
+    // --- checkForSignificantChange: BOOLEAN ---
+
+    @Nested
+    inner class BooleanSignificanceTests {
+        @Test
+        fun `boolean change from Yes to No is significant`() {
+            assertTrue(
+                service.checkForSignificantChange(
+                    originalValue = TextNode("Yes"),
+                    liveValue = TextNode("No"),
+                    valueType = ValueType.BOOLEAN,
+                    dataPointType = dummyDataPointType,
+                    framework = dummyFramework,
+                ),
+            )
+        }
+
+        @Test
+        fun `boolean change from No to Yes is significant`() {
+            assertTrue(
+                service.checkForSignificantChange(
+                    originalValue = TextNode("No"),
+                    liveValue = TextNode("Yes"),
+                    valueType = ValueType.BOOLEAN,
+                    dataPointType = dummyDataPointType,
+                    framework = dummyFramework,
+                ),
+            )
+        }
+
+        @Test
+        fun `same boolean value Yes to Yes is not significant`() {
+            assertFalse(
+                service.checkForSignificantChange(
+                    originalValue = TextNode("Yes"),
+                    liveValue = TextNode("Yes"),
+                    valueType = ValueType.BOOLEAN,
+                    dataPointType = dummyDataPointType,
+                    framework = dummyFramework,
+                ),
+            )
+        }
+
+        @Test
+        fun `same boolean value No to No is not significant`() {
+            assertFalse(
+                service.checkForSignificantChange(
+                    originalValue = TextNode("No"),
+                    liveValue = TextNode("No"),
+                    valueType = ValueType.BOOLEAN,
+                    dataPointType = dummyDataPointType,
+                    framework = dummyFramework,
+                ),
+            )
+        }
+    }
+
+    // --- checkForSignificantChange: DECIMAL ---
+
+    @Nested
+    inner class DecimalSignificanceTests {
+        private fun decimal(value: Double): JsonNode = DecimalNode(BigDecimal.valueOf(value))
+
+        @Test
+        fun `decimal change above 50 percent relative threshold is significant`() {
+            // live=100, original=200 -> |200-100|/100 = 1.0 > 0.5 -> significant
+            assertTrue(
+                service.checkForSignificantChange(
+                    originalValue = decimal(200.0),
+                    liveValue = decimal(100.0),
+                    valueType = ValueType.DECIMAL,
+                    dataPointType = dummyDataPointType,
+                    framework = dummyFramework,
+                ),
+            )
+        }
+
+        @Test
+        fun `decimal change exactly at 50 percent relative threshold is not significant`() {
+            // live=100, original=150 -> |150-100|/100 = 0.5, not strictly > 0.5 -> not significant
+            assertFalse(
+                service.checkForSignificantChange(
+                    originalValue = decimal(150.0),
+                    liveValue = decimal(100.0),
+                    valueType = ValueType.DECIMAL,
+                    dataPointType = dummyDataPointType,
+                    framework = dummyFramework,
+                ),
+            )
+        }
+
+        @Test
+        fun `decimal change below 50 percent relative threshold is not significant`() {
+            // live=100, original=110 -> |110-100|/100 = 0.1 < 0.5 -> not significant
+            assertFalse(
+                service.checkForSignificantChange(
+                    originalValue = decimal(110.0),
+                    liveValue = decimal(100.0),
+                    valueType = ValueType.DECIMAL,
+                    dataPointType = dummyDataPointType,
+                    framework = dummyFramework,
+                ),
+            )
+        }
+
+        @Test
+        fun `decimal unchanged is not significant`() {
+            assertFalse(
+                service.checkForSignificantChange(
+                    originalValue = decimal(100.0),
+                    liveValue = decimal(100.0),
+                    valueType = ValueType.DECIMAL,
+                    dataPointType = dummyDataPointType,
+                    framework = dummyFramework,
+                ),
+            )
+        }
+
+        @Test
+        fun `decimal live value zero and non-zero original is significant`() {
+            // Avoid division by zero: live=0, original != 0 -> significant
+            assertTrue(
+                service.checkForSignificantChange(
+                    originalValue = decimal(10.0),
+                    liveValue = decimal(0.0),
+                    valueType = ValueType.DECIMAL,
+                    dataPointType = dummyDataPointType,
+                    framework = dummyFramework,
+                ),
+            )
+        }
+
+        @Test
+        fun `decimal both values zero is not significant`() {
+            assertFalse(
+                service.checkForSignificantChange(
+                    originalValue = decimal(0.0),
+                    liveValue = decimal(0.0),
+                    valueType = ValueType.DECIMAL,
+                    dataPointType = dummyDataPointType,
+                    framework = dummyFramework,
+                ),
+            )
+        }
+
+        @Test
+        fun `decimal decrease above 50 percent is significant`() {
+            // live=100, original=40 -> |40-100|/100 = 0.6 > 0.5 -> significant
+            assertTrue(
+                service.checkForSignificantChange(
+                    originalValue = decimal(40.0),
+                    liveValue = decimal(100.0),
+                    valueType = ValueType.DECIMAL,
+                    dataPointType = dummyDataPointType,
+                    framework = dummyFramework,
+                ),
+            )
+        }
+    }
+
+    // --- checkForSignificantChange: INTEGER ---
+
+    @Nested
+    inner class IntegerSignificanceTests {
+        private fun integer(value: Int): JsonNode = IntNode(value)
+
+        @Test
+        fun `integer change above absolute threshold of 5 is significant`() {
+            // |12 - 5| = 7 > 5 -> significant
+            assertTrue(
+                service.checkForSignificantChange(
+                    originalValue = integer(12),
+                    liveValue = integer(5),
+                    valueType = ValueType.INTEGER,
+                    dataPointType = dummyDataPointType,
+                    framework = dummyFramework,
+                ),
+            )
+        }
+
+        @Test
+        fun `integer change exactly at threshold of 5 is not significant`() {
+            // |10 - 5| = 5, not strictly > 5 -> not significant
+            assertFalse(
+                service.checkForSignificantChange(
+                    originalValue = integer(10),
+                    liveValue = integer(5),
+                    valueType = ValueType.INTEGER,
+                    dataPointType = dummyDataPointType,
+                    framework = dummyFramework,
+                ),
+            )
+        }
+
+        @Test
+        fun `integer change below absolute threshold of 5 is not significant`() {
+            // |7 - 5| = 2 < 5 -> not significant
+            assertFalse(
+                service.checkForSignificantChange(
+                    originalValue = integer(7),
+                    liveValue = integer(5),
+                    valueType = ValueType.INTEGER,
+                    dataPointType = dummyDataPointType,
+                    framework = dummyFramework,
+                ),
+            )
+        }
+
+        @Test
+        fun `integer unchanged is not significant`() {
+            assertFalse(
+                service.checkForSignificantChange(
+                    originalValue = integer(42),
+                    liveValue = integer(42),
+                    valueType = ValueType.INTEGER,
+                    dataPointType = dummyDataPointType,
+                    framework = dummyFramework,
+                ),
+            )
+        }
+
+        @Test
+        fun `negative integer change above threshold is significant`() {
+            // |1 - 10| = 9 > 5 -> significant
+            assertTrue(
+                service.checkForSignificantChange(
+                    originalValue = integer(1),
+                    liveValue = integer(10),
+                    valueType = ValueType.INTEGER,
+                    dataPointType = dummyDataPointType,
+                    framework = dummyFramework,
+                ),
+            )
+        }
+    }
+
+    // --- checkForSignificantChange: UNSUPPORTED ---
+
+    @Nested
+    inner class UnsupportedTypeTests {
+        @Test
+        fun `unsupported type is never significant`() {
+            assertFalse(
+                service.checkForSignificantChange(
+                    originalValue = TextNode("someValue"),
+                    liveValue = TextNode("otherValue"),
+                    valueType = ValueType.UNSUPPORTED,
+                    dataPointType = dummyDataPointType,
+                    framework = dummyFramework,
+                ),
+            )
+        }
+    }
+}

--- a/dataland-qa-service/src/test/kotlin/org/dataland/datalandqaservice/services/SignificanceCheckServiceTest.kt
+++ b/dataland-qa-service/src/test/kotlin/org/dataland/datalandqaservice/services/SignificanceCheckServiceTest.kt
@@ -55,7 +55,7 @@ class SignificanceCheckServiceTest {
         @Test
         fun `original value null returns false`() {
             assertFalse(
-                service.checkForSignificantChange(
+                service.hasSignificantChange(
                     originalValue = null,
                     liveValue = TextNode("Yes"),
                     valueType = ValueType.BOOLEAN,
@@ -68,7 +68,7 @@ class SignificanceCheckServiceTest {
         @Test
         fun `live value null returns false`() {
             assertFalse(
-                service.checkForSignificantChange(
+                service.hasSignificantChange(
                     originalValue = TextNode("Yes"),
                     liveValue = null,
                     valueType = ValueType.BOOLEAN,
@@ -81,7 +81,7 @@ class SignificanceCheckServiceTest {
         @Test
         fun `original value JSON null returns false`() {
             assertFalse(
-                service.checkForSignificantChange(
+                service.hasSignificantChange(
                     originalValue = NullNode.instance,
                     liveValue = TextNode("Yes"),
                     valueType = ValueType.BOOLEAN,
@@ -94,7 +94,7 @@ class SignificanceCheckServiceTest {
         @Test
         fun `live value JSON null returns false`() {
             assertFalse(
-                service.checkForSignificantChange(
+                service.hasSignificantChange(
                     originalValue = TextNode("Yes"),
                     liveValue = NullNode.instance,
                     valueType = ValueType.BOOLEAN,
@@ -107,7 +107,7 @@ class SignificanceCheckServiceTest {
         @Test
         fun `both null returns false`() {
             assertFalse(
-                service.checkForSignificantChange(
+                service.hasSignificantChange(
                     originalValue = null,
                     liveValue = null,
                     valueType = ValueType.BOOLEAN,
@@ -125,7 +125,7 @@ class SignificanceCheckServiceTest {
         @Test
         fun `boolean change from Yes to No is significant`() {
             assertTrue(
-                service.checkForSignificantChange(
+                service.hasSignificantChange(
                     originalValue = TextNode("Yes"),
                     liveValue = TextNode("No"),
                     valueType = ValueType.BOOLEAN,
@@ -138,7 +138,7 @@ class SignificanceCheckServiceTest {
         @Test
         fun `boolean change from No to Yes is significant`() {
             assertTrue(
-                service.checkForSignificantChange(
+                service.hasSignificantChange(
                     originalValue = TextNode("No"),
                     liveValue = TextNode("Yes"),
                     valueType = ValueType.BOOLEAN,
@@ -151,7 +151,7 @@ class SignificanceCheckServiceTest {
         @Test
         fun `same boolean value Yes to Yes is not significant`() {
             assertFalse(
-                service.checkForSignificantChange(
+                service.hasSignificantChange(
                     originalValue = TextNode("Yes"),
                     liveValue = TextNode("Yes"),
                     valueType = ValueType.BOOLEAN,
@@ -164,7 +164,7 @@ class SignificanceCheckServiceTest {
         @Test
         fun `same boolean value No to No is not significant`() {
             assertFalse(
-                service.checkForSignificantChange(
+                service.hasSignificantChange(
                     originalValue = TextNode("No"),
                     liveValue = TextNode("No"),
                     valueType = ValueType.BOOLEAN,
@@ -185,7 +185,7 @@ class SignificanceCheckServiceTest {
         fun `decimal change above 50 percent relative threshold is significant`() {
             // live=100, original=200 -> |200-100|/100 = 1.0 > 0.5 -> significant
             assertTrue(
-                service.checkForSignificantChange(
+                service.hasSignificantChange(
                     originalValue = decimal(200.0),
                     liveValue = decimal(100.0),
                     valueType = ValueType.DECIMAL,
@@ -199,7 +199,7 @@ class SignificanceCheckServiceTest {
         fun `decimal change exactly at 50 percent relative threshold is not significant`() {
             // live=100, original=150 -> |150-100|/100 = 0.5, not strictly > 0.5 -> not significant
             assertFalse(
-                service.checkForSignificantChange(
+                service.hasSignificantChange(
                     originalValue = decimal(150.0),
                     liveValue = decimal(100.0),
                     valueType = ValueType.DECIMAL,
@@ -213,7 +213,7 @@ class SignificanceCheckServiceTest {
         fun `decimal change below 50 percent relative threshold is not significant`() {
             // live=100, original=110 -> |110-100|/100 = 0.1 < 0.5 -> not significant
             assertFalse(
-                service.checkForSignificantChange(
+                service.hasSignificantChange(
                     originalValue = decimal(110.0),
                     liveValue = decimal(100.0),
                     valueType = ValueType.DECIMAL,
@@ -226,7 +226,7 @@ class SignificanceCheckServiceTest {
         @Test
         fun `decimal unchanged is not significant`() {
             assertFalse(
-                service.checkForSignificantChange(
+                service.hasSignificantChange(
                     originalValue = decimal(100.0),
                     liveValue = decimal(100.0),
                     valueType = ValueType.DECIMAL,
@@ -240,7 +240,7 @@ class SignificanceCheckServiceTest {
         fun `decimal live value zero and non-zero original is significant`() {
             // Avoid division by zero: live=0, original != 0 -> significant
             assertTrue(
-                service.checkForSignificantChange(
+                service.hasSignificantChange(
                     originalValue = decimal(10.0),
                     liveValue = decimal(0.0),
                     valueType = ValueType.DECIMAL,
@@ -253,7 +253,7 @@ class SignificanceCheckServiceTest {
         @Test
         fun `decimal both values zero is not significant`() {
             assertFalse(
-                service.checkForSignificantChange(
+                service.hasSignificantChange(
                     originalValue = decimal(0.0),
                     liveValue = decimal(0.0),
                     valueType = ValueType.DECIMAL,
@@ -267,7 +267,7 @@ class SignificanceCheckServiceTest {
         fun `decimal decrease above 50 percent is significant`() {
             // live=100, original=40 -> |40-100|/100 = 0.6 > 0.5 -> significant
             assertTrue(
-                service.checkForSignificantChange(
+                service.hasSignificantChange(
                     originalValue = decimal(40.0),
                     liveValue = decimal(100.0),
                     valueType = ValueType.DECIMAL,
@@ -288,7 +288,7 @@ class SignificanceCheckServiceTest {
         fun `integer change above absolute threshold of 5 is significant`() {
             // |12 - 5| = 7 > 5 -> significant
             assertTrue(
-                service.checkForSignificantChange(
+                service.hasSignificantChange(
                     originalValue = integer(12),
                     liveValue = integer(5),
                     valueType = ValueType.INTEGER,
@@ -302,7 +302,7 @@ class SignificanceCheckServiceTest {
         fun `integer change exactly at threshold of 5 is not significant`() {
             // |10 - 5| = 5, not strictly > 5 -> not significant
             assertFalse(
-                service.checkForSignificantChange(
+                service.hasSignificantChange(
                     originalValue = integer(10),
                     liveValue = integer(5),
                     valueType = ValueType.INTEGER,
@@ -316,7 +316,7 @@ class SignificanceCheckServiceTest {
         fun `integer change below absolute threshold of 5 is not significant`() {
             // |7 - 5| = 2 < 5 -> not significant
             assertFalse(
-                service.checkForSignificantChange(
+                service.hasSignificantChange(
                     originalValue = integer(7),
                     liveValue = integer(5),
                     valueType = ValueType.INTEGER,
@@ -329,7 +329,7 @@ class SignificanceCheckServiceTest {
         @Test
         fun `integer unchanged is not significant`() {
             assertFalse(
-                service.checkForSignificantChange(
+                service.hasSignificantChange(
                     originalValue = integer(42),
                     liveValue = integer(42),
                     valueType = ValueType.INTEGER,
@@ -343,7 +343,7 @@ class SignificanceCheckServiceTest {
         fun `negative integer change above threshold is significant`() {
             // |1 - 10| = 9 > 5 -> significant
             assertTrue(
-                service.checkForSignificantChange(
+                service.hasSignificantChange(
                     originalValue = integer(1),
                     liveValue = integer(10),
                     valueType = ValueType.INTEGER,
@@ -361,7 +361,7 @@ class SignificanceCheckServiceTest {
         @Test
         fun `unsupported type is never significant`() {
             assertFalse(
-                service.checkForSignificantChange(
+                service.hasSignificantChange(
                     originalValue = TextNode("someValue"),
                     liveValue = TextNode("otherValue"),
                     valueType = ValueType.UNSUPPORTED,

--- a/dataland-qa-service/src/test/kotlin/org/dataland/datalandqaservice/services/SignificanceCheckServiceTest.kt
+++ b/dataland-qa-service/src/test/kotlin/org/dataland/datalandqaservice/services/SignificanceCheckServiceTest.kt
@@ -20,8 +20,6 @@ class SignificanceCheckServiceTest {
     private val dummyFramework = DataTypeEnum.sfdr
     private val dummyDataPointType = "some-datapoint-type"
 
-    // --- resolveValueType ---
-
     @Nested
     inner class ResolveValueTypeTests {
         @Test
@@ -47,8 +45,6 @@ class SignificanceCheckServiceTest {
             assertEquals(ValueType.UNSUPPORTED, service.resolveValueType("some-unknown-type"))
         }
     }
-
-    // --- checkForSignificantChange: null handling ---
 
     @Nested
     inner class NullValueTests {
@@ -118,8 +114,6 @@ class SignificanceCheckServiceTest {
         }
     }
 
-    // --- checkForSignificantChange: BOOLEAN ---
-
     @Nested
     inner class BooleanSignificanceTests {
         @Test
@@ -175,15 +169,12 @@ class SignificanceCheckServiceTest {
         }
     }
 
-    // --- checkForSignificantChange: DECIMAL ---
-
     @Nested
     inner class DecimalSignificanceTests {
         private fun decimal(value: Double): JsonNode = DecimalNode(BigDecimal.valueOf(value))
 
         @Test
         fun `decimal change above 50 percent relative threshold is significant`() {
-            // live=100, original=200 -> |200-100|/100 = 1.0 > 0.5 -> significant
             assertTrue(
                 service.hasSignificantChange(
                     originalValue = decimal(200.0),
@@ -197,7 +188,6 @@ class SignificanceCheckServiceTest {
 
         @Test
         fun `decimal change exactly at 50 percent relative threshold is not significant`() {
-            // live=100, original=150 -> |150-100|/100 = 0.5, not strictly > 0.5 -> not significant
             assertFalse(
                 service.hasSignificantChange(
                     originalValue = decimal(150.0),
@@ -211,7 +201,6 @@ class SignificanceCheckServiceTest {
 
         @Test
         fun `decimal change below 50 percent relative threshold is not significant`() {
-            // live=100, original=110 -> |110-100|/100 = 0.1 < 0.5 -> not significant
             assertFalse(
                 service.hasSignificantChange(
                     originalValue = decimal(110.0),
@@ -238,7 +227,6 @@ class SignificanceCheckServiceTest {
 
         @Test
         fun `decimal live value zero and non-zero original is significant`() {
-            // Avoid division by zero: live=0, original != 0 -> significant
             assertTrue(
                 service.hasSignificantChange(
                     originalValue = decimal(10.0),
@@ -265,7 +253,6 @@ class SignificanceCheckServiceTest {
 
         @Test
         fun `decimal decrease above 50 percent is significant`() {
-            // live=100, original=40 -> |40-100|/100 = 0.6 > 0.5 -> significant
             assertTrue(
                 service.hasSignificantChange(
                     originalValue = decimal(40.0),
@@ -278,15 +265,12 @@ class SignificanceCheckServiceTest {
         }
     }
 
-    // --- checkForSignificantChange: INTEGER ---
-
     @Nested
     inner class IntegerSignificanceTests {
         private fun integer(value: Int): JsonNode = IntNode(value)
 
         @Test
         fun `integer change above absolute threshold of 5 is significant`() {
-            // |12 - 5| = 7 > 5 -> significant
             assertTrue(
                 service.hasSignificantChange(
                     originalValue = integer(12),
@@ -300,7 +284,6 @@ class SignificanceCheckServiceTest {
 
         @Test
         fun `integer change exactly at threshold of 5 is not significant`() {
-            // |10 - 5| = 5, not strictly > 5 -> not significant
             assertFalse(
                 service.hasSignificantChange(
                     originalValue = integer(10),
@@ -314,7 +297,6 @@ class SignificanceCheckServiceTest {
 
         @Test
         fun `integer change below absolute threshold of 5 is not significant`() {
-            // |7 - 5| = 2 < 5 -> not significant
             assertFalse(
                 service.hasSignificantChange(
                     originalValue = integer(7),
@@ -341,7 +323,6 @@ class SignificanceCheckServiceTest {
 
         @Test
         fun `negative integer change above threshold is significant`() {
-            // |1 - 10| = 9 > 5 -> significant
             assertTrue(
                 service.hasSignificantChange(
                     originalValue = integer(1),
@@ -353,8 +334,6 @@ class SignificanceCheckServiceTest {
             )
         }
     }
-
-    // --- checkForSignificantChange: UNSUPPORTED ---
 
     @Nested
     inner class UnsupportedTypeTests {


### PR DESCRIPTION
# Pull Request \<Title>
`<Description here>`
## Things to do during Peer Review
Please check all boxes before the Pull Request is merged. In case you skip a box, describe in the PRs description (that means: here) why the check is skipped.
- [x] The GitHub Actions for the CI are green. This is enforced by GitHub. 
- [x] The PR has been peer-reviewed
  - [x] The code has been manually inspected by someone who did not implement the feature
  - [x] The changes have been inspected for possible breaking API changes (changed data models, endpoints, response codes, exception handling, ...). If there are any discuss them with the team.
  - [x] If this PR includes work on the frontend, at least one `@ts-nocheck` is removed. Additionally, there should not be any `@ts-nocheck` in files modified by this PR. If no `@ts-nocheck` are left: Celebrate :tada: :confetti_ball: type-safety and remove this entry. 
- [x] The PR actually implements what is described in the JIRA-Issue
- [x] Make sure you understand the entire workflow from the user’s perspective, and test/review it accordingly. If anything is unclear, please reach out to the dev team.
- [x] At least one test exists testing the new feature
  - [x] Make sure all newly added functionality (especially user facing) is tested
  - [x] Make sure that new test files are included in a test container and actually run in the CI
- [x] At least 3 consecutive CI runs are successfully executed to ensure that there are no flaky tests.
- [x] Documentation is updated as required. If unsure whether or what to update, ask a fellow developer.
- [x] If there was a database entity class added, there must also be a migration script for creating the corresponding database if flyway is already used by the service
- [x] IF there are changes done to the framework data models or to a database entity class, the following steps were completed in order
  - [ ] A fresh clone of dataland.com is generated (see Wiki page on "OTC" for details)
  - [ ] The feature branch is deployed to clone with `Reset non-user related Docker Volumes & Re-populate` turned off
  - [ ] It's verified that the CD run is green
  - [ ] The new feature is manually used/tested/observed on the clone server. Testing of the new feature should (also) be done by a second, independent reviewer from the dev team
  - [ ] The feature branch is deployed to one of the dev servers with `Reset non-user related Docker Volumes & Re-populate` turned on, and it's verified that the CD run is green
- [x] ELSE, the new version is deployed to one of the dev servers using this branch
  - [x] Run with setting `Reset non-user related Docker Volumes & Re-populate` turned on 
  - [x] It's verified that this version actually is the one deployed (check gitinfo for branch name and commit id!)
  - [ ] It's verified that the CD run is green
  - [x] The new feature is manually used/tested/observed on dev server. Testing of the new feature should (also) be done by a second, independent reviewer from the dev team
- [x] Confirm that the latest version (use the /gitinfo endpoint) of the feature branch is deployed to one of the dev servers (no longer enforced by GitHub)
- [ ] Ensure that the release notes are written in a way that is understandable to a non-technical audience.
