### PR TITLE
DALA-7691: data availability check returns error on empty list input

### DIFF
--- a/dataland-backend/src/main/kotlin/org/dataland/datalandbackend/services/DataAvailabilityChecker.kt
+++ b/dataland-backend/src/main/kotlin/org/dataland/datalandbackend/services/DataAvailabilityChecker.kt
@@ -73,7 +73,7 @@ class DataAvailabilityChecker
          * @param dataDimensions List of data point dimensions to search for.
          * @return List of DataPointMetaInformationEntity objects that match the provided data point dimensions.
          */
-        private fun getMetaDataOfActiveDataPoints(dataDimensions: List<DataPointDimensions>): List<DataPointMetaInformationEntity> =
+        private fun getMetaDataOfActiveDataPoints(dataDimensions: Collection<DataPointDimensions>): List<DataPointMetaInformationEntity> =
             dataPointMetaInformationManager.getActiveDataPointMetaInformationList(
                 dataCompositionService.filterOutInvalidDataPointDimensions(dataDimensions).distinct(),
             )
@@ -190,35 +190,32 @@ class DataAvailabilityChecker
                     .toSet()
 
             return assembledDimensions
-                .flatMap { dimension ->
-                    val relevantDataPointTypes =
-                        dataCompositionService
-                            .getRelevantDataPointTypes(dimension.framework)
+                .groupBy { it.framework }
+                .flatMap { (framework, frameWorkSpecificDimensions) ->
+
+                    val relevantDataPointTypes = dataCompositionService.getRelevantDataPointTypes(framework)
                     val relevantDataPointDimensions =
-                        relevantDataPointTypes
-                            .map { dataPointType ->
-                                BasicDataPointDimensions(
-                                    companyId = dimension.companyId,
-                                    dataPointType = dataPointType,
-                                    reportingPeriod = dimension.reportingPeriod,
-                                )
-                            }
+                        frameWorkSpecificDimensions
+                            .flatMap {
+                                it.toBasicDataPointDimensions(relevantDataPointTypes)
+                            }.toSet()
+                    val requestedBaseDimensions = frameWorkSpecificDimensions.map { it.toBaseDimensions() }.toSet()
+
                     val activeDataPointDimensions =
                         getMetaDataOfActiveDataPoints(
                             relevantDataPointDimensions,
                         ).map { it.toBasicDataPointDimensions() }.toSet()
-
                     val calculatableDataPointDimensions =
-                        dataPointCalculator.getCalculatableDataPointDimensions(
-                            dataPointTypes = relevantDataPointTypes,
-                            dataDimensionQuery =
-                                DataDimensionQuery(
-                                    companyIds = listOf(dimension.companyId),
-                                    reportingPeriods = listOf(dimension.reportingPeriod),
-                                ),
-                        )
-
-                    getViewableDatasetDimensions(activeDataPointDimensions + calculatableDataPointDimensions, dimension.framework)
+                        dataPointCalculator
+                            .getCalculatableDataPointDimensions(
+                                dataPointTypes = relevantDataPointTypes,
+                                dataDimensionQuery =
+                                    DataDimensionQuery(
+                                        companyIds = frameWorkSpecificDimensions.map { it.companyId },
+                                        reportingPeriods = frameWorkSpecificDimensions.map { it.reportingPeriod },
+                                    ),
+                            ).filter { requestedBaseDimensions.contains(it.toBaseDimensions()) }
+                    getViewableDatasetDimensions(activeDataPointDimensions + calculatableDataPointDimensions, framework)
                 }.toSet()
         }
 

