### PR TITLE
DALA-7698: QA Service throws error for some rabbitmq messages

### DIFF
--- a/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/tests/NonSourceabilityTest.kt
+++ b/dataland-e2etests/src/test/kotlin/org/dataland/e2etests/tests/NonSourceabilityTest.kt
@@ -120,7 +120,7 @@ class NonSourceabilityTest {
         ctx = ctx.copy(dataSourcingId = initializeDataSourcing(ctx.companyId))
 
         postNonSourceableWithBypassQa(ctx)
-        assertNoQaReviewRowExists(ctx)
+        assertQaReviewIsAccepted(ctx)
         assertBackendEntryIsAcceptedAndActive(ctx)
         assertDsState(ctx, DataSourcingState.NonSourceable)
     }
@@ -347,20 +347,6 @@ class NonSourceabilityTest {
             "Entry must be immediately Accepted when bypassQa=true",
         )
         assertTrue(createdEntry.currentlyActive, "Entry must be immediately active when bypassQa=true")
-    }
-
-    private fun assertNoQaReviewRowExists(ctx: Ctx) {
-        awaitUntilAsserted {
-            val qaReviews =
-                asAdmin {
-                    apiAccessor.nonSourceabilityQaControllerApi.getNonSourceableReviews(
-                        companyId = ctx.companyId,
-                        dataType = ctx.dataType.value,
-                        reportingPeriod = ctx.reportingPeriod,
-                    )
-                }
-            assertTrue(qaReviews.isEmpty(), "QA service must have no review rows when bypassQa=true")
-        }
     }
 
     private fun uploadDatasetForTriple(ctx: Ctx): String =

