### PR TITLE
DALA-7426 fix judgement test

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -399,6 +399,8 @@ jobs:
           LOKI_VOLUME: "./dataland-loki/data"
           SLACK_ALERT_URL: "irrelevant_in_ci"
           SLACK_CRITICAL_ALERT_URL: "irrelevant_in_ci"
+          AUTO_PREAPPROVAL_QA_ACCEPTED_DATAPOINTS : true
+
       - name: Upload JaCoCo Exec Results
         if: always()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7

--- a/dataland-frontend/tests/e2e/specs/judgement/CheckJudgementProcedure.ts
+++ b/dataland-frontend/tests/e2e/specs/judgement/CheckJudgementProcedure.ts
@@ -96,7 +96,7 @@ describeIf(
           return initializeDataPointOverviewForDataset(uploadedDataMetaInfo, tokens.adminToken).then(
             (preparedOverview: DataPointOverview) => {
               overview = preparedOverview;
-              uploadQaReportsForDataset(overview, {
+              return uploadQaReportsForDataset(overview, {
                 reviewerToken: tokens.reviewerToken,
                 adminToken: tokens.adminToken,
               });
@@ -225,8 +225,8 @@ function uploadQaReportForDataPoint(
   token: string,
   verdict: QaReportDataPointVerdict,
   correctedValue?: string
-): void {
-  cy.request({
+): Cypress.Chainable {
+  return cy.request({
     method: 'POST',
     url: `${apiBaseUrl}/qa/data-points/${dataPointId}/reports`,
     headers: { Authorization: `Bearer ${token}` },
@@ -286,7 +286,7 @@ function initializeDataPointOverviewForDataset(
  * Uploads QA reports for all configured data point types using the provided DataPointOverview.
  *
  * For each entry in `QA_SCENARIO_CONFIG`, the corresponding data point ID is resolved from
- * `overview.dataPointsWithQaReports` and the configured QA actions are executed.
+ * `overview.dataPointsWithQaReports` and the configured QA actions are executed sequentially.
  *
  * @param overview DataPointOverview containing data point IDs and counts.
  * @param tokens   Authentication tokens for the reviewer and admin users, used to upload QA reports.
@@ -294,32 +294,15 @@ function initializeDataPointOverviewForDataset(
 function uploadQaReportsForDataset(
   overview: DataPointOverview,
   tokens: { reviewerToken: string; adminToken: string }
-): void {
-  QA_SCENARIO_CONFIG.forEach((config) => {
+): Cypress.Chainable {
+  return QA_SCENARIO_CONFIG.flatMap((config) => {
     const dataPointId = overview.dataPointsWithQaReports[config.dataPointType];
-    if (!dataPointId) {
-      return;
-    }
-    runQaScenarioForDataPoint(dataPointId, config, tokens);
-  });
-}
-
-/**
- * Executes all configured QA reports for a single data point.
- *
- * @param dataPointId Identifier of the data point for which QA reports should be created.
- * @param config      QA scenario configuration describing verdicts, roles, and corrected values.
- * @param tokens      Authentication tokens for reviewer and admin.
- */
-function runQaScenarioForDataPoint(
-  dataPointId: string,
-  config: QaScenarioConfig,
-  tokens: { reviewerToken: string; adminToken: string }
-): void {
-  config.qaReports.forEach((qaReport) => {
-    const token = qaReport.role === 'reviewer' ? tokens.reviewerToken : tokens.adminToken;
-    uploadQaReportForDataPoint(dataPointId, token, qaReport.verdict, qaReport.correctedValue);
-  });
+    if (!dataPointId) return [];
+    return config.qaReports.map((qaReport) => {
+      const token = qaReport.role === 'reviewer' ? tokens.reviewerToken : tokens.adminToken;
+      return () => uploadQaReportForDataPoint(dataPointId, token, qaReport.verdict, qaReport.correctedValue);
+    });
+  }).reduce<Cypress.Chainable>((chain, upload) => chain.then(upload), cy.wrap(null));
 }
 
 /**
@@ -456,9 +439,12 @@ function checkOriginalDataPointsAccepted(dataPointEntries: Array<[string, string
   cy.reload();
   cy.closeCookieBannerIfItExists();
   cy.get('[data-test="datasetReviewComparisonTable"]').should('be.visible');
-  cy.contains(
-    `${Object.keys(overview.dataPointsWithQaReports).length} / ${overview.amountOfDataPointsToReview} data points to review`
-  ).should('be.visible');
+  const remainingQaDataPoints = QA_SCENARIO_CONFIG.filter((s) =>
+    s.qaReports.some((r) => r.verdict !== QaReportDataPointVerdict.QaAccepted)
+  ).length;
+  cy.contains(`${remainingQaDataPoints} / ${overview.amountOfDataPointsToReview} data points to review`).should(
+    'be.visible'
+  );
 
   dataPointEntries.forEach(([, dataPointId]) => {
     checkRowIcons(dataPointId, [IconState.Accepted, IconState.None, IconState.None, IconState.None]);

--- a/dataland-frontend/tests/e2e/specs/judgement/CheckJudgementProcedure.ts
+++ b/dataland-frontend/tests/e2e/specs/judgement/CheckJudgementProcedure.ts
@@ -114,7 +114,10 @@ describeIf(
     });
 
     it('Check judge modal selects expected values and stores them after finishing review', () => {
+      cy.screenshot('screenshot-beginning', { capture: 'fullPage' });
       createJudgementAndOpenReviewPage(uploadedDataMetaInfo, tokens.judgeToken).then(() => {
+        cy.screenshot('screenshoot-JudgmentDialogOpen', { capture: 'fullPage' });
+
         judgeDataPointsWithoutQaReports(overview);
         tryFinishingJudgementBeforeAllDataPointsReviewed();
         judgeDataPointsWithQaReports(overview);
@@ -403,6 +406,8 @@ function judgeDataPointLoop(
 
   entries.forEach(([dataPointType, dataPointId], index) => {
     if (index > 0) {
+      cy.screenshot(`screnshot-Loop-${index}`, { capture: 'fullPage' });
+
       selectNextDataPointToJudge(dataPointType);
       goToSelectedDataPoint();
     }

--- a/dataland-frontend/tests/e2e/specs/judgement/CheckJudgementProcedure.ts
+++ b/dataland-frontend/tests/e2e/specs/judgement/CheckJudgementProcedure.ts
@@ -114,10 +114,7 @@ describeIf(
     });
 
     it('Check judge modal selects expected values and stores them after finishing review', () => {
-      cy.screenshot('screenshot-beginning', { capture: 'fullPage' });
       createJudgementAndOpenReviewPage(uploadedDataMetaInfo, tokens.judgeToken).then(() => {
-        cy.screenshot('screenshoot-JudgmentDialogOpen', { capture: 'fullPage' });
-
         judgeDataPointsWithoutQaReports(overview);
         tryFinishingJudgementBeforeAllDataPointsReviewed();
         judgeDataPointsWithQaReports(overview);
@@ -389,8 +386,6 @@ function judgeDataPointLoop(
 
   entries.forEach(([dataPointType, dataPointId], index) => {
     if (index > 0) {
-      cy.screenshot(`screnshot-Loop-${index}`, { capture: 'fullPage' });
-
       selectNextDataPointToJudge(dataPointType);
       goToSelectedDataPoint();
     }


### PR DESCRIPTION
# Pull Request \<Title>
`<Description here>`
## Things to do during Peer Review
Please check all boxes before the Pull Request is merged. In case you skip a box, describe in the PRs description (that means: here) why the check is skipped.
- [x] The GitHub Actions for the CI are green. This is enforced by GitHub. 
- [x] The PR has been peer-reviewed
  - [ ] The code has been manually inspected by someone who did not implement the feature
  - [ ] The changes have been inspected for possible breaking API changes (changed data models, endpoints, response codes, exception handling, ...). If there are any discuss them with the team.
  - [ ] If this PR includes work on the frontend, at least one `@ts-nocheck` is removed. Additionally, there should not be any `@ts-nocheck` in files modified by this PR. If no `@ts-nocheck` are left: Celebrate :tada: :confetti_ball: type-safety and remove this entry. 
- [ ] The PR actually implements what is described in the JIRA-Issue
- [ ] Make sure you understand the entire workflow from the user’s perspective, and test/review it accordingly. If anything is unclear, please reach out to the dev team.
- [ ] At least one test exists testing the new feature
  - [ ] Make sure all newly added functionality (especially user facing) is tested
  - [ ] Make sure that new test files are included in a test container and actually run in the CI
- [ ] At least 3 consecutive CI runs are successfully executed to ensure that there are no flaky tests.
- [ ] Documentation is updated as required. If unsure whether or what to update, ask a fellow developer.
- [ ] If there was a database entity class added, there must also be a migration script for creating the corresponding database if flyway is already used by the service
- [ ] IF there are changes done to the framework data models or to a database entity class, the following steps were completed in order
  - [ ] A fresh clone of dataland.com is generated (see Wiki page on "OTC" for details)
  - [ ] The feature branch is deployed to clone with `Reset non-user related Docker Volumes & Re-populate` turned off
  - [ ] It's verified that the CD run is green
  - [ ] The new feature is manually used/tested/observed on the clone server. Testing of the new feature should (also) be done by a second, independent reviewer from the dev team
  - [ ] The feature branch is deployed to one of the dev servers with `Reset non-user related Docker Volumes & Re-populate` turned on, and it's verified that the CD run is green
- [ ] ELSE, the new version is deployed to one of the dev servers using this branch
  - [ ] Run with setting `Reset non-user related Docker Volumes & Re-populate` turned on 
  - [ ] It's verified that this version actually is the one deployed (check gitinfo for branch name and commit id!)
  - [ ] It's verified that the CD run is green
  - [ ] The new feature is manually used/tested/observed on dev server. Testing of the new feature should (also) be done by a second, independent reviewer from the dev team
- [ ] Confirm that the latest version (use the /gitinfo endpoint) of the feature branch is deployed to one of the dev servers (no longer enforced by GitHub)
- [ ] Ensure that the release notes are written in a way that is understandable to a non-technical audience.
