### PR TITLE
Dala 7228 handle case where review object was created before qa report

### DIFF
--- a/dataland-frontend/src/components/pages/QualityAssurance.vue
+++ b/dataland-frontend/src/components/pages/QualityAssurance.vue
@@ -247,6 +247,8 @@
                   icon="pi pi-chevron-right"
                   icon-pos="right"
                   variant="link"
+                  :loading="loadingDataId === slotProps.data.dataId"
+                  :disabled="loadingDataId !== null"
                 />
                 <span v-else>
                   {{ slotProps.data.reviewStatus }}
@@ -268,8 +270,9 @@
     :header="confirmationModal.header"
     :message="confirmationModal.message"
     :error-message="confirmationModal.errorMessage"
-    :is-loading="isCreatingReview"
     @confirm="confirmationModal.onConfirm"
+    :show-cancel-button="false"
+    confirm-label="OK"
   />
 </template>
 
@@ -336,7 +339,7 @@ const selectedFrameworks = ref<Array<FrameworkSelectableItem>>([]);
 const availableFrameworks = ref<Array<FrameworkSelectableItem>>([]);
 const showNotEnoughCharactersWarning = ref(false);
 const selectedDataId = ref<string>('');
-const isCreatingReview = ref(false);
+const loadingDataId = ref<string | null>(null);
 
 const debounceInMs = 300;
 let timerId = 0;