--- a/dataland-frontend/tests/e2e/specs/admin-tools/RabbitMQAdmin.ts
+++ b/dataland-frontend/tests/e2e/specs/admin-tools/RabbitMQAdmin.ts
@@ -21,7 +21,7 @@ const queues = [
   'data-sourcing-service.datasetQaStatusUpdate',
   'user-service.processMessageForDataReportedAsNonSourceable',
   'user-service.processMessageForAvailableDataAndUpdates',
-  'qa-service.processNonSourceabilityCreated',
+  'qa-service.processNonSourceabilitySubmission',
   'data-sourcing-service.processNonSourceabilitySubmission',
   'community-manager.processNonSourceabilitySubmission',
   'backend.processNonSourceabilityQaDecision',

--- a/dataland-message-queue-utils/src/main/kotlin/org/dataland/datalandmessagequeueutils/constants/QueueNames.kt
+++ b/dataland-message-queue-utils/src/main/kotlin/org/dataland/datalandmessagequeueutils/constants/QueueNames.kt
@@ -20,10 +20,12 @@ object QueueNames {
     const val USER_SERVICE_QA_STATUS_UPDATE_EVENT = "user-service.processMessageForAvailableDataAndUpdates"
     const val ACCOUNTING_SERVICE_REQUEST_PROCESSING = "accounting-service.requestProcessing"
     const val ACCOUNTING_SERVICE_REQUEST_WITHDRAWN = "accounting-service.requestWithdrawn"
-    const val QA_SERVICE_NON_SOURCEABILITY_CREATED = "qa-service.processNonSourceabilityCreated"
-    const val DATA_SOURCING_SERVICE_NON_SOURCEABILITY_SUBMISSION = "data-sourcing-service.processNonSourceabilitySubmission"
+    const val DATA_SOURCING_SERVICE_NON_SOURCEABILITY_SUBMISSION =
+        "data-sourcing-service.processNonSourceabilitySubmission"
+    const val QA_SERVICE_NON_SOURCEABILITY_SUBMISSION = "qa-service.processNonSourceabilitySubmission"
     const val COMMUNITY_MANAGER_NON_SOURCEABILITY_SUBMISSION = "community-manager.processNonSourceabilitySubmission"
     const val BACKEND_NON_SOURCEABILITY_QA_DECISION = "backend.processNonSourceabilityQaDecision"
-    const val DATA_SOURCING_SERVICE_NON_SOURCEABILITY_QA_DECISION = "data-sourcing-service.processNonSourceabilityQaDecision"
+    const val DATA_SOURCING_SERVICE_NON_SOURCEABILITY_QA_DECISION =
+        "data-sourcing-service.processNonSourceabilityQaDecision"
     const val COMMUNITY_MANAGER_NON_SOURCEABILITY_QA_DECISION = "community-manager.processNonSourceabilityQaDecision"
 }

--- a/dataland-qa-service/src/main/kotlin/org/dataland/datalandqaservice/services/NonSourceabilityEventListener.kt
+++ b/dataland-qa-service/src/main/kotlin/org/dataland/datalandqaservice/services/NonSourceabilityEventListener.kt
@@ -113,12 +113,40 @@ class NonSourceabilityEventListener(
     }
 
     /**
-     * Auto-accepted events do not require a QA review.
+     * Creates an already-accepted QA review for an auto-accepted non-sourceability event
+     * (i.e. one that bypassed manual QA review), so that the QA service retains a
+     * consistent, queryable audit record for every non-sourceability claim.
      *
-     * Returning normally acknowledges the RabbitMQ message.
+     * No reviewer is set, since no human made this decision. No QA decision message is
+     * emitted, since the auto-accept was already communicated by the backend and handled
+     * directly by other downstream consumers.
      */
-    private fun processAutoAcceptedEvent(event: NonSourceabilityLifecycleEvent) {
-        logger.info("Ignoring auto-accepted non-sourceability event in QA service (nonSourceabilityId=${event.nonSourceabilityId})")
+    @Transactional
+    internal fun processAutoAcceptedEvent(event: NonSourceabilityLifecycleEvent) {
+        val existing = nonSourceableQaReviewRepository.findByNonSourceabilityId(event.nonSourceabilityId)
+
+        if (existing != null) {
+            logger.info("Idempotent skip: QA review record already exists for nonSourceabilityId=${event.nonSourceabilityId}")
+            return
+        }
+
+        val entity =
+            NonSourceableQaReviewInformationEntity(
+                nonSourceabilityId = event.nonSourceabilityId,
+                companyId = event.companyId,
+                dataType = event.dataType,
+                reportingPeriod = event.reportingPeriod,
+                qaStatus = QaStatus.Accepted,
+                reason = null,
+                uploaderUserId = event.uploaderUserId,
+                uploadTime = Instant.now().toEpochMilli(),
+                reviewerUserId = null,
+                qaComment = "Auto-accepted (QA bypass)",
+            )
+
+        nonSourceableQaReviewRepository.save(entity)
+
+        logger.info("Created auto-accepted QA review record for nonSourceabilityId=${event.nonSourceabilityId}")
     }
 
     /**

--- a/dataland-qa-service/src/main/kotlin/org/dataland/datalandqaservice/services/NonSourceabilityEventListener.kt
+++ b/dataland-qa-service/src/main/kotlin/org/dataland/datalandqaservice/services/NonSourceabilityEventListener.kt
@@ -6,6 +6,7 @@ import org.dataland.datalandmessagequeueutils.constants.MessageHeaderKey
 import org.dataland.datalandmessagequeueutils.constants.MessageType
 import org.dataland.datalandmessagequeueutils.constants.QueueNames
 import org.dataland.datalandmessagequeueutils.constants.RoutingKeyNames
+import org.dataland.datalandmessagequeueutils.exceptions.MessageQueueRejectException
 import org.dataland.datalandmessagequeueutils.model.NonSourceabilityLifecycleEvent
 import org.dataland.datalandmessagequeueutils.utils.MessageQueueUtils
 import org.dataland.datalandqaservice.entities.NonSourceableQaReviewInformationEntity
@@ -22,27 +23,32 @@ import org.springframework.messaging.handler.annotation.Payload
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.Instant
+import java.util.UUID
 
 /**
- * Listens to non-sourceability-created events from the backend and creates a corresponding
- * [NonSourceableQaReviewInformationEntity] in the QA service.
+ * Handles non-sourceability submission events from the backend.
+ *
+ * A single queue binds to [RoutingKeyNames.NON_SOURCEABILITY_SUBMISSION] and dispatches on
+ * messageType:
+ *   - [MessageType.NON_SOURCEABILITY_CREATED]       → [DataSourcingState.NonSourceableVerification]
+ *   - [MessageType.NON_SOURCEABILITY_AUTO_ACCEPTED] → [DataSourcingState.NonSourceable]
+ *
+ * Fail-fast validation: events with malformed or blank nonSourceabilityId are
+ * discarded with an error log and a [MessageQueueRejectException].
  */
 @Service
 class NonSourceabilityEventListener(
-    @Autowired private val nonSourceableQaReviewRepository: NonSourceableQaReviewRepository,
+    @Autowired
+    private val nonSourceableQaReviewRepository: NonSourceableQaReviewRepository,
 ) {
     private val logger = LoggerFactory.getLogger(javaClass)
 
-    /**
-     * Handles a non-sourceability-created event from the backend and creates a pending
-     * [NonSourceableQaReviewInformationEntity] for review.
-     */
     @RabbitListener(
         bindings = [
             QueueBinding(
                 value =
                     Queue(
-                        QueueNames.QA_SERVICE_NON_SOURCEABILITY_CREATED,
+                        QueueNames.QA_SERVICE_NON_SOURCEABILITY_SUBMISSION,
                         arguments = [
                             Argument(name = "x-dead-letter-exchange", value = ExchangeName.DEAD_LETTER),
                             Argument(name = "x-dead-letter-routing-key", value = "deadLetterKey"),
@@ -54,24 +60,38 @@ class NonSourceabilityEventListener(
             ),
         ],
     )
-    fun onNonSourceabilityCreated(
+    fun onNonSourceabilitySubmission(
         @Payload payload: String,
         @Header(MessageHeaderKey.TYPE) messageType: String,
     ) {
         MessageQueueUtils.rejectMessageOnException {
-            MessageQueueUtils.validateMessageType(messageType, MessageType.NON_SOURCEABILITY_CREATED)
+            validateMessageType(messageType)
+
             val event = MessageQueueUtils.readMessagePayload<NonSourceabilityLifecycleEvent>(payload)
-            processCreatedEvent(event)
+
+            validateNonSourceabilityId(event.nonSourceabilityId)
+
+            when (messageType) {
+                MessageType.NON_SOURCEABILITY_CREATED -> {
+                    processCreatedEvent(event)
+                }
+
+                MessageType.NON_SOURCEABILITY_AUTO_ACCEPTED -> {
+                    processAutoAcceptedEvent(event)
+                }
+            }
         }
     }
 
+    /**
+     * Creates a pending QA review for a normal non-sourceability event.
+     */
     @Transactional
     internal fun processCreatedEvent(event: NonSourceabilityLifecycleEvent) {
         val existing = nonSourceableQaReviewRepository.findByNonSourceabilityId(event.nonSourceabilityId)
+
         if (existing != null) {
-            logger.info(
-                "Idempotent skip: QA review record already exists for nonSourceabilityId=${event.nonSourceabilityId}",
-            )
+            logger.info("Idempotent skip: QA review record already exists for nonSourceabilityId=${event.nonSourceabilityId}")
             return
         }
 
@@ -86,9 +106,46 @@ class NonSourceabilityEventListener(
                 uploaderUserId = event.uploaderUserId,
                 uploadTime = Instant.now().toEpochMilli(),
             )
+
         nonSourceableQaReviewRepository.save(entity)
-        logger.info(
-            "Created QA review record for nonSourceabilityId=${event.nonSourceabilityId}",
-        )
+
+        logger.info("Created QA review record for nonSourceabilityId=${event.nonSourceabilityId}")
+    }
+
+    /**
+     * Auto-accepted events do not require a QA review.
+     *
+     * Returning normally acknowledges the RabbitMQ message.
+     */
+    private fun processAutoAcceptedEvent(event: NonSourceabilityLifecycleEvent) {
+        logger.info("Ignoring auto-accepted non-sourceability event in QA service (nonSourceabilityId=${event.nonSourceabilityId})")
+    }
+
+    /**
+     * Accepts only the two non-sourceability lifecycle events handled by this listener.
+     */
+    private fun validateMessageType(messageType: String) {
+        if (messageType != MessageType.NON_SOURCEABILITY_CREATED &&
+            messageType != MessageType.NON_SOURCEABILITY_AUTO_ACCEPTED
+        ) {
+            throw MessageQueueRejectException("Unexpected message type \"$messageType\" in NonSourceabilityEventListener")
+        }
+    }
+
+    /**
+     * Validates that the event contains a usable non-sourceability ID.
+     */
+    private fun validateNonSourceabilityId(nonSourceabilityId: String) {
+        if (nonSourceabilityId.isBlank()) {
+            throw MessageQueueRejectException("Received event with blank nonSourceabilityId. Discarding.")
+        }
+
+        try {
+            UUID.fromString(nonSourceabilityId)
+        } catch (exception: IllegalArgumentException) {
+            logger.error("Malformed nonSourceabilityId='$nonSourceabilityId'. Discarding.", exception)
+
+            throw MessageQueueRejectException("Malformed nonSourceabilityId='$nonSourceabilityId'", exception)
+        }
     }
 }

--- a/dataland-qa-service/src/main/kotlin/org/dataland/datalandqaservice/services/NonSourceabilityEventListener.kt
+++ b/dataland-qa-service/src/main/kotlin/org/dataland/datalandqaservice/services/NonSourceabilityEventListener.kt
@@ -43,6 +43,14 @@ class NonSourceabilityEventListener(
 ) {
     private val logger = LoggerFactory.getLogger(javaClass)
 
+    /**
+     * Entry point for the RabbitMQ listener that consumes non-sourceability lifecycle events
+     * and dispatches them to the appropriate handler based on [messageType].
+     *
+     * @param payload the serialized [NonSourceabilityLifecycleEvent]
+     * @param messageType the message type header, expected to be one of
+     *   [MessageType.NON_SOURCEABILITY_CREATED] or [MessageType.NON_SOURCEABILITY_AUTO_ACCEPTED]
+     */
     @RabbitListener(
         bindings = [
             QueueBinding(

--- a/dataland-qa-service/src/test/kotlin/org/dataland/datalandqaservice/services/NonSourceabilityEventListenerTest.kt
+++ b/dataland-qa-service/src/test/kotlin/org/dataland/datalandqaservice/services/NonSourceabilityEventListenerTest.kt
@@ -20,6 +20,12 @@ import org.mockito.kotlin.whenever
 import java.time.Instant
 
 class NonSourceabilityEventListenerTest {
+    companion object {
+        private const val NON_SOURCEABILITY_ID = "00000000-0000-0000-0000-000000000001"
+        private const val COMPANY_ID = "company-1"
+        private const val DATA_TYPE = "eutaxonomy-financials"
+    }
+
     private val repository: NonSourceableQaReviewRepository = mock()
     private lateinit var listener: NonSourceabilityEventListener
     private val objectMapper = jacksonObjectMapper().findAndRegisterModules()
@@ -29,11 +35,11 @@ class NonSourceabilityEventListenerTest {
         listener = NonSourceabilityEventListener(repository)
     }
 
-    private fun event(nonSourceabilityId: String = "00000000-0000-0000-0000-000000000001") =
+    private fun event(nonSourceabilityId: String = NON_SOURCEABILITY_ID) =
         NonSourceabilityLifecycleEvent(
             nonSourceabilityId = nonSourceabilityId,
-            companyId = "company-1",
-            dataType = "eutaxonomy-financials",
+            companyId = COMPANY_ID,
+            dataType = DATA_TYPE,
             reportingPeriod = "2023",
         )
 
@@ -50,9 +56,9 @@ class NonSourceabilityEventListenerTest {
     fun `processCreatedEvent is idempotent skips when review already exists`() {
         val existing =
             NonSourceableQaReviewInformationEntity(
-                nonSourceabilityId = "00000000-0000-0000-0000-000000000001",
-                companyId = "company-1",
-                dataType = "eutaxonomy-financials",
+                nonSourceabilityId = NON_SOURCEABILITY_ID,
+                companyId = COMPANY_ID,
+                dataType = DATA_TYPE,
                 reportingPeriod = "2023",
                 qaStatus = QaStatus.Pending,
                 reason = null,
@@ -83,9 +89,9 @@ class NonSourceabilityEventListenerTest {
     fun `processAutoAcceptedEvent is idempotent skips when review already exists`() {
         val existing =
             NonSourceableQaReviewInformationEntity(
-                nonSourceabilityId = "00000000-0000-0000-0000-000000000001",
-                companyId = "company-1",
-                dataType = "eutaxonomy-financials",
+                nonSourceabilityId = NON_SOURCEABILITY_ID,
+                companyId = COMPANY_ID,
+                dataType = DATA_TYPE,
                 reportingPeriod = "2023",
                 qaStatus = QaStatus.Accepted,
                 reason = null,

--- a/dataland-qa-service/src/test/kotlin/org/dataland/datalandqaservice/services/NonSourceabilityEventListenerTest.kt
+++ b/dataland-qa-service/src/test/kotlin/org/dataland/datalandqaservice/services/NonSourceabilityEventListenerTest.kt
@@ -2,15 +2,17 @@ package org.dataland.datalandqaservice.services
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.dataland.datalandbackendutils.model.QaStatus
-import org.dataland.datalandmessagequeueutils.constants.MessageType
 import org.dataland.datalandmessagequeueutils.exceptions.MessageQueueRejectException
 import org.dataland.datalandmessagequeueutils.model.NonSourceabilityLifecycleEvent
 import org.dataland.datalandqaservice.entities.NonSourceableQaReviewInformationEntity
 import org.dataland.datalandqaservice.repositories.NonSourceableQaReviewRepository
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
@@ -65,10 +67,43 @@ class NonSourceabilityEventListenerTest {
     }
 
     @Test
-    fun `onNonSourceabilityCreated throws reject exception for wrong message type`() {
+    fun `processAutoAcceptedEvent persists QA review record with Accepted status and no reviewer`() {
+        whenever(repository.findByNonSourceabilityId(any())).thenReturn(null)
+
+        listener.processAutoAcceptedEvent(event())
+
+        val captor = argumentCaptor<NonSourceableQaReviewInformationEntity>()
+        verify(repository).save(captor.capture())
+        val savedEntity = captor.firstValue
+        assertEquals(QaStatus.Accepted, savedEntity.qaStatus)
+        assertNull(savedEntity.reviewerUserId)
+    }
+
+    @Test
+    fun `processAutoAcceptedEvent is idempotent skips when review already exists`() {
+        val existing =
+            NonSourceableQaReviewInformationEntity(
+                nonSourceabilityId = "00000000-0000-0000-0000-000000000001",
+                companyId = "company-1",
+                dataType = "eutaxonomy-financials",
+                reportingPeriod = "2023",
+                qaStatus = QaStatus.Accepted,
+                reason = null,
+                uploaderUserId = "",
+                uploadTime = Instant.now().toEpochMilli(),
+            )
+        whenever(repository.findByNonSourceabilityId(any())).thenReturn(existing)
+
+        listener.processAutoAcceptedEvent(event())
+
+        verify(repository, never()).save(any())
+    }
+
+    @Test
+    fun `onNonSourceabilitySubmission throws reject exception for unexpected message type`() {
         val payload = objectMapper.writeValueAsString(event())
         assertThrows<MessageQueueRejectException> {
-            listener.onNonSourceabilityCreated(payload, MessageType.NON_SOURCEABILITY_AUTO_ACCEPTED)
+            listener.onNonSourceabilitySubmission(payload, "unexpectedMessageType")
         }
     }
 }


### PR DESCRIPTION
QA Service throws error for some rabbitmq messages

## Things to do during Peer Review
Please check all boxes before the Pull Request is merged. In case you skip a box, describe in the PRs description (that means: here) why the check is skipped.
- [x] The GitHub Actions for the CI are green. This is enforced by GitHub. 
- [x] The PR has been peer-reviewed
  - [ ] The code has been manually inspected by someone who did not implement the feature
  - [ ] The changes have been inspected for possible breaking API changes (changed data models, endpoints, response codes, exception handling, ...). If there are any discuss them with the team.
  - [ ] If this PR includes work on the frontend, at least one `@ts-nocheck` is removed. Additionally, there should not be any `@ts-nocheck` in files modified by this PR. If no `@ts-nocheck` are left: Celebrate :tada: :confetti_ball: type-safety and remove this entry. 
- [x] The PR actually implements what is described in the JIRA-Issue
- [x] Make sure you understand the entire workflow from the user’s perspective, and test/review it accordingly. If anything is unclear, please reach out to the dev team.
- [x] At least one test exists testing the new feature
  - [ ] Make sure all newly added functionality (especially user facing) is tested
  - [ ] Make sure that new test files are included in a test container and actually run in the CI
- [x] At least 3 consecutive CI runs are successfully executed to ensure that there are no flaky tests.
- [x] Documentation is updated as required. If unsure whether or what to update, ask a fellow developer.
- [x] If there was a database entity class added, there must also be a migration script for creating the corresponding database if flyway is already used by the service
- [x] IF there are changes done to the framework data models or to a database entity class, the following steps were completed in order
  - [ ] A fresh clone of dataland.com is generated (see Wiki page on "OTC" for details)
  - [ ] The feature branch is deployed to clone with `Reset non-user related Docker Volumes & Re-populate` turned off
  - [ ] It's verified that the CD run is green
  - [ ] The new feature is manually used/tested/observed on the clone server. Testing of the new feature should (also) be done by a second, independent reviewer from the dev team
  - [ ] The feature branch is deployed to one of the dev servers with `Reset non-user related Docker Volumes & Re-populate` turned on, and it's verified that the CD run is green
- [x] ELSE, the new version is deployed to one of the dev servers using this branch
  - [ ] Run with setting `Reset non-user related Docker Volumes & Re-populate` turned on 
  - [ ] It's verified that this version actually is the one deployed (check gitinfo for branch name and commit id!)
  - [ ] It's verified that the CD run is green
  - [ ] The new feature is manually used/tested/observed on dev server. Testing of the new feature should (also) be done by a second, independent reviewer from the dev team
- [x] Confirm that the latest version (use the /gitinfo endpoint) of the feature branch is deployed to one of the dev servers (no longer enforced by GitHub)
- [x] Ensure that the release notes are written in a way that is understandable to a non-technical audience.