--- a/dataland-backend/src/main/kotlin/org/dataland/datalandbackend/services/DataAvailabilityChecker.kt
+++ b/dataland-backend/src/main/kotlin/org/dataland/datalandbackend/services/DataAvailabilityChecker.kt
@@ -112,7 +112,9 @@ class DataAvailabilityChecker
          * @return The subset of the input dimensions for which active data exists
          */
         fun filterViewableDimensions(dimensions: List<BasicDataDimensions>): List<BasicDataDimensions> {
-            requireNonEmptyInput(dimensions.isEmpty())
+            if (dimensions.isEmpty()) {
+                return emptyList()
+            }
             val dataPointBasedDimensions =
                 getMetaDataOfActiveDataPoints(dimensions.map { it.toBasicDataPointDimensions() }).map { it.toBasicDataDimensions() }
             val nonAssembledFrameworkBasedDimensions =

--- a/dataland-backend/src/main/kotlin/org/dataland/datalandbackend/services/DataCompositionService.kt
+++ b/dataland-backend/src/main/kotlin/org/dataland/datalandbackend/services/DataCompositionService.kt
@@ -97,7 +97,7 @@ class DataCompositionService
          * @param dataDimensions the list of data point dimensions to filter
          * @return the list of all valid data point dimensions from the original input
          */
-        fun filterOutInvalidDataPointDimensions(dataDimensions: List<DataPointDimensions>) =
+        fun filterOutInvalidDataPointDimensions(dataDimensions: Collection<DataPointDimensions>) =
             dataDimensions.filter { dimensions ->
                 ValidationUtils.isBaseDimensions(dimensions) &&
                     specificationService.isDataPointType(dimensions.dataPointType)

--- a/dataland-backend/src/test/kotlin/org/dataland/datalandbackend/services/DataAvailabilityCheckerFilterTest.kt
+++ b/dataland-backend/src/test/kotlin/org/dataland/datalandbackend/services/DataAvailabilityCheckerFilterTest.kt
@@ -1,9 +1,9 @@
 package org.dataland.datalandbackend.services
 
-import org.dataland.datalandbackendutils.exceptions.InvalidInputApiException
 import org.dataland.datalandbackendutils.model.BasicDataDimensions
+import org.junit.Assert.assertTrue
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 import java.util.UUID
@@ -13,10 +13,11 @@ import org.dataland.datalandbackend.utils.DEFAULT_REPORTING_PERIOD as reportingP
 
 class DataAvailabilityCheckerFilterTest : DataAvailabilityCheckerTestBase() {
     @Test
-    fun `check that an empty throws an InvalidInputApiException`() {
-        assertThrows<InvalidInputApiException> {
+    fun `check that an empty filter does not throw and returns an empty list`() {
+        val result = assertDoesNotThrow {
             dataAvailabilityChecker.filterViewableDimensions(emptyList())
         }
+        assertTrue(result.isEmpty())
     }
 
     @Test

--- a/dataland-backend/src/test/kotlin/org/dataland/datalandbackend/services/DataAvailabilityCheckerFilterTest.kt
+++ b/dataland-backend/src/test/kotlin/org/dataland/datalandbackend/services/DataAvailabilityCheckerFilterTest.kt
@@ -14,9 +14,7 @@ import org.dataland.datalandbackend.utils.DEFAULT_REPORTING_PERIOD as reportingP
 class DataAvailabilityCheckerFilterTest : DataAvailabilityCheckerTestBase() {
     @Test
     fun `check that an empty filter does not throw and returns an empty list`() {
-        val result = assertDoesNotThrow {
-            dataAvailabilityChecker.filterViewableDimensions(emptyList())
-        }
+        val result = assertDoesNotThrow { dataAvailabilityChecker.filterViewableDimensions(emptyList()) }
         assertTrue(result.isEmpty())
     }
 

--- a/dataland-data-sourcing-service/src/main/kotlin/org/dataland/datasourcingservice/services/BulkRequestManager.kt
+++ b/dataland-data-sourcing-service/src/main/kotlin/org/dataland/datasourcingservice/services/BulkRequestManager.kt
@@ -111,6 +111,9 @@ class BulkRequestManager
             }
 
         private fun getExistingDatasets(requests: Set<BasicDataDimensions>): Set<BasicDataDimensions> {
+            if (requests.isEmpty()) {
+                return emptySet()
+            }
             val newTaxonomyEquivalentRequests = requests.mapNotNull { req -> getNewEuTaxonomyEquivalent(req) }
 
             val activeDatasetDimensions =


### PR DESCRIPTION
# Pull Request \<Title>
`<Description here>`
## Things to do during Peer Review
Please check all boxes before the Pull Request is merged. In case you skip a box, describe in the PRs description (that means: here) why the check is skipped.
- [x] The GitHub Actions for the CI are green. This is enforced by GitHub. 
- [x] The PR has been peer-reviewed
  - [x] The code has been manually inspected by someone who did not implement the feature
  - [x] The changes have been inspected for possible breaking API changes (changed data models, endpoints, response codes, exception handling, ...). If there are any discuss them with the team.
  - [ ] If this PR includes work on the frontend, at least one `@ts-nocheck` is removed. Additionally, there should not be any `@ts-nocheck` in files modified by this PR. If no `@ts-nocheck` are left: Celebrate :tada: :confetti_ball: type-safety and remove this entry. 
- [x] The PR actually implements what is described in the JIRA-Issue
- [ ] Make sure you understand the entire workflow from the user’s perspective, and test/review it accordingly. If anything is unclear, please reach out to the dev team.
- [x] At least one test exists testing the new feature
  - [x] Make sure all newly added functionality (especially user facing) is tested
  - [x] Make sure that new test files are included in a test container and actually run in the CI
- [x] At least 3 consecutive CI runs are successfully executed to ensure that there are no flaky tests.
- [x] Documentation is updated as required. If unsure whether or what to update, ask a fellow developer.
- [ ] If there was a database entity class added, there must also be a migration script for creating the corresponding database if flyway is already used by the service
- [ ] IF there are changes done to the framework data models or to a database entity class, the following steps were completed in order
  - [ ] A fresh clone of dataland.com is generated (see Wiki page on "OTC" for details)
  - [ ] The feature branch is deployed to clone with `Reset non-user related Docker Volumes & Re-populate` turned off
  - [ ] It's verified that the CD run is green
  - [ ] The new feature is manually used/tested/observed on the clone server. Testing of the new feature should (also) be done by a second, independent reviewer from the dev team
  - [ ] The feature branch is deployed to one of the dev servers with `Reset non-user related Docker Volumes & Re-populate` turned on, and it's verified that the CD run is green
- [x] ELSE, the new version is deployed to one of the dev servers using this branch
  - [ ] Run with setting `Reset non-user related Docker Volumes & Re-populate` turned on 
  - [x] It's verified that this version actually is the one deployed (check gitinfo for branch name and commit id!)
  - [x] It's verified that the CD run is green
  - [x] The new feature is manually used/tested/observed on dev server. Testing of the new feature should (also) be done by a second, independent reviewer from the dev team
- [x] Confirm that the latest version (use the /gitinfo endpoint) of the feature branch is deployed to one of the dev servers (no longer enforced by GitHub)
- [x] Ensure that the release notes are written in a way that is understandable to a non-technical audience.
