### PR TITLE
DALA-7708: Fix formatting breaks for activity datapoints in the judge modal

### DIFF
--- a/dataland-frontend/src/components/resources/datasetReview/JudgeDialogCustomSection.vue
+++ b/dataland-frontend/src/components/resources/datasetReview/JudgeDialogCustomSection.vue
@@ -255,13 +255,32 @@ const selectedDocumentOption = computed<DocumentOption | null>(
 );
 
 /**
+ * Parses text edited in the value textarea back into an object/array whenever it forms valid
+ * JSON that represents one, so the underlying form data keeps its structured type and
+ * "Accept Custom" does not send a double-encoded string to the backend.
+ *
+ * @param value - The raw text entered into the value textarea.
+ * @returns The parsed object/array, or the original raw string if it isn't one.
+ */
+function parseEditedValue(value: string): unknown {
+  try {
+    const parsedValue: unknown = JSON.parse(value);
+    return parsedValue !== null && typeof parsedValue === 'object' ? parsedValue : value;
+  } catch {
+    return value;
+  }
+}
+
+/**
  * A string-typed proxy for the value textarea.
- * Object/array values are only stringified for display and converted to a string on edit.
  */
 const customValueText = computed<string>({
   get: () => toSafeDisplayString(formData.value.value),
   set: (newValue: string) => {
-    formData.value = { ...formData.value, value: newValue };
+    formData.value = {
+      ...formData.value,
+      value: parseEditedValue(newValue),
+    };
   },
 });
 

--- a/dataland-frontend/src/components/resources/datasetReview/JudgeDialogCustomSection.vue
+++ b/dataland-frontend/src/components/resources/datasetReview/JudgeDialogCustomSection.vue
@@ -55,7 +55,7 @@
                 <Textarea
                   ref="customValueTextarea"
                   id="custom-value-field"
-                  v-model="formData.value"
+                  v-model="customValueText"
                   rows="1"
                   autoResize
                   size="small"
@@ -210,9 +210,11 @@ import InputText from 'primevue/inputtext';
 import Textarea from 'primevue/textarea';
 import { QualityOptions } from '@clients/backend';
 import type { CustomFormData, DocumentOption } from '@/types/JudgeDialogTypes.ts';
+import { toSafeDisplayString } from '@/utils/StringFormatter.ts';
 import {
   DEFAULT_CUSTOM_FORM_DATA,
   DEFAULT_CUSTOM_JSON,
+  hasValueContent,
   parseDataPointJsonToFormData,
   parseFormDataToDataPointJson,
 } from '@/utils/JudgeDialogUtils.ts';
@@ -252,9 +254,22 @@ const selectedDocumentOption = computed<DocumentOption | null>(
   () => props.availableDocuments?.find((doc) => doc.value === formData.value.document) ?? null
 );
 
