### PR TITLE
Add Specification Explorer to dataland-frontend

### DIFF
--- a/dataland-frontend/build.gradle.kts
+++ b/dataland-frontend/build.gradle.kts
@@ -83,6 +83,7 @@ tasks.register("generateClients") {
     dependsOn("generateUserServiceClient")
     dependsOn("generateDataSourcingServiceClient")
     dependsOn("generateAccountingServiceClient")
+    dependsOn("generateSpecificationServiceClient")
 }
 
 tasks.register("generateBackendClient", org.openapitools.generator.gradle.plugin.tasks.GenerateTask::class) {
@@ -311,6 +312,34 @@ tasks.register("generateAccountingServiceClient", org.openapitools.generator.gra
     )
 }
 
+tasks.register("generateSpecificationServiceClient", org.openapitools.generator.gradle.plugin.tasks.GenerateTask::class) {
+    description = "Task to generate clients for the specification service."
+    group = "clients"
+    val destinationPackage = "org.dataland.datalandfrontend.openApiClient.specificationservice"
+    inputSpec.set(project.file("${project.rootDir}/dataland-specification-service/specificationServiceOpenApi.json").path)
+    outputDir.set(
+        layout.buildDirectory
+            .dir("clients/specificationservice")
+            .get()
+            .toString(),
+    )
+    modelPackage.set("$destinationPackage.model")
+    apiPackage.set("$destinationPackage.api")
+    packageName.set(destinationPackage)
+    generatorName.set("typescript-axios")
+    additionalProperties.set(
+        mapOf(
+            "removeEnumValuePrefix" to false,
+        ),
+    )
+    configOptions.set(
+        mapOf(
+            "withInterfaces" to "true",
+            "withSeparateModelsAndApi" to "true",
+        ),
+    )
+}
+
 sourceSets {
     val main by getting
     main.java.srcDir(layout.buildDirectory.dir("clients/backend/src/main/kotlin"))
@@ -321,6 +350,7 @@ sourceSets {
     main.java.srcDir(layout.buildDirectory.dir("clients/userservice/src/main/kotlin"))
     main.java.srcDir(layout.buildDirectory.dir("clients/datasourcingservice/src/main/kotlin"))
     main.java.srcDir(layout.buildDirectory.dir("clients/accountingservice/src/main/kotlin"))
+    main.java.srcDir(layout.buildDirectory.dir("clients/specificationservice/src/main/kotlin"))
 }
 
 ktlint {

--- a/dataland-frontend/src/api-queries/specification/specificationKeys.ts
+++ b/dataland-frontend/src/api-queries/specification/specificationKeys.ts
@@ -1,0 +1,9 @@
+export const specificationKeys = {
+  all: ['specification'] as const,
+  frameworkList: () => ['specification', 'frameworks'] as const,
+  framework: (frameworkId: string | undefined) => ['specification', 'frameworks', frameworkId] as const,
+  frameworkExists: (frameworkId: string | undefined) => ['specification', 'frameworks', frameworkId, 'exists'] as const,
+  dataPointType: (dataPointTypeId: string | undefined) => ['specification', 'dataPointTypes', dataPointTypeId] as const,
+  dataPointBaseType: (dataPointBaseTypeId: string | undefined) =>
+    ['specification', 'dataPointBaseTypes', dataPointBaseTypeId] as const,
+};

--- a/dataland-frontend/src/api-queries/specification/useDataPointBaseTypeSpecificationQuery.ts
+++ b/dataland-frontend/src/api-queries/specification/useDataPointBaseTypeSpecificationQuery.ts
@@ -1,0 +1,33 @@
+import { computed, type Ref } from 'vue';
+import { useQuery, type UseQueryReturnType } from '@tanstack/vue-query';
+import { useApiClient } from '@/utils/useApiClient.ts';
+import { specificationKeys } from '@/api-queries/specification/specificationKeys.ts';
+import type { DataPointBaseTypeSpecification } from '@clients/specificationservice';
+
+/**
+ * Fetch the specification for a single data point base type by id.
+ *
+ * @param {{ dataPointBaseTypeId: Ref<string | undefined> }} options - Reactive ref with the base type id.
+ * @returns {UseQueryReturnType<DataPointBaseTypeSpecification, Error>} Vue Query result; `data` holds the
+ *   data point base type specification. The query is disabled while `dataPointBaseTypeId.value` is falsy.
+ */
+export function useDataPointBaseTypeSpecificationQuery(options: {
+  dataPointBaseTypeId: Ref<string | undefined>;
+}): UseQueryReturnType<DataPointBaseTypeSpecification, Error> {
+  const apiClientProvider = useApiClient();
+
+  return useQuery<DataPointBaseTypeSpecification, Error>({
+    queryKey: computed(() => specificationKeys.dataPointBaseType(options.dataPointBaseTypeId.value)),
+
+    queryFn: async () => {
+      const { specificationController } = apiClientProvider.apiClients;
+      const dataPointBaseTypeId = options.dataPointBaseTypeId.value;
+      if (!dataPointBaseTypeId) {
+        throw new Error('dataPointBaseTypeId is undefined');
+      }
+      const { data } = await specificationController.getDataPointBaseType(dataPointBaseTypeId);
+      return data;
+    },
+    enabled: computed(() => !!options.dataPointBaseTypeId.value),
+  });
+}

--- a/dataland-frontend/src/api-queries/specification/useDataPointTypeSpecificationQuery.ts
+++ b/dataland-frontend/src/api-queries/specification/useDataPointTypeSpecificationQuery.ts
@@ -1,0 +1,33 @@
+import { computed, type Ref } from 'vue';
+import { useQuery, type UseQueryReturnType } from '@tanstack/vue-query';
+import { useApiClient } from '@/utils/useApiClient.ts';
+import { specificationKeys } from '@/api-queries/specification/specificationKeys.ts';
+import type { DataPointTypeSpecification } from '@clients/specificationservice';
+
+/**
+ * Fetch the specification for a single data point type by id.
+ *
+ * @param {{ dataPointTypeId: Ref<string | undefined> }} options - Reactive ref with the data point type id.
+ * @returns {UseQueryReturnType<DataPointTypeSpecification, Error>} Vue Query result; `data` holds the
+ *   data point type specification. The query is disabled while `dataPointTypeId.value` is falsy.
+ */
+export function useDataPointTypeSpecificationQuery(options: {
+  dataPointTypeId: Ref<string | undefined>;
+}): UseQueryReturnType<DataPointTypeSpecification, Error> {
+  const apiClientProvider = useApiClient();
+
+  return useQuery<DataPointTypeSpecification, Error>({
+    queryKey: computed(() => specificationKeys.dataPointType(options.dataPointTypeId.value)),
+
+    queryFn: async () => {
+      const { specificationController } = apiClientProvider.apiClients;
+      const dataPointTypeId = options.dataPointTypeId.value;
+      if (!dataPointTypeId) {
+        throw new Error('dataPointTypeId is undefined');
+      }
+      const { data } = await specificationController.getDataPointTypeSpecification(dataPointTypeId);
+      return data;
+    },
+    enabled: computed(() => !!options.dataPointTypeId.value),
+  });
+}

--- a/dataland-frontend/src/api-queries/specification/useFrameworkListQuery.ts
+++ b/dataland-frontend/src/api-queries/specification/useFrameworkListQuery.ts
@@ -1,0 +1,23 @@
+import { useQuery, type UseQueryReturnType } from '@tanstack/vue-query';
+import { useApiClient } from '@/utils/useApiClient.ts';
+import { specificationKeys } from '@/api-queries/specification/specificationKeys.ts';
+import type { SimpleFrameworkSpecification } from '@clients/specificationservice';
+
+/**
+ * Fetch the list of all frameworks known to the specification service.
+ *
+ * @returns {UseQueryReturnType<Array<SimpleFrameworkSpecification>, Error>} Vue Query result; `data` holds
+ *   the list of simple framework specifications.
+ */
+export function useFrameworkListQuery(): UseQueryReturnType<Array<SimpleFrameworkSpecification>, Error> {
+  const apiClientProvider = useApiClient();
+
+  return useQuery<Array<SimpleFrameworkSpecification>, Error>({
+    queryKey: specificationKeys.frameworkList(),
+    queryFn: async () => {
+      const { specificationController } = apiClientProvider.apiClients;
+      const { data } = await specificationController.listFrameworkSpecifications();
+      return data;
+    },
+  });
+}

--- a/dataland-frontend/src/api-queries/specification/useFrameworkSpecificationExistsQuery.ts
+++ b/dataland-frontend/src/api-queries/specification/useFrameworkSpecificationExistsQuery.ts
@@ -1,0 +1,41 @@
+import { computed, type Ref } from 'vue';
+import { useQuery, type UseQueryReturnType } from '@tanstack/vue-query';
+import { isAxiosError } from 'axios';
+import { useApiClient } from '@/utils/useApiClient.ts';
+import { specificationKeys } from '@/api-queries/specification/specificationKeys.ts';
+
+/**
+ * Check whether the specification service knows about a given framework id. Used to conditionally
+ * show links to the Specification Explorer for frameworks that do not (yet) have a specification.
+ *
+ * @param {{ frameworkId: Ref<string | undefined> }} options - Reactive ref with the framework id.
+ * @returns {UseQueryReturnType<boolean, Error>} Vue Query result; `data` is true if a specification
+ *   exists for the given framework id. The query is disabled while `frameworkId.value` is falsy.
+ */
+export function useFrameworkSpecificationExistsQuery(options: {
+  frameworkId: Ref<string | undefined>;
+}): UseQueryReturnType<boolean, Error> {
+  const apiClientProvider = useApiClient();
+
+  return useQuery<boolean, Error>({
+    queryKey: computed(() => specificationKeys.frameworkExists(options.frameworkId.value)),
+
+    queryFn: async () => {
+      const { specificationController } = apiClientProvider.apiClients;
+      const frameworkId = options.frameworkId.value;
+      if (!frameworkId) {
+        throw new Error('frameworkId is undefined');
+      }
+      try {
+        await specificationController.doesFrameworkSpecificationExist(frameworkId);
+        return true;
+      } catch (error) {
+        if (isAxiosError(error) && error.response?.status === 404) {
+          return false;
+        }
+        throw error;
+      }
+    },
+    enabled: computed(() => !!options.frameworkId.value),
+  });
+}

--- a/dataland-frontend/src/api-queries/specification/useFrameworkSpecificationQuery.ts
+++ b/dataland-frontend/src/api-queries/specification/useFrameworkSpecificationQuery.ts
@@ -1,0 +1,33 @@
+import { computed, type Ref } from 'vue';
+import { useQuery, type UseQueryReturnType } from '@tanstack/vue-query';
+import { useApiClient } from '@/utils/useApiClient.ts';
+import { specificationKeys } from '@/api-queries/specification/specificationKeys.ts';
+import type { FrameworkSpecification } from '@clients/specificationservice';
+
+/**
+ * Fetch the full specification for a single framework by id.
+ *
+ * @param {{ frameworkId: Ref<string | undefined> }} options - Reactive ref with the framework id.
+ * @returns {UseQueryReturnType<FrameworkSpecification, Error>} Vue Query result; `data` holds the
+ *   framework specification. The query is disabled while `frameworkId.value` is falsy.
+ */
+export function useFrameworkSpecificationQuery(options: {
+  frameworkId: Ref<string | undefined>;
+}): UseQueryReturnType<FrameworkSpecification, Error> {
+  const apiClientProvider = useApiClient();
+
+  return useQuery<FrameworkSpecification, Error>({
+    queryKey: computed(() => specificationKeys.framework(options.frameworkId.value)),
+
+    queryFn: async () => {
+      const { specificationController } = apiClientProvider.apiClients;
+      const frameworkId = options.frameworkId.value;
+      if (!frameworkId) {
+        throw new Error('frameworkId is undefined');
+      }
+      const { data } = await specificationController.getFrameworkSpecification(frameworkId);
+      return data;
+    },
+    enabled: computed(() => !!options.frameworkId.value),
+  });
+}

--- a/dataland-frontend/src/components/general/DatasetsTabMenu.vue
+++ b/dataland-frontend/src/components/general/DatasetsTabMenu.vue
@@ -61,6 +61,7 @@ const tabs = ref<Array<TabInfo>>([
     route: '/requestoverview-legacy',
     isVisible: false,
   },
+  { id: 'specifications', label: 'SPECIFICATIONS', route: '/specifications', isVisible: true },
 ]);
 
 const visibleTabs = computed(() => tabs.value.filter((tab) => tab.isVisible || tab.id === currentTabId.value));

--- a/dataland-frontend/src/components/generics/ViewMultipleDatasetsDisplayBase.vue
+++ b/dataland-frontend/src/components/generics/ViewMultipleDatasetsDisplayBase.vue
@@ -18,6 +18,7 @@
         <div class="grid">
           <div class="col-12 text-left">
             <h2 class="mb-0" data-test="frameworkDataTableTitle">{{ humanizeString(dataType) }}</h2>
+            <FrameworkSpecificationLink :frameworkIdentifier="dataType" />
           </div>
           <div class="col-12">
             <MultiLayerDataTableFrameworkPanel
@@ -69,6 +70,7 @@ import { type AxiosError } from 'axios';
 import type Keycloak from 'keycloak-js';
 import DatasetDisplayStatusIndicator from '@/components/resources/frameworkDataSearch/DatasetDisplayStatusIndicator.vue';
 import MultiLayerDataTableFrameworkPanel from '@/components/resources/frameworkDataSearch/frameworkPanel/MultiLayerDataTableFrameworkPanel.vue';
+import FrameworkSpecificationLink from '@/components/resources/specifications/FrameworkSpecificationLink.vue';
 import { getFrontendFrameworkDefinition } from '@/frameworks/FrontendFrameworkRegistry';
 import {
   type FrameworkViewConfiguration,
@@ -89,6 +91,7 @@ export default defineComponent({
     MultiLayerDataTableFrameworkPanel,
     DatasetDisplayStatusIndicator,
     ViewFrameworkBase,
+    FrameworkSpecificationLink,
   },
   props: {
     companyId: {

--- a/dataland-frontend/src/components/pages/ApiKeysPage.vue
+++ b/dataland-frontend/src/components/pages/ApiKeysPage.vue
@@ -101,6 +101,10 @@
           <a href="/community/swagger-ui/index.html" target="_blank" rel="noopener noreferrer">Community</a>
           <a href="/qa/swagger-ui/index.html" target="_blank" rel="noopener noreferrer">Quality Assurance</a>
           <a href="/users/swagger-ui/index.html" target="_blank" rel="noopener noreferrer">Users</a>
+          <a href="/specifications/swagger-ui/index.html" target="_blank" rel="noopener noreferrer"
+            >Framework Specifications</a
+          >
+          <router-link to="/specifications">Specification Explorer</router-link>
         </div>
       </div>
     </div>

--- a/dataland-frontend/src/components/pages/SpecificationDataPointBaseTypePage.vue
+++ b/dataland-frontend/src/components/pages/SpecificationDataPointBaseTypePage.vue
@@ -1,0 +1,67 @@
+<template>
+  <TheContent class="flex">
+    <div class="col-12 text-left pb-0">
+      <nav class="specification-breadcrumb text-color-secondary mb-2">
+        <router-link to="/specifications" class="text-primary underline">Specifications</router-link>
+      </nav>
+      <div v-if="isPending">
+        <p class="font-medium text-xl">Loading data point base type...</p>
+        <DatalandProgressSpinner />
+      </div>
+      <FailMessage v-else-if="isError" message="Could not load this data point base type." />
+      <template v-else-if="dataPointBaseType">
+        <h1>{{ dataPointBaseType.name }}</h1>
+        <p class="text-lg">{{ dataPointBaseType.businessDefinition }}</p>
+      </template>
+    </div>
+    <div v-if="dataPointBaseType" class="grid m-0 text-left">
+      <div class="col-12">
+        <h2>Example</h2>
+        <SpecificationJsonPreview :value="dataPointBaseType.example" />
+      </div>
+
+      <div v-if="dataPointBaseType.usedBy.length" class="col-12">
+        <h2>Used by these data point types</h2>
+        <ul>
+          <li v-for="usage in dataPointBaseType.usedBy" :key="usage.id">
+            <router-link
+              :to="`/specifications/data-point-types/${usage.id}`"
+              class="text-primary font-semibold underline"
+            >
+              {{ usage.id }}
+            </router-link>
+          </li>
+        </ul>
+      </div>
+
+      <div class="col-12">
+        <p class="text-color-secondary text-sm">Validated by: {{ dataPointBaseType.validatedBy }}</p>
+      </div>
+    </div>
+  </TheContent>
+</template>
+
+<script setup lang="ts">
+import { toRef } from 'vue';
+import TheContent from '@/components/generics/TheContent.vue';
+import DatalandProgressSpinner from '@/components/general/DatalandProgressSpinner.vue';
+import FailMessage from '@/components/messages/FailMessage.vue';
+import SpecificationJsonPreview from '@/components/resources/specifications/SpecificationJsonPreview.vue';
+import { useDataPointBaseTypeSpecificationQuery } from '@/api-queries/specification/useDataPointBaseTypeSpecificationQuery.ts';
+
+const props = defineProps<{
+  dataPointBaseTypeId: string;
+}>();
+
+const {
+  data: dataPointBaseType,
+  isPending,
+  isError,
+} = useDataPointBaseTypeSpecificationQuery({ dataPointBaseTypeId: toRef(props, 'dataPointBaseTypeId') });
+</script>
+
+<style scoped>
+.specification-breadcrumb {
+  font-size: var(--font-size-sm);
+}
+</style>

--- a/dataland-frontend/src/components/pages/SpecificationDataPointTypePage.vue
+++ b/dataland-frontend/src/components/pages/SpecificationDataPointTypePage.vue
@@ -1,0 +1,80 @@
+<template>
+  <TheContent class="flex">
+    <div class="col-12 text-left pb-0">
+      <nav class="specification-breadcrumb text-color-secondary mb-2">
+        <router-link to="/specifications" class="text-primary underline">Specifications</router-link>
+      </nav>
+      <div v-if="isPending">
+        <p class="font-medium text-xl">Loading data point type...</p>
+        <DatalandProgressSpinner />
+      </div>
+      <FailMessage v-else-if="isError" message="Could not load this data point type." />
+      <template v-else-if="dataPointType">
+        <h1>{{ dataPointType.name }}</h1>
+        <p class="text-lg">{{ dataPointType.businessDefinition }}</p>
+      </template>
+    </div>
+    <div v-if="dataPointType" class="grid m-0 text-left">
+      <div class="col-12 md:col-6">
+        <h2>Base type</h2>
+        <router-link
+          :to="`/specifications/data-point-base-types/${dataPointType.dataPointBaseType.id}`"
+          class="text-primary font-semibold underline"
+        >
+          {{ dataPointType.dataPointBaseType.id }}
+        </router-link>
+      </div>
+
+      <div v-if="dataPointType.constraints?.length" class="col-12 md:col-6">
+        <h2>Constraints</h2>
+        <ul>
+          <li v-for="constraint in dataPointType.constraints" :key="constraint">{{ constraint }}</li>
+        </ul>
+      </div>
+
+      <div v-if="dataPointType.calculationRules.length" class="col-12">
+        <h2>Calculation rules</h2>
+        <ul>
+          <li v-for="(rule, index) in dataPointType.calculationRules" :key="index">
+            {{ rule.calculationMethod }} (inputs: {{ rule.inputs.join(', ') }})
+          </li>
+        </ul>
+      </div>
+
+      <div v-if="dataPointType.usedBy.length" class="col-12">
+        <h2>Used by these frameworks</h2>
+        <ul>
+          <li v-for="usage in dataPointType.usedBy" :key="usage.id">
+            <router-link :to="`/specifications/frameworks/${usage.id}`" class="text-primary font-semibold underline">
+              {{ usage.id }}
+            </router-link>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </TheContent>
+</template>
+
+<script setup lang="ts">
+import { toRef } from 'vue';
+import TheContent from '@/components/generics/TheContent.vue';
+import DatalandProgressSpinner from '@/components/general/DatalandProgressSpinner.vue';
+import FailMessage from '@/components/messages/FailMessage.vue';
+import { useDataPointTypeSpecificationQuery } from '@/api-queries/specification/useDataPointTypeSpecificationQuery.ts';
+
+const props = defineProps<{
+  dataPointTypeId: string;
+}>();
+
+const {
+  data: dataPointType,
+  isPending,
+  isError,
+} = useDataPointTypeSpecificationQuery({ dataPointTypeId: toRef(props, 'dataPointTypeId') });
+</script>
+
+<style scoped>
+.specification-breadcrumb {
+  font-size: var(--font-size-sm);
+}
+</style>

--- a/dataland-frontend/src/components/pages/SpecificationFrameworkPage.vue
+++ b/dataland-frontend/src/components/pages/SpecificationFrameworkPage.vue
@@ -1,0 +1,64 @@
+<template>
+  <TheContent class="flex">
+    <div class="col-12 text-left pb-0">
+      <nav class="specification-breadcrumb text-color-secondary mb-2">
+        <router-link to="/specifications" class="text-primary underline">Specifications</router-link>
+        <span v-if="framework"> / {{ framework.name }}</span>
+      </nav>
+      <div v-if="isPending">
+        <p class="font-medium text-xl">Loading framework specification...</p>
+        <DatalandProgressSpinner />
+      </div>
+      <FailMessage v-else-if="isError" message="Could not load this framework specification." />
+      <template v-else-if="framework">
+        <h1>{{ framework.name }}</h1>
+        <p class="text-lg">{{ framework.businessDefinition }}</p>
+      </template>
+    </div>
+    <div v-if="framework" class="grid m-0 text-left">
+      <div class="col-12">
+        <h2>Fields</h2>
+        <p class="text-color-secondary">
+          Click on a field to see its data point definition, validation rules and where else it is used.
+        </p>
+        <SpecificationSchemaTree :schema="parsedSchema" />
+      </div>
+    </div>
+  </TheContent>
+</template>
+
+<script setup lang="ts">
+import { computed, toRef } from 'vue';
+import TheContent from '@/components/generics/TheContent.vue';
+import DatalandProgressSpinner from '@/components/general/DatalandProgressSpinner.vue';
+import FailMessage from '@/components/messages/FailMessage.vue';
+import SpecificationSchemaTree from '@/components/resources/specifications/SpecificationSchemaTree.vue';
+import { useFrameworkSpecificationQuery } from '@/api-queries/specification/useFrameworkSpecificationQuery.ts';
+
+const props = defineProps<{
+  frameworkId: string;
+}>();
+
+const {
+  data: framework,
+  isPending,
+  isError,
+} = useFrameworkSpecificationQuery({ frameworkId: toRef(props, 'frameworkId') });
+
+const parsedSchema = computed<Record<string, unknown>>(() => {
+  if (!framework.value) {
+    return {};
+  }
+  try {
+    return JSON.parse(framework.value.schema) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+});
+</script>
+
+<style scoped>
+.specification-breadcrumb {
+  font-size: var(--font-size-sm);
+}
+</style>

--- a/dataland-frontend/src/components/pages/SpecificationsOverviewPage.vue
+++ b/dataland-frontend/src/components/pages/SpecificationsOverviewPage.vue
@@ -1,0 +1,76 @@
+<template>
+  <TheContent class="flex">
+    <div class="col-12 text-left pb-0">
+      <h1>Specification Explorer</h1>
+      <p class="text-lg">
+        Browse Dataland's frameworks, their data points and underlying base types. This explorer is generated directly
+        from the
+        <a href="/specifications/swagger-ui/index.html" target="_blank" rel="noopener noreferrer"
+          >specification service</a
+        >, so it always reflects the current state &mdash; unlike static documentation.
+      </p>
+    </div>
+    <div class="col-12 md:col-6 lg:col-4 text-left">
+      <InputText
+        v-model="searchTerm"
+        placeholder="Search frameworks"
+        class="w-full"
+        data-test="specificationSearchInput"
+      />
+    </div>
+    <div v-if="isPending" class="col-12 text-left">
+      <p class="font-medium text-xl">Loading frameworks...</p>
+      <DatalandProgressSpinner />
+    </div>
+    <FailMessage v-else-if="isError" message="Could not load the list of frameworks." />
+    <div v-else class="grid m-0">
+      <div
+        v-for="framework in filteredFrameworks"
+        :key="framework.framework.id"
+        class="col-12 md:col-6 lg:col-4 text-left"
+      >
+        <router-link
+          :to="`/specifications/frameworks/${framework.framework.id}`"
+          class="specification-card block surface-card shadow-1 p-3 border-round-sm"
+          :data-test="`specificationFrameworkCard-${framework.framework.id}`"
+        >
+          <div class="font-semibold text-lg">{{ framework.name }}</div>
+          <div class="text-color-secondary">{{ framework.framework.id }}</div>
+        </router-link>
+      </div>
+      <p v-if="filteredFrameworks.length === 0" class="col-12">No frameworks match your search.</p>
+    </div>
+  </TheContent>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import InputText from 'primevue/inputtext';
+import TheContent from '@/components/generics/TheContent.vue';
+import DatalandProgressSpinner from '@/components/general/DatalandProgressSpinner.vue';
+import FailMessage from '@/components/messages/FailMessage.vue';
+import { useFrameworkListQuery } from '@/api-queries/specification/useFrameworkListQuery.ts';
+
+const searchTerm = ref('');
+
+const { data: frameworks, isPending, isError } = useFrameworkListQuery();
+
+const filteredFrameworks = computed(() => {
+  const term = searchTerm.value.trim().toLowerCase();
+  const list = frameworks.value ?? [];
+  if (!term) {
+    return list;
+  }
+  return list.filter(
+    (framework) => framework.name.toLowerCase().includes(term) || framework.framework.id.toLowerCase().includes(term)
+  );
+});
+</script>
+
+<style scoped>
+.specification-card {
+  text-decoration: none;
+  color: inherit;
+  height: 100%;
+}
+</style>

--- a/dataland-frontend/src/components/resources/specifications/FrameworkSpecificationLink.vue
+++ b/dataland-frontend/src/components/resources/specifications/FrameworkSpecificationLink.vue
@@ -1,0 +1,37 @@
+<template>
+  <router-link
+    v-if="specificationExists"
+    :to="`/specifications/frameworks/${frameworkIdentifier}`"
+    class="specification-link text-primary font-semibold"
+    data-test="frameworkSpecificationLink"
+  >
+    <i class="pi pi-book" aria-hidden="true" />
+    View specification &amp; documentation
+  </router-link>
+</template>
+
+<script setup lang="ts">
+import { toRef } from 'vue';
+import { useFrameworkSpecificationExistsQuery } from '@/api-queries/specification/useFrameworkSpecificationExistsQuery.ts';
+
+const props = defineProps<{
+  /**
+   * The Dataland framework identifier (e.g. `sfdr`, `eutaxonomy-financials`) to link the specification of.
+   */
+  frameworkIdentifier: string;
+}>();
+
+const { data: specificationExists } = useFrameworkSpecificationExistsQuery({
+  frameworkId: toRef(props, 'frameworkIdentifier'),
+});
+</script>
+
+<style scoped>
+.specification-link {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xxs);
+  font-size: var(--font-size-sm);
+  text-decoration: underline;
+}
+</style>

--- a/dataland-frontend/src/components/resources/specifications/SpecificationJsonPreview.vue
+++ b/dataland-frontend/src/components/resources/specifications/SpecificationJsonPreview.vue
@@ -1,0 +1,26 @@
+<template>
+  <pre class="specification-json-preview" data-test="specificationJsonPreview">{{ formattedJson }}</pre>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+
+const props = defineProps<{
+  /**
+   * The value to render as pretty-printed, read-only JSON (e.g. a data point base type's `example`).
+   */
+  value: unknown;
+}>();
+
+const formattedJson = computed(() => JSON.stringify(props.value, null, 2));
+</script>
+
+<style scoped>
+.specification-json-preview {
+  background: var(--p-surface-50);
+  border-radius: var(--p-border-radius-xs);
+  padding: var(--spacing-md);
+  overflow-x: auto;
+  text-align: left;
+}
+</style>

--- a/dataland-frontend/src/components/resources/specifications/SpecificationSchemaTree.vue
+++ b/dataland-frontend/src/components/resources/specifications/SpecificationSchemaTree.vue
@@ -1,0 +1,77 @@
+<template>
+  <Tree :value="treeNodes" class="specification-schema-tree" data-test="specificationSchemaTree">
+    <template #default="slotProps">
+      <router-link
+        v-if="slotProps.node.data"
+        :to="`/specifications/data-point-types/${slotProps.node.data.dataPointTypeId}`"
+        class="text-primary font-semibold underline"
+        data-test="specificationSchemaTreeLeafLink"
+      >
+        {{ slotProps.node.label }}
+      </router-link>
+      <span v-else>{{ slotProps.node.label }}</span>
+    </template>
+  </Tree>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import Tree from 'primevue/tree';
+import type { TreeNode } from 'primevue/treenode';
+import { humanizeStringOrNumber } from '@/utils/StringFormatter';
+
+const props = defineProps<{
+  /**
+   * The parsed `schema` of a `FrameworkSpecification` (i.e. `JSON.parse(frameworkSpecification.schema)`):
+   * a tree of categories/subcategories whose leaves reference a data point type via `{ id, ref }`.
+   */
+  schema: Record<string, unknown>;
+}>();
+
+interface SchemaLeafReference {
+  id: string;
+  ref: string;
+}
+
+/**
+ * Checks whether a schema node is a leaf referencing a data point type (as opposed to a nested category).
+ * @param value the schema node to check
+ * @returns true if the node is a `{ id, ref }` reference to a data point type
+ */
+function isSchemaLeafReference(value: unknown): value is SchemaLeafReference {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as Partial<SchemaLeafReference>).id === 'string' &&
+    typeof (value as Partial<SchemaLeafReference>).ref === 'string'
+  );
+}
+
+/**
+ * Recursively converts the parsed framework schema into PrimeVue tree nodes. Leaf nodes carry the
+ * referenced data point type id so they can link to that data point type's detail page.
+ * @param schema the (sub-)tree to convert
+ * @param keyPrefix the tree-node key of the parent, used to build unique keys for children
+ * @returns the corresponding PrimeVue tree nodes
+ */
+function buildTreeNodes(schema: Record<string, unknown>, keyPrefix: string): TreeNode[] {
+  return Object.entries(schema).map(([fieldName, value]) => {
+    const key = keyPrefix ? `${keyPrefix}.${fieldName}` : fieldName;
+    if (isSchemaLeafReference(value)) {
+      return {
+        key,
+        label: humanizeStringOrNumber(fieldName),
+        leaf: true,
+        data: { dataPointTypeId: value.id },
+      };
+    }
+    return {
+      key,
+      label: humanizeStringOrNumber(fieldName),
+      children: buildTreeNodes(value as Record<string, unknown>, key),
+    };
+  });
+}
+
+const treeNodes = computed<TreeNode[]>(() => buildTreeNodes(props.schema, ''));
+</script>

--- a/dataland-frontend/src/router/index.ts
+++ b/dataland-frontend/src/router/index.ts
@@ -31,6 +31,14 @@ const AdminRequestsOverviewLegacy = (): Promise<RouteComponent> =>
 const ChooseFrameworkForDataUpload = (): Promise<RouteComponent> =>
   import('@/components/pages/ChooseFrameworkForDataUpload.vue');
 const DatasetReviewOverview = (): Promise<RouteComponent> => import('@/components/pages/DatasetReviewOverview.vue');
+const SpecificationsOverviewPage = (): Promise<RouteComponent> =>
+  import('@/components/pages/SpecificationsOverviewPage.vue');
+const SpecificationFrameworkPage = (): Promise<RouteComponent> =>
+  import('@/components/pages/SpecificationFrameworkPage.vue');
+const SpecificationDataPointTypePage = (): Promise<RouteComponent> =>
+  import('@/components/pages/SpecificationDataPointTypePage.vue');
+const SpecificationDataPointBaseTypePage = (): Promise<RouteComponent> =>
+  import('@/components/pages/SpecificationDataPointBaseTypePage.vue');
 import PlatformRedirect from '@/components/pages/PlatformRedirect.vue';
 import KeycloakRedirect from '@/components/pages/KeycloakRedirect.vue';
 
@@ -292,6 +300,45 @@ const routes = [
     meta: {
       requiresAuthentication: false,
       register: true,
+    },
+  },
+  {
+    path: '/specifications',
+    name: 'Specifications Overview',
+    component: SpecificationsOverviewPage,
+    meta: {
+      initialTabId: 'specifications',
+      requiresAuthentication: false,
+    },
+  },
+  {
+    path: '/specifications/frameworks/:frameworkId',
+    props: true,
+    name: 'Specification Framework Page',
+    component: SpecificationFrameworkPage,
+    meta: {
+      initialTabId: 'specifications',
+      requiresAuthentication: false,
+    },
+  },
+  {
+    path: '/specifications/data-point-types/:dataPointTypeId',
+    props: true,
+    name: 'Specification Data Point Type Page',
+    component: SpecificationDataPointTypePage,
+    meta: {
+      initialTabId: 'specifications',
+      requiresAuthentication: false,
+    },
+  },
+  {
+    path: '/specifications/data-point-base-types/:dataPointBaseTypeId',
+    props: true,
+    name: 'Specification Data Point Base Type Page',
+    component: SpecificationDataPointBaseTypePage,
+    meta: {
+      initialTabId: 'specifications',
+      requiresAuthentication: false,
     },
   },
   {

--- a/dataland-frontend/src/services/ApiClients.ts
+++ b/dataland-frontend/src/services/ApiClients.ts
@@ -18,6 +18,7 @@ import { DocumentControllerApi } from '@clients/documentmanager';
 import { EmailControllerApi } from '@clients/emailservice';
 import { QaControllerApi, DatasetJudgementControllerApi } from '@clients/qaservice';
 import { PortfolioControllerApi } from '@clients/userservice';
+import { SpecificationControllerApi } from '@clients/specificationservice';
 import type Keycloak from 'keycloak-js';
 import axios, { type AxiosInstance } from 'axios';
 import { updateTokenAndItsExpiryTimestampAndStoreBoth } from '@/utils/SessionTimeoutUtils';
@@ -49,6 +50,7 @@ interface ApiClients {
   dataExportController: DataExportControllerApi;
   companyRightsController: CompanyRightsControllerApi;
   creditsController: CreditsControllerApi;
+  specificationController: SpecificationControllerApi;
 }
 
 type ApiClientConstructor<T> = new (
@@ -118,6 +120,7 @@ export class ApiClientProvider {
       dataExportController: this.getClientFactory('/api')(DataExportControllerApi),
       companyRightsController: this.getClientFactory('/community')(CompanyRightsControllerApi),
       creditsController: this.getClientFactory('/accounting')(CreditsControllerApi),
+      specificationController: this.getClientFactory('/specifications')(SpecificationControllerApi),
     };
   }
 


### PR DESCRIPTION
Introduce a public "Specification Explorer" that renders the JSON served by dataland-specification-service (frameworks, data point types, data point base types) in an explorable, linked UI, and adds hints/links to this documentation elsewhere in the frontend.

- Add a generateSpecificationServiceClient Gradle task and wire the generated TypeScript client into ApiClientProvider.
- Add Vue Query hooks for the framework list, a single framework, a data point type, a data point base type, and a doesFrameworkSpecificationExist existence check.
- Add four new public routes/pages: /specifications, /specifications/frameworks/:frameworkId, /specifications/data-point-types/:dataPointTypeId and /specifications/data-point-base-types/:dataPointBaseTypeId.
- Render a framework's schema as an explorable PrimeVue tree whose leaves link to their data point type, which in turn link to their base type and back to all frameworks/data point types using them (usedBy), with the base type's example payload pretty-printed.
- Add a "SPECIFICATIONS" tab to the main navigation.
- Add a self-hiding "View specification & documentation" link on the generic framework data view page title (hidden for frameworks without a specification yet), and Swagger UI / explorer links on the API Keys page's documentation panel.

# Pull Request \<Title>
`<Description here>`
## Things to do during Peer Review
Please check all boxes before the Pull Request is merged. In case you skip a box, describe in the PRs description (that means: here) why the check is skipped.
- [x] The GitHub Actions for the CI are green. This is enforced by GitHub. 
- [ ] The PR has been peer-reviewed
  - [ ] The code has been manually inspected by someone who did not implement the feature
  - [ ] The changes have been inspected for possible breaking API changes (changed data models, endpoints, response codes, exception handling, ...). If there are any discuss them with the team.
  - [ ] If this PR includes work on the frontend, at least one `@ts-nocheck` is removed. Additionally, there should not be any `@ts-nocheck` in files modified by this PR. If no `@ts-nocheck` are left: Celebrate :tada: :confetti_ball: type-safety and remove this entry. 
- [ ] The PR actually implements what is described in the JIRA-Issue
- [ ] Make sure you understand the entire workflow from the user’s perspective, and test/review it accordingly. If anything is unclear, please reach out to the dev team.
- [ ] At least one test exists testing the new feature
  - [ ] Make sure all newly added functionality (especially user facing) is tested
  - [ ] Make sure that new test files are included in a test container and actually run in the CI
- [ ] At least 3 consecutive CI runs are successfully executed to ensure that there are no flaky tests.
- [ ] Documentation is updated as required. If unsure whether or what to update, ask a fellow developer.
- [ ] If there was a database entity class added, there must also be a migration script for creating the corresponding database if flyway is already used by the service
- [ ] IF there are changes done to the framework data models or to a database entity class, the following steps were completed in order
  - [ ] A fresh clone of dataland.com is generated (see Wiki page on "OTC" for details)
  - [ ] The feature branch is deployed to clone with `Reset non-user related Docker Volumes & Re-populate` turned off
  - [ ] It's verified that the CD run is green
  - [ ] The new feature is manually used/tested/observed on the clone server. Testing of the new feature should (also) be done by a second, independent reviewer from the dev team
  - [ ] The feature branch is deployed to one of the dev servers with `Reset non-user related Docker Volumes & Re-populate` turned on, and it's verified that the CD run is green
- [ ] ELSE, the new version is deployed to one of the dev servers using this branch
  - [ ] Run with setting `Reset non-user related Docker Volumes & Re-populate` turned on 
  - [ ] It's verified that this version actually is the one deployed (check gitinfo for branch name and commit id!)
  - [ ] It's verified that the CD run is green
  - [ ] The new feature is manually used/tested/observed on dev server. Testing of the new feature should (also) be done by a second, independent reviewer from the dev team
- [ ] Confirm that the latest version (use the /gitinfo endpoint) of the feature branch is deployed to one of the dev servers (no longer enforced by GitHub)
- [ ] Ensure that the release notes are written in a way that is understandable to a non-technical audience.