@@ -405,7 +408,6 @@ function handleRowAction(qaDataObject: QaReviewRow): void {
 
 /**
  * Handles the click on the review button in the QA table.
- * If no review exists yet, a confirmation modal is shown and the review is created before navigation.
  * If a review already exists, the user is directly navigated to the corresponding dataset review page.
  */
 function handleReviewButtonClick(qaDataObject: QaReviewRow): void {
@@ -413,14 +415,8 @@ function handleReviewButtonClick(qaDataObject: QaReviewRow): void {
     void goToDatasetReviewPage(qaDataObject.datasetReviewId);
     return;
   }
-
   selectedDataId.value = qaDataObject.dataId;
-  openConfirmationModal(
-    'Start Review',
-    'Are you sure you want to start a review for this dataset? \n\n' +
-      'Once started, the review cannot be deleted and will be visible for other reviewers on Dataland.',
-    () => void confirmStartReview()
-  );
+  confirmStartReview();
 }
 
 /**
@@ -440,18 +436,25 @@ function goToDatasetReviewPage(datasetReviewId: string): ReturnType<typeof route
 /**
  * Confirms the start of a dataset review in the confirmation modal.
  * Creates a dataset review for the dataset with the selected data id and navigates to the corresponding dataset review page.
+ * Opens a confirmation modal with an error message if the dataset review creation fails.
  */
 async function confirmStartReview(): Promise<void> {
-  isCreatingReview.value = true;
+  loadingDataId.value = selectedDataId.value;
 
   try {
     const response = await apiClientProvider.apiClients.datasetJudgementController.postDatasetJudgement(
       selectedDataId.value
     );
-
     confirmationModal.value.visible = false;
     await goToDatasetReviewPage(response.data.dataSetJudgementId);
   } catch (error) {
+    openConfirmationModal(
+      'Failed to start review',
+      'An error occurred while trying to make the postDatasetJudgement call.',
+      () => {
+        confirmationModal.value.visible = false;
+      }
+    );
     if (error instanceof AxiosError) {
       confirmationModal.value.errorMessage = formatAxiosErrorMessage(error);
     } else {
@@ -459,7 +462,7 @@ async function confirmStartReview(): Promise<void> {
     }
     console.error(confirmationModal.value.errorMessage);
   } finally {
-    isCreatingReview.value = false;
+    loadingDataId.value = null;
   }
 }
 

--- a/dataland-frontend/src/components/pages/QualityAssurance.vue
+++ b/dataland-frontend/src/components/pages/QualityAssurance.vue
@@ -416,7 +416,7 @@ function handleReviewButtonClick(qaDataObject: QaReviewRow): void {
     return;
   }
   selectedDataId.value = qaDataObject.dataId;
-  confirmStartReview();
+  void confirmStartReview();
 }
 
 /**

--- a/dataland-frontend/tests/component/components/pages/QualityAssurance.cy.ts
+++ b/dataland-frontend/tests/component/components/pages/QualityAssurance.cy.ts
@@ -614,7 +614,7 @@ describe('Component tests for the Quality Assurance page', () => {
     cy.get('@routerPush').should('have.been.calledWith', `/qualityassurance/review/${datasetReviewIdBeta}`);
   });
 
-  it.only('Check display of error message.', () => {
+  it('Check display of error message.', () => {
     mountQaAssurancePageWithMocks();
     cy.intercept('POST', `**/qa/dataset-judgements/${dataIdAlpha}`, (request) => {
       request.reply(403, {
@@ -631,7 +631,6 @@ describe('Component tests for the Quality Assurance page', () => {
     }).as('createDatasetReviewForbidden');
     cy.get('button[data-test="goToReviewButton"]').not(`:contains(${reviewerUserName})`).click();
     cy.wait('@createDatasetReviewForbidden');
-    cy.pause();
     cy.get('[data-test="confirmation-modal-error-message"]')
       .should('be.visible')
       .and('contain', 'Access Denied: Access to this resource has been denied.');

--- a/dataland-frontend/tests/component/components/pages/QualityAssurance.cy.ts
+++ b/dataland-frontend/tests/component/components/pages/QualityAssurance.cy.ts
@@ -584,7 +584,6 @@ describe('Component tests for the Quality Assurance page', () => {
       });
     }).as('createDatasetReview');
     cy.get('button[data-test="goToReviewButton"]').not(`:contains(${reviewerUserName})`).click();
-    cy.get('[data-test="ok-confirmation-modal-button"]').should('be.visible').click();
     cy.wait('@createDatasetReview');
     cy.get('@routerPush').should('have.been.calledWith', `/qualityassurance/review/${datasetReviewIdAlpha}`);
   });
@@ -615,7 +614,7 @@ describe('Component tests for the Quality Assurance page', () => {
     cy.get('@routerPush').should('have.been.calledWith', `/qualityassurance/review/${datasetReviewIdBeta}`);
   });
 
-  it('Check display of error message.', () => {
+  it.only('Check display of error message.', () => {
     mountQaAssurancePageWithMocks();
     cy.intercept('POST', `**/qa/dataset-judgements/${dataIdAlpha}`, (request) => {
       request.reply(403, {
@@ -631,11 +630,12 @@ describe('Component tests for the Quality Assurance page', () => {
       });
     }).as('createDatasetReviewForbidden');
     cy.get('button[data-test="goToReviewButton"]').not(`:contains(${reviewerUserName})`).click();
-    cy.get('[data-test="ok-confirmation-modal-button"]').should('be.visible').click();
     cy.wait('@createDatasetReviewForbidden');
+    cy.pause();
     cy.get('[data-test="confirmation-modal-error-message"]')
       .should('be.visible')
       .and('contain', 'Access Denied: Access to this resource has been denied.');
+    cy.get('[data-test="ok-confirmation-modal-button"]').should('be.visible').click();
   });
 
   it('Check QA-overview-page for RESET FILTERS button behaviour', () => {

--- a/dataland-frontend/tests/e2e/specs/judgement/CheckJudgementProcedure.ts
+++ b/dataland-frontend/tests/e2e/specs/judgement/CheckJudgementProcedure.ts
@@ -106,7 +106,7 @@ describeIf(
       })
     );
 
-    it.only('Check creating a Judgement and reassigning the Judge works as expected', () => {
+    it('Check creating a Judgement and reassigning the Judge works as expected', () => {
       const dataSetId = uploadedDataMetaInfo.dataId;
       checkoutDataset(dataSetId);
       startJudgement(dataSetId);

--- a/dataland-frontend/tests/e2e/specs/judgement/CheckJudgementProcedure.ts
+++ b/dataland-frontend/tests/e2e/specs/judgement/CheckJudgementProcedure.ts
@@ -106,7 +106,7 @@ describeIf(
       })
     );
 
-    it('Check creating a Judgement and reassigning the Judge works as expected', () => {
+    it.only('Check creating a Judgement and reassigning the Judge works as expected', () => {
       const dataSetId = uploadedDataMetaInfo.dataId;
       checkoutDataset(dataSetId);
       startJudgement(dataSetId);
@@ -331,8 +331,6 @@ function startJudgement(dataSetId: string): void {
     .closest('tr')
     .contains('td', 'Start Review')
     .click();
-
-  cy.get('.p-dialog').should('be.visible').contains('button', 'CONFIRM').click();
 
   cy.wait('@startJudgementRequest').then((interception) => {
     expect(interception.response?.statusCode).to.eq(201);


### PR DESCRIPTION
# Pull Request \<Title>
`<Description here>`
## Things to do during Peer Review
Please check all boxes before the Pull Request is merged. In case you skip a box, describe in the PRs description (that means: here) why the check is skipped.
- [x] The GitHub Actions for the CI are green. This is enforced by GitHub. 
- [x] The PR has been peer-reviewed
  - [x] The code has been manually inspected by someone who did not implement the feature
  - [x] The changes have been inspected for possible breaking API changes (changed data models, endpoints, response codes, exception handling, ...). If there are any discuss them with the team.
  - [x] If this PR includes work on the frontend, at least one `@ts-nocheck` is removed. Additionally, there should not be any `@ts-nocheck` in files modified by this PR. If no `@ts-nocheck` are left: Celebrate :tada: :confetti_ball: type-safety and remove this entry. 
- [x] The PR actually implements what is described in the JIRA-Issue
- [x] Make sure you understand the entire workflow from the user’s perspective, and test/review it accordingly. If anything is unclear, please reach out to the dev team.
- [x] At least one test exists testing the new feature
  - [x] Make sure all newly added functionality (especially user facing) is tested
  - [x] Make sure that new test files are included in a test container and actually run in the CI
- [x] At least 3 consecutive CI runs are successfully executed to ensure that there are no flaky tests.
- [x] Documentation is updated as required. If unsure whether or what to update, ask a fellow developer.
- [x] If there was a database entity class added, there must also be a migration script for creating the corresponding database if flyway is already used by the service
- [ ] IF there are changes done to the framework data models or to a database entity class, the following steps were completed in order
  - [ ] A fresh clone of dataland.com is generated (see Wiki page on "OTC" for details)
  - [ ] The feature branch is deployed to clone with `Reset non-user related Docker Volumes & Re-populate` turned off
  - [ ] It's verified that the CD run is green
  - [ ] The new feature is manually used/tested/observed on the clone server. Testing of the new feature should (also) be done by a second, independent reviewer from the dev team
  - [ ] The feature branch is deployed to one of the dev servers with `Reset non-user related Docker Volumes & Re-populate` turned on, and it's verified that the CD run is green
- [x] ELSE, the new version is deployed to one of the dev servers using this branch
  - [x] Run with setting `Reset non-user related Docker Volumes & Re-populate` turned on 
  - [x] It's verified that this version actually is the one deployed (check gitinfo for branch name and commit id!)
  - [x] It's verified that the CD run is green
  - [x] The new feature is manually used/tested/observed on dev server. Testing of the new feature should (also) be done by a second, independent reviewer from the dev team
- [x] Confirm that the latest version (use the /gitinfo endpoint) of the feature branch is deployed to one of the dev servers (no longer enforced by GitHub)
- [x] Ensure that the release notes are written in a way that is understandable to a non-technical audience.