+/**
+ * A string-typed proxy for the value textarea.
+ * Object/array values are only stringified for display and converted to a string on edit.
+ */
+const customValueText = computed<string>({
+  get: () => toSafeDisplayString(formData.value.value),
+  set: (newValue: string) => {
+    formData.value = { ...formData.value, value: newValue };
+  },
+});
+
 const isFormValid = computed<boolean>(() => {
   const f = formData.value;
-  const hasAnyContent = [f.value, f.quality, f.document, f.pages, f.comment].some((v) => v.trim().length > 0);
+  const valueHasContent = hasValueContent(f.value);
+  const otherFieldsHaveContent = [f.quality, f.document, f.pages, f.comment].some((v) => v.trim().length > 0);
+  const hasAnyContent = valueHasContent || otherFieldsHaveContent;
   const pagesPatternOk = !f.pages || /^[0-9,\-\s]+$/.test(f.pages);
 
   return hasAnyContent && pagesPatternOk;

--- a/dataland-frontend/src/types/JudgeDialogTypes.ts
+++ b/dataland-frontend/src/types/JudgeDialogTypes.ts
@@ -13,7 +13,7 @@ export interface DocumentOption {
 }
 
 export interface CustomFormData {
-  value: string;
+  value: unknown;
   quality: string;
   document: string;
   pages: string;

--- a/dataland-frontend/src/utils/JudgeDialogUtils.ts
+++ b/dataland-frontend/src/utils/JudgeDialogUtils.ts
@@ -28,8 +28,29 @@ export type JudgementErrorResponse = {
 };
 
 /**
+ * Returns whether the value should be included in the custom data point payload.
+ * Empty or whitespace-only strings are excluded; all other non-null values are included.
+ *
+ * @param value - The value to check.
+ * @returns True if the value should be included in the resulting payload.
+ */
+export function hasValueContent(value: unknown): boolean {
+  if (value === null || value === undefined) {
+    return false;
+  }
+  if (typeof value === 'string') {
+    return value.trim().length > 0;
+  }
+  return true;
+}
+
+/**
  * Converts {@link CustomFormData} into the pretty-printed JSON string expected by the backend.
  * Returns {@link DEFAULT_CUSTOM_JSON} when the resulting data point would be empty.
+ *
+ * Non-string `value`s (e.g. objects or arrays copied over from Activity-type data points) are
+ * embedded as-is so that the returned JSON is only ever stringified once, avoiding double
+ * JSON-encoding of nested structures.
  *
  * @param formData - The form data to convert.
  * @param selectedDocument - The currently selected document option, used to resolve the data source.
@@ -52,7 +73,7 @@ export function parseFormDataToDataPointJson(
   }
 
   const data: ParsedSingleDataPoint = {
-    ...(value && { value }),
+    ...(hasValueContent(value) ? { value } : {}),
     ...(quality && { quality }),
     ...(comment && { comment }),
     ...(dataSource && Object.keys(dataSource).length > 0 && { dataSource }),
@@ -79,12 +100,14 @@ export function parseDataPointJsonToFormData(json: string): CustomFormData | nul
 /**
  * Maps a {@link ParsedSingleDataPoint} object directly into a {@link CustomFormData} object.
  *
+ * Object and array values are preserved to avoid double serialization.
+ *
  * @param detail - The data point detail to map.
  * @returns The mapped {@link CustomFormData}.
  */
 export function transformDataPointDetailToFormData(detail: ParsedSingleDataPoint): CustomFormData {
   return {
-    value: toSafeDisplayString(detail.value),
+    value: detail.value !== null && typeof detail.value === 'object' ? detail.value : toSafeDisplayString(detail.value),
     quality: toSafeDisplayString(detail.quality),
     document: toSafeDisplayString(detail.dataSource?.fileName ?? detail.dataSource?.fileReference),
     pages: toSafeDisplayString(detail.dataSource?.page),

--- a/dataland-frontend/tests/component/components/resources/datasetReview/JudgeDialog.cy.ts
+++ b/dataland-frontend/tests/component/components/resources/datasetReview/JudgeDialog.cy.ts
@@ -710,6 +710,42 @@ describe('JudgeDialog component tests', () => {
       cy.get('[data-test="custom-json-textarea"]').should('contain.value', correctedCommentEntry);
     });
 
+    it(
+      'copies an Activity-typed (object/array valued) original data point in normal mode and accepts it as custom ' +
+        'without double-encoding the value',
+      () => {
+        const activities = [
+          { activityName: 'Afforestation', naceCodes: ['A2.10'], share: { relativeShareInPercent: 42 } },
+          { activityName: 'Manufacture of low carbon technologies', naceCodes: ['C28'], share: null },
+        ];
+
+        mountJudgeDialog({
+          originalDataPointBody: {
+            value: activities,
+            quality: 'Audited',
+            comment: 'Activity list from original data point.',
+            dataSource: { fileName: 'original-doc.pdf', page: '3' },
+          },
+        });
+        cy.wait('@getOriginalDataPoint');
+
+        cy.get('[data-test="edit-mode-toggle"]').should('not.be.checked');
+        cy.get('[data-test="copy-original-to-custom"]').click();
+
+        cy.get('[data-test="accept-custom-button"]').click();
+
+        cy.wait('@patchJudgementDetail').then((interception) => {
+          expect(interception.request.body.acceptedSource).to.eq(AcceptedDataPointSource.Custom);
+          expect(interception.request.body.customDataPoint).to.be.a('string');
+
+          const parsed = JSON.parse(interception.request.body.customDataPoint);
+          expect(parsed.value).to.deep.equal(activities);
+          expect(parsed.value).to.not.be.a('string');
+          expect(parsed.quality).to.eq('Audited');
+        });
+      }
+    );
+
     it('disables the copy-original button when there is no original data point loaded yet', () => {
       const judgement: DatasetJudgementResponse = {
         ...baseDatasetJudgement,

--- a/dataland-frontend/tests/component/components/resources/datasetReview/JudgeDialog.cy.ts
+++ b/dataland-frontend/tests/component/components/resources/datasetReview/JudgeDialog.cy.ts
@@ -746,6 +746,46 @@ describe('JudgeDialog component tests', () => {
       }
     );
 
+    it(
+      'keeps an edited Activity-typed (object/array valued) value as an object after copying the original data ' +
+        'point in normal mode, editing the value field, and accepting it as custom',
+      () => {
+        const activities = [
+          { activityName: 'Afforestation', naceCodes: ['A2.10'], share: { relativeShareInPercent: 42 } },
+        ];
+        const editedActivities = [
+          { activityName: 'Afforestation', naceCodes: ['A2.10'], share: { relativeShareInPercent: 99 } },
+        ];
+
+        mountJudgeDialog({
+          originalDataPointBody: {
+            value: activities,
+            quality: 'Audited',
+            comment: 'Activity list from original data point.',
+            dataSource: { fileName: 'original-doc.pdf', page: '3' },
+          },
+        });
+        cy.wait('@getOriginalDataPoint');
+
+        cy.get('[data-test="edit-mode-toggle"]').should('not.be.checked');
+        cy.get('[data-test="copy-original-to-custom"]').click();
+
+        cy.get('[data-test="custom-value-field"]').clear();
+        cy.get('[data-test="custom-value-field"]').invoke('val', JSON.stringify(editedActivities)).trigger('input');
+
+        cy.get('[data-test="accept-custom-button"]').click();
+
+        cy.wait('@patchJudgementDetail').then((interception) => {
+          expect(interception.request.body.acceptedSource).to.eq(AcceptedDataPointSource.Custom);
+          expect(interception.request.body.customDataPoint).to.be.a('string');
+
+          const parsed = JSON.parse(interception.request.body.customDataPoint);
+          expect(parsed.value).to.deep.equal(editedActivities);
+          expect(parsed.value).to.not.be.a('string');
+        });
+      }
+    );
+
     it('disables the copy-original button when there is no original data point loaded yet', () => {
       const judgement: DatasetJudgementResponse = {
         ...baseDatasetJudgement,

--- a/dataland-frontend/tests/component/utils/JudgeDialogUtils.cy.ts
+++ b/dataland-frontend/tests/component/utils/JudgeDialogUtils.cy.ts
@@ -1,11 +1,40 @@
 import {
   DEFAULT_CUSTOM_JSON,
+  hasValueContent,
   parseFormDataToDataPointJson,
   parseDataPointJsonToFormData,
   transformDataPointDetailToFormData,
 } from '@/utils/JudgeDialogUtils';
 import type { CustomFormData, DocumentOption } from '@/types/JudgeDialogTypes.ts';
 import { type ParsedSingleDataPoint, unwrapDataPointJson, wrapDataPointJson } from '@/utils/DataPoint.ts';
+
+describe('hasValueContent', () => {
+  it('returns false for null, undefined, and empty/whitespace-only strings', () => {
+    expect(hasValueContent(null)).to.equal(false);
+    expect(hasValueContent(undefined)).to.equal(false);
+    expect(hasValueContent('')).to.equal(false);
+    expect(hasValueContent('   ')).to.equal(false);
+  });
+
+  it('returns true for non-empty strings', () => {
+    expect(hasValueContent('123.45')).to.equal(true);
+    expect(hasValueContent('  some value  ')).to.equal(true);
+  });
+
+  it('returns true for numbers and booleans, including falsy ones like 0 and false', () => {
+    expect(hasValueContent(0)).to.equal(true);
+    expect(hasValueContent(123)).to.equal(true);
+    expect(hasValueContent(false)).to.equal(true);
+    expect(hasValueContent(true)).to.equal(true);
+  });
+
+  it('returns true for objects and arrays, including empty ones', () => {
+    expect(hasValueContent({ activityName: 'Afforestation' })).to.equal(true);
+    expect(hasValueContent([{ activityName: 'Afforestation' }])).to.equal(true);
+    expect(hasValueContent({})).to.equal(true);
+    expect(hasValueContent([])).to.equal(true);
+  });
+});
 
 describe('parseFormDataToDataPointJson', () => {
   const emptyForm: CustomFormData = {
@@ -182,6 +211,51 @@ describe('transformDataPointDetailToFormData', () => {
       pages: '',
       comment: '',
     });
+  });
+
+  it('preserves an object/array value as an actual object instead of collapsing it to a display string', () => {
+    const activities = [
+      { activityName: 'Afforestation', naceCodes: ['A2.10'], share: { relativeShareInPercent: 42 } },
+      { activityName: 'Manufacture of low carbon technologies', naceCodes: ['C28'], share: null },
+    ];
+
+    const detail: ParsedSingleDataPoint = {
+      value: activities,
+      quality: 'Reported',
+      comment: 'Copied from original.',
+      dataSource: { fileName: 'ActivitiesReport.pdf', page: '4' },
+    };
+
+    const form = transformDataPointDetailToFormData(detail);
+
+    expect(form.value).to.deep.equal(activities);
+    expect(form.value).to.not.be.a('string');
+  });
+});
+
+describe('object/array value round-trip through transformDataPointDetailToFormData -> parseFormDataToDataPointJson', () => {
+  it('does not double-encode an object/array value when converting a data point detail into the submit payload', () => {
+    const activities = [
+      { activityName: 'Afforestation', naceCodes: ['A2.10'], share: { relativeShareInPercent: 42 } },
+      { activityName: 'Manufacture of low carbon technologies', naceCodes: ['C28'], share: null },
+    ];
+
+    const detail: ParsedSingleDataPoint = {
+      value: activities,
+      quality: 'Reported',
+      comment: 'Copied from original.',
+      dataSource: { fileName: 'ActivitiesReport.pdf', page: '4' },
+    };
+
+    const form = transformDataPointDetailToFormData(detail);
+    const json = parseFormDataToDataPointJson(form, null);
+    const parsed = JSON.parse(json) as ParsedSingleDataPoint;
+
+    expect(parsed.value).to.deep.equal(activities);
+    expect(parsed.value).to.not.be.a('string');
+    expect(parsed.quality).to.equal('Reported');
+    expect(parsed.comment).to.equal('Copied from original.');
+    expect(parsed.dataSource).to.deep.equal({ page: '4' });
   });
 });
 


### PR DESCRIPTION
# Pull Request \<Title>
`<Description here>`
## Things to do during Peer Review
Please check all boxes before the Pull Request is merged. In case you skip a box, describe in the PRs description (that means: here) why the check is skipped.
- [x] The GitHub Actions for the CI are green. This is enforced by GitHub. 
- [ ] The PR has been peer-reviewed
  - [ ] The code has been manually inspected by someone who did not implement the feature
  - [ ] The changes have been inspected for possible breaking API changes (changed data models, endpoints, response codes, exception handling, ...). If there are any discuss them with the team.
  - [ ] If this PR includes work on the frontend, at least one `@ts-nocheck` is removed. Additionally, there should not be any `@ts-nocheck` in files modified by this PR. If no `@ts-nocheck` are left: Celebrate :tada: :confetti_ball: type-safety and remove this entry. 
- [ ] The PR actually implements what is described in the JIRA-Issue
- [ ] Make sure you understand the entire workflow from the user’s perspective, and test/review it accordingly. If anything is unclear, please reach out to the dev team.
- [ ] At least one test exists testing the new feature
  - [ ] Make sure all newly added functionality (especially user facing) is tested
  - [ ] Make sure that new test files are included in a test container and actually run in the CI
- [ ] At least 3 consecutive CI runs are successfully executed to ensure that there are no flaky tests.
- [ ] Documentation is updated as required. If unsure whether or what to update, ask a fellow developer.
- [ ] If there was a database entity class added, there must also be a migration script for creating the corresponding database if flyway is already used by the service
- [ ] IF there are changes done to the framework data models or to a database entity class, the following steps were completed in order
  - [ ] A fresh clone of dataland.com is generated (see Wiki page on "OTC" for details)
  - [ ] The feature branch is deployed to clone with `Reset non-user related Docker Volumes & Re-populate` turned off
  - [ ] It's verified that the CD run is green
  - [ ] The new feature is manually used/tested/observed on the clone server. Testing of the new feature should (also) be done by a second, independent reviewer from the dev team
  - [ ] The feature branch is deployed to one of the dev servers with `Reset non-user related Docker Volumes & Re-populate` turned on, and it's verified that the CD run is green
- [ ] ELSE, the new version is deployed to one of the dev servers using this branch
  - [ ] Run with setting `Reset non-user related Docker Volumes & Re-populate` turned on 
  - [ ] It's verified that this version actually is the one deployed (check gitinfo for branch name and commit id!)
  - [ ] It's verified that the CD run is green
  - [ ] The new feature is manually used/tested/observed on dev server. Testing of the new feature should (also) be done by a second, independent reviewer from the dev team
- [ ] Confirm that the latest version (use the /gitinfo endpoint) of the feature branch is deployed to one of the dev servers (no longer enforced by GitHub)
- [ ] Ensure that the release notes are written in a way that is understandable to a non-technical audience.
