### PR TITLE
DALA-6901 Display nonsourceability in the frontend

### DIFF
--- a/dataland-backend/backendOpenApi.json
+++ b/dataland-backend/backendOpenApi.json
@@ -582,6 +582,76 @@
         ]
       }
     },
+    "/non-sourceable/search/grouped": {
+      "post": {
+        "tags": [
+          "non-sourceability-controller"
+        ],
+        "summary": "Returns all currently-active non-sourceability data dimensions matching the given filters, grouped by company ID and framework.",
+        "description": "Accepts lists of company IDs, frameworks, and reporting periods. Returns the set of (companyId, dataType, reportingPeriod) triples for which an active non-sourceability entry exists and that match any combination of the provided filters, pre-grouped into a map of maps: companyId -\u003e framework -\u003e set of matching data dimensions. An empty list for any field is treated as a wildcard and matches all values for that dimension.",
+        "operationId": "searchNonSourceableDimensionsGroupedByCompanyAndFramework",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DataDimensionSearchRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved non-sourceable data dimensions grouped by company and framework.",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "uniqueItems": true,
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/BasicDataDimensions"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An error occurred",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "default-oauth": []
+          },
+          {
+            "default-bearer-auth": []
+          }
+        ]
+      }
+    },
     "/metadata/nonSourceable": {
       "get": {
         "tags": [

--- a/dataland-backend/backendOpenApi.json
+++ b/dataland-backend/backendOpenApi.json
@@ -518,6 +518,70 @@
         ]
       }
     },
+    "/non-sourceable/search": {
+      "post": {
+        "tags": [
+          "non-sourceability-controller"
+        ],
+        "summary": "Returns all currently-active non-sourceability data dimensions matching the given filters.",
+        "description": "Accepts lists of company IDs, frameworks, and reporting periods. Returns the set of (companyId, dataType, reportingPeriod) triples for which an active non-sourceability entry exists and that match any combination of the provided filters. An empty list for any field is treated as a wildcard and matches all values for that dimension.",
+        "operationId": "searchNonSourceableDimensions",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DataDimensionSearchRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved non-sourceable data dimensions.",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "uniqueItems": true,
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/BasicDataDimensions"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An error occurred",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "default-oauth": []
+          },
+          {
+            "default-bearer-auth": []
+          }
+        ]
+      }
+    },
     "/metadata/nonSourceable": {
       "get": {
         "tags": [
@@ -8140,6 +8204,72 @@
             "items": {
               "$ref": "#/components/schemas/DataMetaInformation"
             }
+          }
+        }
+      },
+      "DataDimensionSearchRequest": {
+        "type": "object",
+        "properties": {
+          "companyIds": {
+            "type": "array",
+            "description": "A list of Dataland company ids for which the data export is requested.",
+            "nullable": true,
+            "example": [
+              "c9710c7b-9cd6-446b-85b0-3773d2aceb48",
+              "1e63a842-1e65-43ed-b78a-5e7cec155c28"
+            ],
+            "items": {
+              "type": "string"
+            }
+          },
+          "dataTypes": {
+            "type": "array",
+            "description": "A list of the frameworks of the wanted datasets and of the dataPointTypes of the wanted data points.",
+            "nullable": true,
+            "example": [
+              "sfdr",
+              "extendedDateFiscalYearEnd"
+            ],
+            "items": {
+              "type": "string"
+            }
+          },
+          "reportingPeriods": {
+            "type": "array",
+            "description": "The reporting periods for which the data export is requested.",
+            "nullable": true,
+            "example": [
+              "2023",
+              "2024"
+            ],
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "BasicDataDimensions": {
+        "required": [
+          "companyId",
+          "dataType",
+          "reportingPeriod"
+        ],
+        "type": "object",
+        "properties": {
+          "companyId": {
+            "type": "string",
+            "description": "The unique identifier under which a company can be found on Dataland.",
+            "example": "c9710c7b-9cd6-446b-85b0-3773d2aceb48"
+          },
+          "dataType": {
+            "type": "string",
+            "description": "The associated reporting framework or data point type (as applicable).",
+            "example": "sfdr"
+          },
+          "reportingPeriod": {
+            "type": "string",
+            "description": "The relevant reporting period (e.g. a fiscal year).",
+            "example": "2023"
           }
         }
       },
@@ -20899,72 +21029,6 @@
             "type": "string",
             "description": "The data point type of the provided data point.",
             "example": "extendedEnumYesNoIsNfrdMandatory"
-          }
-        }
-      },
-      "DataDimensionSearchRequest": {
-        "type": "object",
-        "properties": {
-          "companyIds": {
-            "type": "array",
-            "description": "A list of Dataland company ids for which the data export is requested.",
-            "nullable": true,
-            "example": [
-              "c9710c7b-9cd6-446b-85b0-3773d2aceb48",
-              "1e63a842-1e65-43ed-b78a-5e7cec155c28"
-            ],
-            "items": {
-              "type": "string"
-            }
-          },
-          "dataTypes": {
-            "type": "array",
-            "description": "A list of the frameworks of the wanted datasets and of the dataPointTypes of the wanted data points.",
-            "nullable": true,
-            "example": [
-              "sfdr",
-              "extendedDateFiscalYearEnd"
-            ],
-            "items": {
-              "type": "string"
-            }
-          },
-          "reportingPeriods": {
-            "type": "array",
-            "description": "The reporting periods for which the data export is requested.",
-            "nullable": true,
-            "example": [
-              "2023",
-              "2024"
-            ],
-            "items": {
-              "type": "string"
-            }
-          }
-        }
-      },
-      "BasicDataDimensions": {
-        "required": [
-          "companyId",
-          "dataType",
-          "reportingPeriod"
-        ],
-        "type": "object",
-        "properties": {
-          "companyId": {
-            "type": "string",
-            "description": "The unique identifier under which a company can be found on Dataland.",
-            "example": "c9710c7b-9cd6-446b-85b0-3773d2aceb48"
-          },
-          "dataType": {
-            "type": "string",
-            "description": "The associated reporting framework or data point type (as applicable).",
-            "example": "sfdr"
-          },
-          "reportingPeriod": {
-            "type": "string",
-            "description": "The relevant reporting period (e.g. a fiscal year).",
-            "example": "2023"
           }
         }
       },

--- a/dataland-backend/src/main/kotlin/org/dataland/datalandbackend/api/NonSourceabilityApi.kt
+++ b/dataland-backend/src/main/kotlin/org/dataland/datalandbackend/api/NonSourceabilityApi.kt
@@ -1,0 +1,45 @@
+package org.dataland.datalandbackend.api
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import org.dataland.datalandbackend.model.DataDimensionSearchRequest
+import org.dataland.datalandbackendutils.model.BasicDataDimensions
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+
+/**
+ * Defines the restful dataland-backend API for bulk non-sourceability queries.
+ */
+@RequestMapping("/non-sourceable")
+@SecurityRequirement(name = "default-bearer-auth")
+@SecurityRequirement(name = "default-oauth")
+interface NonSourceabilityApi {
+    /**
+     * Searches for all currently-active non-sourceability triples matching the given filters.
+     * @param request filter containing companyIds, dataTypes, and reportingPeriods;
+     *   an empty list for any field is treated as a wildcard (all values)
+     */
+    @Operation(
+        summary = "Returns all currently-active non-sourceability data dimensions matching the given filters.",
+        description =
+            "Accepts lists of company IDs, frameworks, and reporting periods. " +
+                "Returns the set of (companyId, dataType, reportingPeriod) triples for which an active " +
+                "non-sourceability entry exists and that match any combination of the provided filters. " +
+                "An empty list for any field is treated as a wildcard and matches all values for that dimension.",
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "Successfully retrieved non-sourceable data dimensions."),
+        ],
+    )
+    @PostMapping(value = ["/search"])
+    @PreAuthorize("hasRole('ROLE_USER')")
+    fun searchNonSourceableDimensions(
+        @RequestBody request: DataDimensionSearchRequest,
+    ): ResponseEntity<Set<BasicDataDimensions>>
+}

--- a/dataland-backend/src/main/kotlin/org/dataland/datalandbackend/api/NonSourceabilityApi.kt
+++ b/dataland-backend/src/main/kotlin/org/dataland/datalandbackend/api/NonSourceabilityApi.kt
@@ -42,4 +42,35 @@ interface NonSourceabilityApi {
     fun searchNonSourceableDimensions(
         @RequestBody request: DataDimensionSearchRequest,
     ): ResponseEntity<Set<BasicDataDimensions>>
+
+    /**
+     * Searches for all currently-active non-sourceability triples matching the given filters and
+     * groups the results by company ID and framework (data type).
+     * @param request filter containing companyIds, dataTypes, and reportingPeriods;
+     *   an empty list for any field is treated as a wildcard (all values)
+     */
+    @Operation(
+        summary =
+            "Returns all currently-active non-sourceability data dimensions matching the given filters, " +
+                "grouped by company ID and framework.",
+        description =
+            "Accepts lists of company IDs, frameworks, and reporting periods. " +
+                "Returns the set of (companyId, dataType, reportingPeriod) triples for which an active " +
+                "non-sourceability entry exists and that match any combination of the provided filters, " +
+                "pre-grouped into a map of maps: companyId -> framework -> set of matching data dimensions. " +
+                "An empty list for any field is treated as a wildcard and matches all values for that dimension.",
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "Successfully retrieved non-sourceable data dimensions grouped by company and framework.",
+            ),
+        ],
+    )
+    @PostMapping(value = ["/search/grouped"])
+    @PreAuthorize("hasRole('ROLE_USER')")
+    fun searchNonSourceableDimensionsGroupedByCompanyAndFramework(
+        @RequestBody request: DataDimensionSearchRequest,
+    ): ResponseEntity<Map<String, Map<String, Set<BasicDataDimensions>>>>
 }

--- a/dataland-backend/src/main/kotlin/org/dataland/datalandbackend/controller/NonSourceabilityController.kt
+++ b/dataland-backend/src/main/kotlin/org/dataland/datalandbackend/controller/NonSourceabilityController.kt
@@ -26,4 +26,17 @@ class NonSourceabilityController
             val query = request.toDataDimensionQuery()
             return ResponseEntity.ok(nonSourceabilityInformationManager.searchActiveNonSourceableDimensions(query))
         }
+
+        override fun searchNonSourceableDimensionsGroupedByCompanyAndFramework(
+            request: DataDimensionSearchRequest,
+        ): ResponseEntity<Map<String, Map<String, Set<BasicDataDimensions>>>> {
+            logger.info(
+                "Received a request to search non-sourceable dimensions grouped by company and framework " +
+                    "with the search request being $request",
+            )
+            val query = request.toDataDimensionQuery()
+            return ResponseEntity.ok(
+                nonSourceabilityInformationManager.searchActiveNonSourceableDimensionsGroupedByCompanyAndFramework(query),
+            )
+        }
     }

--- a/dataland-backend/src/main/kotlin/org/dataland/datalandbackend/controller/NonSourceabilityController.kt
+++ b/dataland-backend/src/main/kotlin/org/dataland/datalandbackend/controller/NonSourceabilityController.kt
@@ -1,0 +1,29 @@
+package org.dataland.datalandbackend.controller
+
+import org.dataland.datalandbackend.api.NonSourceabilityApi
+import org.dataland.datalandbackend.model.DataDimensionSearchRequest
+import org.dataland.datalandbackend.services.NonSourceabilityInformationManager
+import org.dataland.datalandbackendutils.model.BasicDataDimensions
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * Controller for bulk non-sourceability query endpoints.
+ * @param nonSourceabilityInformationManager the service used to look up non-sourceability information
+ */
+@RestController
+class NonSourceabilityController
+    @Autowired
+    constructor(
+        private val nonSourceabilityInformationManager: NonSourceabilityInformationManager,
+    ) : NonSourceabilityApi {
+        private val logger = LoggerFactory.getLogger(javaClass)
+
+        override fun searchNonSourceableDimensions(request: DataDimensionSearchRequest): ResponseEntity<Set<BasicDataDimensions>> {
+            logger.info("Received a request to search non-sourceable dimensions with the search request being $request")
+            val query = request.toDataDimensionQuery()
+            return ResponseEntity.ok(nonSourceabilityInformationManager.searchActiveNonSourceableDimensions(query))
+        }
+    }

--- a/dataland-backend/src/main/kotlin/org/dataland/datalandbackend/repositories/NonSourceabilityDataRepository.kt
+++ b/dataland-backend/src/main/kotlin/org/dataland/datalandbackend/repositories/NonSourceabilityDataRepository.kt
@@ -75,4 +75,24 @@ interface NonSourceabilityDataRepository : JpaRepository<NonSourceabilityInforma
         @Param("dataType") dataType: DataType,
         @Param("reportingPeriod") reportingPeriod: String,
     ): NonSourceabilityInformationEntity?
+
+    /**
+     * Returns all currently-active non-sourceability entries matching the given filters.
+     * An empty list for any parameter is treated as a wildcard (no restriction on that dimension).
+     * Used for bulk triple search (e.g. POST /non-sourceable/search).
+     */
+    @Query(
+        """
+        SELECT e FROM NonSourceabilityInformationEntity e
+        WHERE (:companyIds IS EMPTY OR e.companyId IN :companyIds)
+          AND (:dataTypes IS EMPTY OR e.dataType IN :dataTypes)
+          AND (:reportingPeriods IS EMPTY OR e.reportingPeriod IN :reportingPeriods)
+          AND e.currentlyActive = true
+        """,
+    )
+    fun findActiveTriples(
+        @Param("companyIds") companyIds: List<String>,
+        @Param("dataTypes") dataTypes: List<DataType>,
+        @Param("reportingPeriods") reportingPeriods: List<String>,
+    ): List<NonSourceabilityInformationEntity>
 }

--- a/dataland-backend/src/main/kotlin/org/dataland/datalandbackend/repositories/NonSourceabilityDataRepository.kt
+++ b/dataland-backend/src/main/kotlin/org/dataland/datalandbackend/repositories/NonSourceabilityDataRepository.kt
@@ -78,21 +78,37 @@ interface NonSourceabilityDataRepository : JpaRepository<NonSourceabilityInforma
 
     /**
      * Returns all currently-active non-sourceability entries matching the given filters.
-     * A null value for any parameter is treated as a wildcard (no restriction on that dimension).
+     * An empty list for any parameter is treated as a wildcard (no restriction on that dimension),
+     * indicated by the corresponding "isXEmpty" flag being true (in which case the list itself is ignored).
+     * Note on the query structure: for each filter, we pass a separate boolean flag
+     * (e.g. "isDataTypesEmpty") instead of writing "(:dataTypes IS NULL OR e.dataType IN :dataTypes)".
+     *
+     * Reason: the "dataType" column is not a plain String column - it's mapped via
+     * DataTypeConverter, which converts between the DataType Kotlin class and its
+     * String representation in the database. When the same query parameter
+     * (":dataTypes") is used both for an "IS NULL" check and for an "IN" list check,
+     * Hibernate gets confused about which conversion to apply to the list elements.
+     * Instead of using DataTypeConverter as expected, it tries to serialize the
+     * DataType objects directly via plain Java serialization - which fails at runtime
+     * with a NotSerializableException, because DataType does not implement Serializable.
+     *
      * Used for bulk triple search (e.g. POST /non-sourceable/search).
      */
     @Query(
         """
         SELECT e FROM NonSourceabilityInformationEntity e
-        WHERE (:companyIds IS NULL OR e.companyId IN :companyIds)
-          AND (:dataTypes IS NULL OR e.dataType IN :dataTypes)
-          AND (:reportingPeriods IS NULL OR e.reportingPeriod IN :reportingPeriods)
+        WHERE (:isCompanyIdsEmpty = true OR e.companyId IN :companyIds)
+          AND (:isDataTypesEmpty = true OR e.dataType IN :dataTypes)
+          AND (:isReportingPeriodsEmpty = true OR e.reportingPeriod IN :reportingPeriods)
           AND e.currentlyActive = true
         """,
     )
     fun findActiveTriples(
-        @Param("companyIds") companyIds: List<String>?,
-        @Param("dataTypes") dataTypes: List<DataType>?,
-        @Param("reportingPeriods") reportingPeriods: List<String>?,
+        @Param("companyIds") companyIds: List<String>,
+        @Param("isCompanyIdsEmpty") isCompanyIdsEmpty: Boolean,
+        @Param("dataTypes") dataTypes: List<DataType>,
+        @Param("isDataTypesEmpty") isDataTypesEmpty: Boolean,
+        @Param("reportingPeriods") reportingPeriods: List<String>,
+        @Param("isReportingPeriodsEmpty") isReportingPeriodsEmpty: Boolean,
     ): List<NonSourceabilityInformationEntity>
 }

--- a/dataland-backend/src/main/kotlin/org/dataland/datalandbackend/repositories/NonSourceabilityDataRepository.kt
+++ b/dataland-backend/src/main/kotlin/org/dataland/datalandbackend/repositories/NonSourceabilityDataRepository.kt
@@ -78,21 +78,21 @@ interface NonSourceabilityDataRepository : JpaRepository<NonSourceabilityInforma
 
     /**
      * Returns all currently-active non-sourceability entries matching the given filters.
-     * An empty list for any parameter is treated as a wildcard (no restriction on that dimension).
+     * A null value for any parameter is treated as a wildcard (no restriction on that dimension).
      * Used for bulk triple search (e.g. POST /non-sourceable/search).
      */
     @Query(
         """
         SELECT e FROM NonSourceabilityInformationEntity e
-        WHERE (:companyIds IS EMPTY OR e.companyId IN :companyIds)
-          AND (:dataTypes IS EMPTY OR e.dataType IN :dataTypes)
-          AND (:reportingPeriods IS EMPTY OR e.reportingPeriod IN :reportingPeriods)
+        WHERE (:companyIds IS NULL OR e.companyId IN :companyIds)
+          AND (:dataTypes IS NULL OR e.dataType IN :dataTypes)
+          AND (:reportingPeriods IS NULL OR e.reportingPeriod IN :reportingPeriods)
           AND e.currentlyActive = true
         """,
     )
     fun findActiveTriples(
-        @Param("companyIds") companyIds: List<String>,
-        @Param("dataTypes") dataTypes: List<DataType>,
-        @Param("reportingPeriods") reportingPeriods: List<String>,
+        @Param("companyIds") companyIds: List<String>?,
+        @Param("dataTypes") dataTypes: List<DataType>?,
+        @Param("reportingPeriods") reportingPeriods: List<String>?,
     ): List<NonSourceabilityInformationEntity>
 }

--- a/dataland-backend/src/main/kotlin/org/dataland/datalandbackend/services/NonSourceabilityInformationManager.kt
+++ b/dataland-backend/src/main/kotlin/org/dataland/datalandbackend/services/NonSourceabilityInformationManager.kt
@@ -275,9 +275,12 @@ class NonSourceabilityInformationManager(
         val dataTypes = query.dataTypes.map { DataType.valueOf(it) }
         return nonSourceabilityDataRepository
             .findActiveTriples(
-                query.companyIds.ifEmpty { null },
-                dataTypes.ifEmpty { null },
-                query.reportingPeriods.ifEmpty { null },
+                companyIds = query.companyIds,
+                isCompanyIdsEmpty = query.companyIds.isEmpty(),
+                dataTypes = dataTypes,
+                isDataTypesEmpty = dataTypes.isEmpty(),
+                reportingPeriods = query.reportingPeriods,
+                isReportingPeriodsEmpty = query.reportingPeriods.isEmpty(),
             ).map { BasicDataDimensions(it.companyId, it.dataType.name, it.reportingPeriod) }
             .toSet()
     }

--- a/dataland-backend/src/main/kotlin/org/dataland/datalandbackend/services/NonSourceabilityInformationManager.kt
+++ b/dataland-backend/src/main/kotlin/org/dataland/datalandbackend/services/NonSourceabilityInformationManager.kt
@@ -274,8 +274,11 @@ class NonSourceabilityInformationManager(
     fun searchActiveNonSourceableDimensions(query: DataDimensionQuery): Set<BasicDataDimensions> {
         val dataTypes = query.dataTypes.map { DataType.valueOf(it) }
         return nonSourceabilityDataRepository
-            .findActiveTriples(query.companyIds, dataTypes, query.reportingPeriods)
-            .map { BasicDataDimensions(it.companyId, it.dataType.name, it.reportingPeriod) }
+            .findActiveTriples(
+                query.companyIds.ifEmpty { null },
+                dataTypes.ifEmpty { null },
+                query.reportingPeriods.ifEmpty { null },
+            ).map { BasicDataDimensions(it.companyId, it.dataType.name, it.reportingPeriod) }
             .toSet()
     }
 

--- a/dataland-backend/src/main/kotlin/org/dataland/datalandbackend/services/NonSourceabilityInformationManager.kt
+++ b/dataland-backend/src/main/kotlin/org/dataland/datalandbackend/services/NonSourceabilityInformationManager.kt
@@ -2,12 +2,14 @@ package org.dataland.datalandbackend.services
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.dataland.datalandbackend.entities.NonSourceabilityInformationEntity
+import org.dataland.datalandbackend.model.DataDimensionQuery
 import org.dataland.datalandbackend.model.DataType
 import org.dataland.datalandbackend.model.metainformation.NonSourceabilityInformationResponse
 import org.dataland.datalandbackend.model.metainformation.NonSourceabilityRequest
 import org.dataland.datalandbackend.repositories.NonSourceabilityDataRepository
 import org.dataland.datalandbackendutils.exceptions.ConflictApiException
 import org.dataland.datalandbackendutils.exceptions.InvalidInputApiException
+import org.dataland.datalandbackendutils.model.BasicDataDimensions
 import org.dataland.datalandbackendutils.model.QaStatus
 import org.dataland.datalandmessagequeueutils.cloudevents.CloudEventMessageHandler
 import org.dataland.datalandmessagequeueutils.constants.ExchangeName
@@ -262,6 +264,19 @@ class NonSourceabilityInformationManager(
                     "companyId=$companyId, dataType=$dataType, reportingPeriod=$reportingPeriod",
             )
         }
+    }
+
+    /**
+     * Returns the set of (companyId, dataType, reportingPeriod) triples for which an active
+     * non-sourceability entry exists, matching the given filter query. An empty list for any
+     * field of the query is treated as a wildcard (used by POST /non-sourceable/search).
+     */
+    fun searchActiveNonSourceableDimensions(query: DataDimensionQuery): Set<BasicDataDimensions> {
+        val dataTypes = query.dataTypes.map { DataType.valueOf(it) }
+        return nonSourceabilityDataRepository
+            .findActiveTriples(query.companyIds, dataTypes, query.reportingPeriods)
+            .map { BasicDataDimensions(it.companyId, it.dataType.name, it.reportingPeriod) }
+            .toSet()
     }
 
     private fun emitLifecycleEvent(

--- a/dataland-backend/src/main/kotlin/org/dataland/datalandbackend/services/NonSourceabilityInformationManager.kt
+++ b/dataland-backend/src/main/kotlin/org/dataland/datalandbackend/services/NonSourceabilityInformationManager.kt
@@ -285,6 +285,22 @@ class NonSourceabilityInformationManager(
             .toSet()
     }
 
+    /**
+     * Returns the currently-active non-sourceability data dimensions matching the given filter query,
+     * pre-grouped into a map of maps: companyId -> framework (dataType) -> set of matching data dimensions.
+     * An empty list for any field of the query is treated as a wildcard (used by POST /non-sourceable/search/grouped).
+     */
+    fun searchActiveNonSourceableDimensionsGroupedByCompanyAndFramework(
+        query: DataDimensionQuery,
+    ): Map<String, Map<String, Set<BasicDataDimensions>>> =
+        searchActiveNonSourceableDimensions(query)
+            .groupBy { it.companyId }
+            .mapValues { (_, dimensionsForCompany) ->
+                dimensionsForCompany
+                    .groupBy { it.dataType }
+                    .mapValues { (_, dimensionsForFramework) -> dimensionsForFramework.toSet() }
+            }
+
     private fun emitLifecycleEvent(
         entity: NonSourceabilityInformationEntity,
         bypassQa: Boolean,

--- a/dataland-backend/src/test/kotlin/org/dataland/datalandbackend/controller/NonSourceabilityControllerTest.kt
+++ b/dataland-backend/src/test/kotlin/org/dataland/datalandbackend/controller/NonSourceabilityControllerTest.kt
@@ -1,5 +1,6 @@
 package org.dataland.datalandbackend.controller
 
+import com.fasterxml.jackson.module.kotlin.readValue
 import org.dataland.datalandbackend.DatalandBackend
 import org.dataland.datalandbackend.entities.StoredCompanyEntity
 import org.dataland.datalandbackend.model.DataType
@@ -8,9 +9,12 @@ import org.dataland.datalandbackend.model.metainformation.NonSourceabilityReques
 import org.dataland.datalandbackend.services.CompanyAlterationManager
 import org.dataland.datalandbackend.services.NonSourceabilityInformationManager
 import org.dataland.datalandbackend.utils.DefaultMocks
+import org.dataland.datalandbackendutils.model.BasicDataDimensions
+import org.dataland.datalandbackendutils.utils.JsonUtils
 import org.dataland.datalandmessagequeueutils.cloudevents.CloudEventMessageHandler
 import org.dataland.keycloakAdapter.auth.DatalandRealmRole
 import org.dataland.keycloakAdapter.utils.AuthenticationMock
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.doReturn
@@ -27,18 +31,23 @@ import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import org.springframework.transaction.annotation.Transactional
 
 private const val SEARCH_NON_SOURCEABLE_PATH = "/non-sourceable/search"
+private const val SEARCH_NON_SOURCEABLE_GROUPED_PATH = "/non-sourceable/search/grouped"
 private const val CONTENT_TYPE = "application/json"
 
 /**
- * Endpoint test for POST /non-sourceable/search, exercising the full stack
+ * Endpoint test for POST /non-sourceable/search and POST /non-sourceable/search/grouped, exercising the full stack
  * (controller -> NonSourceabilityInformationManager -> NonSourceabilityDataRepository -> H2)
  * without mocking the business service layer. Only the CloudEventMessageHandler (RabbitMQ
  * side effect) is mocked, matching the pattern used in MetaDataControllerNonSourceableTest.
+ *
+ * Response bodies are deserialized back into their Kotlin target types before asserting on them,
+ * rather than navigating the raw JSON via jsonPath. This still validates the actual serialized
+ * response bytes (via the real ObjectMapper), while keeping the assertions readable and
+ * order-independent (important since several of the response types are Kotlin Sets).
  */
 @SpringBootTest(
     classes = [DatalandBackend::class],
@@ -54,6 +63,8 @@ class NonSourceabilityControllerTest(
     @Autowired private val companyAlterationManager: CompanyAlterationManager,
     @Autowired private val nonSourceabilityInformationManager: NonSourceabilityInformationManager,
 ) {
+    private val objectMapper = JsonUtils.defaultObjectMapper
+
     private lateinit var storedCompany: StoredCompanyEntity
     private val adminRoles = DatalandRealmRole.entries.toSet()
     private val dataType = DataType("sfdr")
@@ -124,36 +135,51 @@ class NonSourceabilityControllerTest(
         }
         """.trimIndent()
 
-    @Test
-    fun `search returns the active non-sourceable triple matching filters`() {
-        markNonSourceable()
-
+    private fun performSearch(requestBody: String = searchRequestBody()) =
         mockMvc
             .perform(
                 post(SEARCH_NON_SOURCEABLE_PATH)
                     .contentType(CONTENT_TYPE)
-                    .content(searchRequestBody())
+                    .content(requestBody)
                     .with(securityContext(mockSecurityContext)),
-            ).andExpect(status().isOk)
-            .andExpect(jsonPath("$[0].companyId").value(storedCompany.companyId))
-            .andExpect(jsonPath("$[0].dataType").value(dataType.name))
-            .andExpect(jsonPath("$[0].reportingPeriod").value(reportingPeriod))
-            .andExpect(jsonPath("$.length()").value(1))
+            )
+
+    private fun performGroupedSearch(requestBody: String = searchRequestBody()) =
+        mockMvc
+            .perform(
+                post(SEARCH_NON_SOURCEABLE_GROUPED_PATH)
+                    .contentType(CONTENT_TYPE)
+                    .content(requestBody)
+                    .with(securityContext(mockSecurityContext)),
+            )
+
+    private fun readSearchResponse(responseBody: String): Set<BasicDataDimensions> = objectMapper.readValue(responseBody)
+
+    private fun readGroupedSearchResponse(responseBody: String): Map<String, Map<String, Set<BasicDataDimensions>>> =
+        objectMapper.readValue(responseBody)
+
+    @Test
+    fun `search returns the active non-sourceable triple matching filters`() {
+        markNonSourceable()
+
+        val response = performSearch().andExpect(status().isOk).andReturn().response
+        val result = readSearchResponse(response.contentAsString)
+
+        assertEquals(setOf(BasicDataDimensions(storedCompany.companyId, dataType.name, reportingPeriod)), result)
     }
 
     @Test
     fun `search treats empty lists as wildcards`() {
         markNonSourceable()
 
-        mockMvc
-            .perform(
-                post(SEARCH_NON_SOURCEABLE_PATH)
-                    .contentType(CONTENT_TYPE)
-                    .content(searchRequestBody(companyIds = "[]", dataTypes = "[]", reportingPeriods = "[]"))
-                    .with(securityContext(mockSecurityContext)),
-            ).andExpect(status().isOk)
-            .andExpect(jsonPath("$[0].companyId").value(storedCompany.companyId))
-            .andExpect(jsonPath("$.length()").value(1))
+        val response =
+            performSearch(searchRequestBody(companyIds = "[]", dataTypes = "[]", reportingPeriods = "[]"))
+                .andExpect(status().isOk)
+                .andReturn()
+                .response
+        val result = readSearchResponse(response.contentAsString)
+
+        assertEquals(setOf(BasicDataDimensions(storedCompany.companyId, dataType.name, reportingPeriod)), result)
     }
 
     @Test
@@ -171,14 +197,10 @@ class NonSourceabilityControllerTest(
             currentlyActive = false,
         )
 
-        mockMvc
-            .perform(
-                post(SEARCH_NON_SOURCEABLE_PATH)
-                    .contentType(CONTENT_TYPE)
-                    .content(searchRequestBody())
-                    .with(securityContext(mockSecurityContext)),
-            ).andExpect(status().isOk)
-            .andExpect(jsonPath("$.length()").value(0))
+        val response = performSearch().andExpect(status().isOk).andReturn().response
+        val result = readSearchResponse(response.contentAsString)
+
+        assertEquals(emptySet<BasicDataDimensions>(), result)
     }
 
     @Test
@@ -196,14 +218,10 @@ class NonSourceabilityControllerTest(
             currentlyActive = false,
         )
 
-        mockMvc
-            .perform(
-                post(SEARCH_NON_SOURCEABLE_PATH)
-                    .contentType(CONTENT_TYPE)
-                    .content(searchRequestBody())
-                    .with(securityContext(mockSecurityContext)),
-            ).andExpect(status().isOk)
-            .andExpect(jsonPath("$.length()").value(0))
+        val response = performSearch().andExpect(status().isOk).andReturn().response
+        val result = readSearchResponse(response.contentAsString)
+
+        assertEquals(emptySet<BasicDataDimensions>(), result)
     }
 
     @Test
@@ -211,6 +229,94 @@ class NonSourceabilityControllerTest(
         mockMvc
             .perform(
                 post(SEARCH_NON_SOURCEABLE_PATH)
+                    .contentType(CONTENT_TYPE)
+                    .content(searchRequestBody()),
+            ).andExpect(status().isUnauthorized)
+    }
+
+    @Test
+    fun `grouped search returns the active non-sourceable triple matching filters`() {
+        markNonSourceable()
+
+        val response = performGroupedSearch().andExpect(status().isOk).andReturn().response
+        val result = readGroupedSearchResponse(response.contentAsString)
+
+        assertEquals(
+            mapOf(
+                storedCompany.companyId to
+                    mapOf(dataType.name to setOf(BasicDataDimensions(storedCompany.companyId, dataType.name, reportingPeriod))),
+            ),
+            result,
+        )
+    }
+
+    @Test
+    fun `grouped search treats empty lists as wildcards`() {
+        markNonSourceable()
+
+        val response =
+            performGroupedSearch(searchRequestBody(companyIds = "[]", dataTypes = "[]", reportingPeriods = "[]"))
+                .andExpect(status().isOk)
+                .andReturn()
+                .response
+        val result = readGroupedSearchResponse(response.contentAsString)
+
+        assertEquals(
+            mapOf(
+                storedCompany.companyId to
+                    mapOf(dataType.name to setOf(BasicDataDimensions(storedCompany.companyId, dataType.name, reportingPeriod))),
+            ),
+            result,
+        )
+    }
+
+    @Test
+    fun `grouped search excludes pending entries`() {
+        AuthenticationMock
+            .mockSecurityContext("uploader", "uploaderId", setOf(DatalandRealmRole.ROLE_USER, DatalandRealmRole.ROLE_UPLOADER))
+        nonSourceabilityInformationManager.processNonSourceabilityRequest(
+            NonSourceabilityRequest(
+                companyId = storedCompany.companyId,
+                dataType = dataType,
+                reportingPeriod = reportingPeriod,
+                reason = "Pending request",
+            ),
+            bypassQa = false,
+            currentlyActive = false,
+        )
+
+        val response = performGroupedSearch().andExpect(status().isOk).andReturn().response
+        val result = readGroupedSearchResponse(response.contentAsString)
+
+        assertEquals(emptyMap<String, Map<String, Set<BasicDataDimensions>>>(), result)
+    }
+
+    @Test
+    fun `grouped search excludes reversed entries`() {
+        markNonSourceable()
+        AuthenticationMock.mockSecurityContext("admin", "adminId", adminRoles)
+        nonSourceabilityInformationManager.processNonSourceabilityRequest(
+            NonSourceabilityRequest(
+                companyId = storedCompany.companyId,
+                dataType = dataType,
+                reportingPeriod = reportingPeriod,
+                reason = "Reversal",
+            ),
+            bypassQa = true,
+            currentlyActive = false,
+        )
+
+        val response = performGroupedSearch().andExpect(status().isOk).andReturn().response
+        val result = readGroupedSearchResponse(response.contentAsString)
+
+        assertEquals(emptyMap<String, Map<String, Set<BasicDataDimensions>>>(), result)
+    }
+
+    @Test
+    fun `grouped search returns 401 for unauthenticated request`() {
+        mockMvc
+            .perform(
+                post(SEARCH_NON_SOURCEABLE_GROUPED_PATH)
                     .contentType(CONTENT_TYPE)
                     .content(searchRequestBody()),
             ).andExpect(status().isUnauthorized)

--- a/dataland-backend/src/test/kotlin/org/dataland/datalandbackend/controller/NonSourceabilityControllerTest.kt
+++ b/dataland-backend/src/test/kotlin/org/dataland/datalandbackend/controller/NonSourceabilityControllerTest.kt
@@ -1,0 +1,218 @@
+package org.dataland.datalandbackend.controller
+
+import org.dataland.datalandbackend.DatalandBackend
+import org.dataland.datalandbackend.entities.StoredCompanyEntity
+import org.dataland.datalandbackend.model.DataType
+import org.dataland.datalandbackend.model.companies.CompanyInformation
+import org.dataland.datalandbackend.model.metainformation.NonSourceabilityRequest
+import org.dataland.datalandbackend.services.CompanyAlterationManager
+import org.dataland.datalandbackend.services.NonSourceabilityInformationManager
+import org.dataland.datalandbackend.utils.DefaultMocks
+import org.dataland.datalandmessagequeueutils.cloudevents.CloudEventMessageHandler
+import org.dataland.keycloakAdapter.auth.DatalandRealmRole
+import org.dataland.keycloakAdapter.utils.AuthenticationMock
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.reset
+import org.mockito.kotlin.whenever
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.security.core.context.SecurityContext
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.securityContext
+import org.springframework.test.annotation.DirtiesContext
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.transaction.annotation.Transactional
+
+private const val SEARCH_NON_SOURCEABLE_PATH = "/non-sourceable/search"
+private const val CONTENT_TYPE = "application/json"
+
+/**
+ * Endpoint test for POST /non-sourceable/search, exercising the full stack
+ * (controller -> NonSourceabilityInformationManager -> NonSourceabilityDataRepository -> H2)
+ * without mocking the business service layer. Only the CloudEventMessageHandler (RabbitMQ
+ * side effect) is mocked, matching the pattern used in MetaDataControllerNonSourceableTest.
+ */
+@SpringBootTest(
+    classes = [DatalandBackend::class],
+    properties = ["spring.profiles.active=nodb"],
+)
+@AutoConfigureMockMvc
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+@Transactional
+@DefaultMocks
+@MockitoBean(types = [CloudEventMessageHandler::class])
+class NonSourceabilityControllerTest(
+    @Autowired private val mockMvc: MockMvc,
+    @Autowired private val companyAlterationManager: CompanyAlterationManager,
+    @Autowired private val nonSourceabilityInformationManager: NonSourceabilityInformationManager,
+) {
+    private lateinit var storedCompany: StoredCompanyEntity
+    private val adminRoles = DatalandRealmRole.entries.toSet()
+    private val dataType = DataType("sfdr")
+    private val reportingPeriod = "2023"
+
+    private val mockSecurityContext = mock<SecurityContext>()
+
+    private val userAuthentication =
+        AuthenticationMock.mockJwtAuthentication(
+            username = "testuser",
+            userId = "test-user-id",
+            roles = setOf(DatalandRealmRole.ROLE_USER),
+        )
+
+    @BeforeEach
+    fun setup() {
+        AuthenticationMock
+            .mockSecurityContext("uploader", "uploaderId", setOf(DatalandRealmRole.ROLE_USER, DatalandRealmRole.ROLE_UPLOADER))
+        val companyInfo =
+            CompanyInformation(
+                companyName = "TestCo",
+                headquarters = "DE",
+                headquartersPostalCode = "10115",
+                countryCode = "DE",
+                companyContactDetails = emptyList(),
+                companyLegalForm = null,
+                sector = null,
+                website = null,
+                identifiers = emptyMap(),
+                companyAlternativeNames = null,
+                isTeaserCompany = false,
+                parentCompanyLei = null,
+            )
+        storedCompany = companyAlterationManager.addCompany(companyInfo)
+
+        reset(mockSecurityContext)
+        doReturn(userAuthentication).whenever(mockSecurityContext).authentication
+        SecurityContextHolder.setContext(mockSecurityContext)
+    }
+
+    private fun markNonSourceable(
+        period: String = reportingPeriod,
+        type: DataType = dataType,
+        currentlyActive: Boolean = true,
+    ) {
+        AuthenticationMock.mockSecurityContext("admin", "adminId", adminRoles)
+        nonSourceabilityInformationManager.processNonSourceabilityRequest(
+            NonSourceabilityRequest(
+                companyId = storedCompany.companyId,
+                dataType = type,
+                reportingPeriod = period,
+                reason = "No public source",
+            ),
+            bypassQa = true,
+            currentlyActive = currentlyActive,
+        )
+    }
+
+    private fun searchRequestBody(
+        companyIds: String = """["${storedCompany.companyId}"]""",
+        dataTypes: String = """["${dataType.name}"]""",
+        reportingPeriods: String = """["$reportingPeriod"]""",
+    ) = """
+        {
+            "companyIds": $companyIds,
+            "dataTypes": $dataTypes,
+            "reportingPeriods": $reportingPeriods
+        }
+        """.trimIndent()
+
+    @Test
+    fun `search returns the active non-sourceable triple matching filters`() {
+        markNonSourceable()
+
+        mockMvc
+            .perform(
+                post(SEARCH_NON_SOURCEABLE_PATH)
+                    .contentType(CONTENT_TYPE)
+                    .content(searchRequestBody())
+                    .with(securityContext(mockSecurityContext)),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$[0].companyId").value(storedCompany.companyId))
+            .andExpect(jsonPath("$[0].dataType").value(dataType.name))
+            .andExpect(jsonPath("$[0].reportingPeriod").value(reportingPeriod))
+            .andExpect(jsonPath("$.length()").value(1))
+    }
+
+    @Test
+    fun `search treats empty lists as wildcards`() {
+        markNonSourceable()
+
+        mockMvc
+            .perform(
+                post(SEARCH_NON_SOURCEABLE_PATH)
+                    .contentType(CONTENT_TYPE)
+                    .content(searchRequestBody(companyIds = "[]", dataTypes = "[]", reportingPeriods = "[]"))
+                    .with(securityContext(mockSecurityContext)),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$[0].companyId").value(storedCompany.companyId))
+            .andExpect(jsonPath("$.length()").value(1))
+    }
+
+    @Test
+    fun `search excludes pending entries`() {
+        AuthenticationMock
+            .mockSecurityContext("uploader", "uploaderId", setOf(DatalandRealmRole.ROLE_USER, DatalandRealmRole.ROLE_UPLOADER))
+        nonSourceabilityInformationManager.processNonSourceabilityRequest(
+            NonSourceabilityRequest(
+                companyId = storedCompany.companyId,
+                dataType = dataType,
+                reportingPeriod = reportingPeriod,
+                reason = "Pending request",
+            ),
+            bypassQa = false,
+            currentlyActive = false,
+        )
+
+        mockMvc
+            .perform(
+                post(SEARCH_NON_SOURCEABLE_PATH)
+                    .contentType(CONTENT_TYPE)
+                    .content(searchRequestBody())
+                    .with(securityContext(mockSecurityContext)),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.length()").value(0))
+    }
+
+    @Test
+    fun `search excludes reversed entries`() {
+        markNonSourceable()
+        AuthenticationMock.mockSecurityContext("admin", "adminId", adminRoles)
+        nonSourceabilityInformationManager.processNonSourceabilityRequest(
+            NonSourceabilityRequest(
+                companyId = storedCompany.companyId,
+                dataType = dataType,
+                reportingPeriod = reportingPeriod,
+                reason = "Reversal",
+            ),
+            bypassQa = true,
+            currentlyActive = false,
+        )
+
+        mockMvc
+            .perform(
+                post(SEARCH_NON_SOURCEABLE_PATH)
+                    .contentType(CONTENT_TYPE)
+                    .content(searchRequestBody())
+                    .with(securityContext(mockSecurityContext)),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.length()").value(0))
+    }
+
+    @Test
+    fun `search returns 401 for unauthenticated request`() {
+        mockMvc
+            .perform(
+                post(SEARCH_NON_SOURCEABLE_PATH)
+                    .contentType(CONTENT_TYPE)
+                    .content(searchRequestBody()),
+            ).andExpect(status().isUnauthorized)
+    }
+}

--- a/dataland-frontend/src/api-queries/backend/non-sourceability/nonSourceabilityKeys.ts
+++ b/dataland-frontend/src/api-queries/backend/non-sourceability/nonSourceabilityKeys.ts
@@ -1,0 +1,6 @@
+import type { DataDimensionSearchRequest } from '@clients/backend';
+
+export const nonSourceabilityKeys = {
+  all: ['nonSourceability'] as const,
+  search: (request: DataDimensionSearchRequest) => ['nonSourceability', 'search', request] as const,
+};

--- a/dataland-frontend/src/api-queries/backend/non-sourceability/nonSourceabilityKeys.ts
+++ b/dataland-frontend/src/api-queries/backend/non-sourceability/nonSourceabilityKeys.ts
@@ -3,4 +3,6 @@ import type { DataDimensionSearchRequest } from '@clients/backend';
 export const nonSourceabilityKeys = {
   all: ['nonSourceability'] as const,
   search: (request: DataDimensionSearchRequest) => ['nonSourceability', 'search', request] as const,
+  searchGroupedByCompanyAndFramework: (request: DataDimensionSearchRequest) =>
+    ['nonSourceability', 'searchGroupedByCompanyAndFramework', request] as const,
 };

--- a/dataland-frontend/src/api-queries/backend/non-sourceability/useSearchNonSourceabilityDimensionsGroupedByCompanyAndFrameworkQuery.ts
+++ b/dataland-frontend/src/api-queries/backend/non-sourceability/useSearchNonSourceabilityDimensionsGroupedByCompanyAndFrameworkQuery.ts
@@ -1,0 +1,37 @@
+import { type Ref, computed } from 'vue';
+import { useQuery, type UseQueryOptions, type UseQueryReturnType } from '@tanstack/vue-query';
+import { useApiClient } from '@/utils/useApiClient.ts';
+import { nonSourceabilityKeys } from '@/api-queries/backend/non-sourceability/nonSourceabilityKeys.ts';
+import type { BasicDataDimensions, DataDimensionSearchRequest } from '@clients/backend';
+/**
+ * Vue Query hook that fetches non-sourceable data dimensions matching the given search request, grouped by
+ * company and framework.
+ *
+ * Uses POST /non-sourceable/search/grouped.
+ *
+ * @param request - Reactive search request (companyIds/dataTypes/reportingPeriods filters).
+ * @param options - Additional query options (e.g. enabled).
+ * @returns Query result containing the matching non-sourceable BasicDataDimensions, grouped first by companyId
+ *          and then by framework (dataType).
+ */
+export function useSearchNonSourceableDimensionsGroupedByCompanyAndFrameworkQuery(
+  request: Readonly<Ref<DataDimensionSearchRequest>>,
+  options?: Omit<
+    UseQueryOptions<Record<string, Record<string, Set<BasicDataDimensions>>>, Error>,
+    'queryKey' | 'queryFn'
+  >
+): UseQueryReturnType<Record<string, Record<string, Set<BasicDataDimensions>>>, Error> {
+  const apiClientProvider = useApiClient();
+  const queryKey = computed(() => nonSourceabilityKeys.searchGroupedByCompanyAndFramework(request.value));
+  return useQuery<Record<string, Record<string, Set<BasicDataDimensions>>>, Error>({
+    queryKey,
+    queryFn: async () => {
+      const response =
+        await apiClientProvider.backendClients.nonSourceabilityController.searchNonSourceableDimensionsGroupedByCompanyAndFramework(
+          request.value
+        );
+      return response.data;
+    },
+    ...options,
+  });
+}

--- a/dataland-frontend/src/api-queries/backend/non-sourceability/useSearchNonSourceableDimensionsQuery.ts
+++ b/dataland-frontend/src/api-queries/backend/non-sourceability/useSearchNonSourceableDimensionsQuery.ts
@@ -1,0 +1,33 @@
+import { type Ref, computed } from 'vue';
+import { useQuery, type UseQueryOptions, type UseQueryReturnType } from '@tanstack/vue-query';
+import { useApiClient } from '@/utils/useApiClient.ts';
+import { nonSourceabilityKeys } from '@/api-queries/backend/non-sourceability/nonSourceabilityKeys.ts';
+import type { BasicDataDimensions, DataDimensionSearchRequest } from '@clients/backend';
+
+/**
+ * Vue Query hook that fetches the set of non-sourceable data dimensions matching the given search request.
+ *
+ * Uses POST /non-sourceable/search.
+ *
+ * @param request - Reactive search request (companyIds/dataTypes/reportingPeriods filters).
+ * @param options - Additional query options (e.g. enabled).
+ * @returns Query result containing the matching non-sourceable BasicDataDimensions.
+ */
+export function useSearchNonSourceableDimensionsQuery(
+  request: Readonly<Ref<DataDimensionSearchRequest>>,
+  options?: Omit<UseQueryOptions<Set<BasicDataDimensions>, Error>, 'queryKey' | 'queryFn'>
+): UseQueryReturnType<Set<BasicDataDimensions>, Error> {
+  const apiClientProvider = useApiClient();
+  const queryKey = computed(() => nonSourceabilityKeys.search(request.value));
+
+  return useQuery<Set<BasicDataDimensions>, Error>({
+    queryKey,
+    queryFn: async () => {
+      const response = await apiClientProvider.backendClients.nonSourceabilityController.searchNonSourceableDimensions(
+        request.value
+      );
+      return response.data;
+    },
+    ...options,
+  });
+}

--- a/dataland-frontend/src/components/generics/ViewMultipleDatasetsDisplayBase.vue
+++ b/dataland-frontend/src/components/generics/ViewMultipleDatasetsDisplayBase.vue
@@ -89,7 +89,9 @@ export default defineComponent({
       return this.frameworkConfiguration?.getFrameworkViewConfiguration();
     },
     nonSourceabilityInfoText(): string {
-      const periods = Array.from(this.nonSourceableDimensions ?? []).map((dim) => dim.reportingPeriod);
+      const periods = Array.from(this.nonSourceableDimensions ?? [])
+        .map((dim) => dim.reportingPeriod)
+        .sort();
       if (periods.length === 0) {
         return '';
       }

--- a/dataland-frontend/src/components/generics/ViewMultipleDatasetsDisplayBase.vue
+++ b/dataland-frontend/src/components/generics/ViewMultipleDatasetsDisplayBase.vue
@@ -19,6 +19,10 @@
           <div class="col-12 text-left">
             <h2 class="mb-0" data-test="frameworkDataTableTitle">{{ humanizeString(dataType) }}</h2>
           </div>
+          <!-- TODO: this box currently relies on mocked non-sourceability data (see script section); replace with real data once backend is ready -->
+          <div v-if="nonSourceabilityInfoText" class="col-12 non-sourceability-reporting-year-info my-3">
+            <span data-test="nonSourceabilityReportingYearInfo">{{ nonSourceabilityInfoText }}</span>
+          </div>
           <div class="col-12">
             <MultiLayerDataTableFrameworkPanel
               v-if="frameworkViewConfiguration?.type == 'MultiLayerDataTable'"
@@ -75,6 +79,64 @@ import {
   type FrontendFrameworkDefinition,
 } from '@/frameworks/BaseFrameworkDefinition';
 
+// TODO: remove this mock data once the backend endpoint / NonSourceabilityInfo.ts util is available
+const ReportingPeriodMock = {
+  Year2021: '2021',
+  Year2022: '2022',
+} as const;
+type ReportingPeriodMock = (typeof ReportingPeriodMock)[keyof typeof ReportingPeriodMock];
+
+// TODO: remove this mock interface once the backend endpoint / NonSourceabilityInfo.ts util is available
+interface NonSourceabilityTriple {
+  companyId: string;
+  dataType: DataTypeEnum;
+  reportingPeriod: ReportingPeriodMock;
+}
+
+// TODO: remove this mocked array once the backend endpoint / NonSourceabilityInfo.ts util is available
+const mockNonSourceableTriples: NonSourceabilityTriple[] = [
+  { companyId: 'TestCompany', dataType: 'sfdr' as DataTypeEnum, reportingPeriod: ReportingPeriodMock.Year2021 },
+  { companyId: 'TestCompany', dataType: 'sfdr' as DataTypeEnum, reportingPeriod: ReportingPeriodMock.Year2022 },
+];
+
+/**
+ * Simulates fetching the non-sourceability triples from the backend for the given company and data type.
+ * Currently ignores companyId/dataType and just returns the hardcoded mock data.
+ * TODO: replace this mock function with a real async call to NonSourceabilityInfo.ts once the backend endpoint is
+ * available. Once replaced, companyId/dataType will actually be used to fetch/filter the real data.
+ * @param companyId the company id (currently unused, will be used once the real backend call is wired in)
+ * @param dataType the data type / framework (currently unused, will be used once the real backend call is wired in)
+ * @returns an iterable of non-sourceability triples
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function getNonSourceabilityTriplesFromBackend(companyId: string, dataType: DataTypeEnum): NonSourceabilityTriple[] {
+  return mockNonSourceableTriples;
+}
+
+/**
+ * Builds the display text for the non-sourceable-periods info box, e.g.
+ * "For the following periods the data is non-sourceable: 2021, 2022".
+ * Extracts the reporting periods from the triples returned for the given company and data type.
+ * TODO: once getNonSourceabilityTriplesFromBackend is replaced with a real async call, this can no longer be a
+ * simple synchronous computed property. Instead, the fetched reporting periods need to be loaded asynchronously
+ * (e.g. in a watcher on companyId/dataType) into a reactive data() field, and only the text-building logic below
+ * should remain as a (still synchronous) computed property based on that reactive field.
+ * @param companyId the company id to fetch/filter by
+ * @param dataType the data type / framework to fetch/filter by
+ * @returns the display string, or an empty string if no non-sourceable periods exist
+ */
+function getNonSourceableReportingPeriodsText(companyId: string, dataType: DataTypeEnum): string {
+  const matchingPeriods = getNonSourceabilityTriplesFromBackend(companyId, dataType).map(
+    (triple) => triple.reportingPeriod
+  );
+
+  if (matchingPeriods.length === 0) {
+    return '';
+  }
+
+  return `For the following periods the data is non-sourceable: ${matchingPeriods.join(', ')}`;
+}
+
 export default defineComponent({
   name: 'ViewMultipleDatasetsDisplayBase',
   computed: {
@@ -83,6 +145,10 @@ export default defineComponent({
     },
     frameworkViewConfiguration(): FrameworkViewConfiguration<object> | undefined {
       return this.frameworkConfiguration?.getFrameworkViewConfiguration();
+    },
+    // TODO: remove this computed property's dependency on mock data once the real backend call is wired in
+    nonSourceabilityInfoText(): string {
+      return getNonSourceableReportingPeriodsText(this.companyId, this.dataType);
     },
   },
   components: {
@@ -276,3 +342,10 @@ export default defineComponent({
   },
 });
 </script>
+<style scoped>
+.non-sourceability-reporting-year-info {
+  background-color: var(--grey-tones-100);
+  border-radius: 8px;
+  padding: 0.75rem 1rem;
+}
+</style>

--- a/dataland-frontend/src/components/generics/ViewMultipleDatasetsDisplayBase.vue
+++ b/dataland-frontend/src/components/generics/ViewMultipleDatasetsDisplayBase.vue
@@ -19,7 +19,6 @@
           <div class="col-12 text-left">
             <h2 class="mb-0" data-test="frameworkDataTableTitle">{{ humanizeString(dataType) }}</h2>
           </div>
-          <!-- TODO: this box currently relies on mocked non-sourceability data (see script section); replace with real data once backend is ready -->
           <div v-if="nonSourceabilityInfoText" class="col-12 non-sourceability-reporting-year-info my-3">
             <span data-test="nonSourceabilityReportingYearInfo">{{ nonSourceabilityInfoText }}</span>
           </div>
@@ -64,7 +63,7 @@
 
 <script lang="ts">
 import ViewFrameworkBase from '@/components/generics/ViewFrameworkBase.vue';
-import { defineComponent, inject, type PropType } from 'vue';
+import { computed, defineComponent, inject, type PropType } from 'vue';
 import { type BasicDataDimensions, type DataMetaInformation, type DataTypeEnum, QaStatus } from '@clients/backend';
 import { humanizeStringOrNumber } from '@/utils/StringFormatter';
 import { ApiClientProvider } from '@/services/ApiClients';
@@ -78,64 +77,7 @@ import {
   type FrameworkViewConfiguration,
   type FrontendFrameworkDefinition,
 } from '@/frameworks/BaseFrameworkDefinition';
-
-// TODO: remove this mock data once the backend endpoint / NonSourceabilityInfo.ts util is available
-const ReportingPeriodMock = {
-  Year2021: '2021',
-  Year2022: '2022',
-} as const;
-type ReportingPeriodMock = (typeof ReportingPeriodMock)[keyof typeof ReportingPeriodMock];
-
-// TODO: remove this mock interface once the backend endpoint / NonSourceabilityInfo.ts util is available
-interface NonSourceabilityTriple {
-  companyId: string;
-  dataType: DataTypeEnum;
-  reportingPeriod: ReportingPeriodMock;
-}
-
-// TODO: remove this mocked array once the backend endpoint / NonSourceabilityInfo.ts util is available
-const mockNonSourceableTriples: NonSourceabilityTriple[] = [
-  { companyId: 'TestCompany', dataType: 'sfdr' as DataTypeEnum, reportingPeriod: ReportingPeriodMock.Year2021 },
-  { companyId: 'TestCompany', dataType: 'sfdr' as DataTypeEnum, reportingPeriod: ReportingPeriodMock.Year2022 },
-];
-
-/**
- * Simulates fetching the non-sourceability triples from the backend for the given company and data type.
- * Currently ignores companyId/dataType and just returns the hardcoded mock data.
- * TODO: replace this mock function with a real async call to NonSourceabilityInfo.ts once the backend endpoint is
- * available. Once replaced, companyId/dataType will actually be used to fetch/filter the real data.
- * @param companyId the company id (currently unused, will be used once the real backend call is wired in)
- * @param dataType the data type / framework (currently unused, will be used once the real backend call is wired in)
- * @returns an iterable of non-sourceability triples
- */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-function getNonSourceabilityTriplesFromBackend(companyId: string, dataType: DataTypeEnum): NonSourceabilityTriple[] {
-  return mockNonSourceableTriples;
-}
-
-/**
- * Builds the display text for the non-sourceable-periods info box, e.g.
- * "For the following periods the data is non-sourceable: 2021, 2022".
- * Extracts the reporting periods from the triples returned for the given company and data type.
- * TODO: once getNonSourceabilityTriplesFromBackend is replaced with a real async call, this can no longer be a
- * simple synchronous computed property. Instead, the fetched reporting periods need to be loaded asynchronously
- * (e.g. in a watcher on companyId/dataType) into a reactive data() field, and only the text-building logic below
- * should remain as a (still synchronous) computed property based on that reactive field.
- * @param companyId the company id to fetch/filter by
- * @param dataType the data type / framework to fetch/filter by
- * @returns the display string, or an empty string if no non-sourceable periods exist
- */
-function getNonSourceableReportingPeriodsText(companyId: string, dataType: DataTypeEnum): string {
-  const matchingPeriods = getNonSourceabilityTriplesFromBackend(companyId, dataType).map(
-    (triple) => triple.reportingPeriod
-  );
-
-  if (matchingPeriods.length === 0) {
-    return '';
-  }
-
-  return `For the following periods the data is non-sourceable: ${matchingPeriods.join(', ')}`;
-}
+import { useSearchNonSourceableDimensionsQuery } from '@/api-queries/backend/non-sourceability/useSearchNonSourceableDimensionsQuery';
 
 export default defineComponent({
   name: 'ViewMultipleDatasetsDisplayBase',
@@ -146,9 +88,12 @@ export default defineComponent({
     frameworkViewConfiguration(): FrameworkViewConfiguration<object> | undefined {
       return this.frameworkConfiguration?.getFrameworkViewConfiguration();
     },
-    // TODO: remove this computed property's dependency on mock data once the real backend call is wired in
     nonSourceabilityInfoText(): string {
-      return getNonSourceableReportingPeriodsText(this.companyId, this.dataType);
+      const periods = Array.from(this.nonSourceableDimensions ?? []).map((dim) => dim.reportingPeriod);
+      if (periods.length === 0) {
+        return '';
+      }
+      return `For the following periods the data is non-sourceable: ${periods.join(', ')}`;
     },
   },
   components: {
@@ -184,9 +129,16 @@ export default defineComponent({
       humanizedDataDescription: humanizeStringOrNumber(this.dataType),
     };
   },
-  setup() {
+  setup(props) {
+    const nonSourceabilityRequest = computed(() => ({
+      companyIds: [props.companyId],
+      dataTypes: [props.dataType],
+    }));
+    const { data: nonSourceableDimensions } = useSearchNonSourceableDimensionsQuery(nonSourceabilityRequest);
+
     return {
       getKeycloakPromise: inject<() => Promise<Keycloak>>('getKeycloakPromise'),
+      nonSourceableDimensions,
     };
   },
   watch: {

--- a/dataland-frontend/src/components/resources/companyCockpit/CompanyDatasetsPane.vue
+++ b/dataland-frontend/src/components/resources/companyCockpit/CompanyDatasetsPane.vue
@@ -49,6 +49,8 @@
           :number-of-provided-reporting-periods="
             aggregatedFrameworkDataSummary?.[framework]?.numberOfProvidedReportingPeriods
           "
+          :number-of-non-sourceable-reporting-periods="nonSourceablePeriodsByFramework[framework]?.length ?? 0"
+          :non-sourceable-reporting-periods="nonSourceablePeriodsByFramework[framework]"
           :data-test="`${framework}-summary-panel`"
         />
       </div>
@@ -112,6 +114,63 @@ const router = useRouter();
 /** local state (self-contained) */
 type SummaryByType = Partial<Record<DataTypeEnum, AggregatedFrameworkDataSummary>>;
 const aggregatedFrameworkDataSummary = ref<SummaryByType>({});
+
+// TODO: remove this mock data once the backend endpoint / NonSourceabilityInfo.ts util is available
+const ReportingPeriodMock = {
+  Year2019: '2019',
+  Year2020: '2020',
+  Year2021: '2021',
+  Year2022: '2022',
+  Year2023: '2023',
+} as const;
+type ReportingPeriodMock = (typeof ReportingPeriodMock)[keyof typeof ReportingPeriodMock];
+
+// TODO: remove this mock interface once the backend endpoint / NonSourceabilityInfo.ts util is available
+interface NonSourceabilityTriple {
+  companyId: string;
+  dataType: DataTypeEnum;
+  reportingPeriod: ReportingPeriodMock;
+}
+
+// TODO: remove this mocked array once the backend endpoint / NonSourceabilityInfo.ts util is available
+const mockNonSourceableTriples: NonSourceabilityTriple[] = [
+  { companyId: 'TestCompany', dataType: 'sfdr' as DataTypeEnum, reportingPeriod: ReportingPeriodMock.Year2021 },
+  { companyId: 'TestCompany', dataType: 'sfdr' as DataTypeEnum, reportingPeriod: ReportingPeriodMock.Year2022 },
+  {
+    companyId: 'TestCompany',
+    dataType: 'eutaxonomy-financials' as DataTypeEnum,
+    reportingPeriod: ReportingPeriodMock.Year2019,
+  },
+  {
+    companyId: 'TestCompany',
+    dataType: 'eutaxonomy-financials' as DataTypeEnum,
+    reportingPeriod: ReportingPeriodMock.Year2020,
+  },
+  {
+    companyId: 'TestCompany',
+    dataType: 'eutaxonomy-financials' as DataTypeEnum,
+    reportingPeriod: ReportingPeriodMock.Year2021,
+  },
+  {
+    companyId: 'TestCompany',
+    dataType: 'eutaxonomy-financials' as DataTypeEnum,
+    reportingPeriod: ReportingPeriodMock.Year2022,
+  },
+  {
+    companyId: 'TestCompany',
+    dataType: 'eutaxonomy-financials' as DataTypeEnum,
+    reportingPeriod: ReportingPeriodMock.Year2023,
+  },
+];
+
+// TODO: remove this computed helper once the backend field / util is available
+const nonSourceablePeriodsByFramework = computed<Partial<Record<DataTypeEnum, string[]>>>(() => {
+  const grouped: Partial<Record<DataTypeEnum, string[]>> = {};
+  for (const triple of mockNonSourceableTriples) {
+    (grouped[triple.dataType] ??= []).push(triple.reportingPeriod);
+  }
+  return grouped;
+});
 
 const FRAMEWORKS_ALL = ALL_FRAMEWORKS_IN_DISPLAYED_ORDER;
 const FRAMEWORKS_MAIN = MAIN_FRAMEWORKS_IN_ENUM_CLASS_ORDER;

--- a/dataland-frontend/src/components/resources/companyCockpit/CompanyDatasetsPane.vue
+++ b/dataland-frontend/src/components/resources/companyCockpit/CompanyDatasetsPane.vue
@@ -99,6 +99,7 @@ import {
   type DocumentMetaInfoResponse,
   SearchForDocumentMetaInformationDocumentCategoriesEnum,
 } from '@clients/documentmanager';
+import { useSearchNonSourceableDimensionsQuery } from '@/api-queries/backend/non-sourceability/useSearchNonSourceableDimensionsQuery';
 
 const props = defineProps<{ companyId: string }>();
 
@@ -115,59 +116,16 @@ const router = useRouter();
 type SummaryByType = Partial<Record<DataTypeEnum, AggregatedFrameworkDataSummary>>;
 const aggregatedFrameworkDataSummary = ref<SummaryByType>({});
 
-// TODO: remove this mock data once the backend endpoint / NonSourceabilityInfo.ts util is available
-const ReportingPeriodMock = {
-  Year2019: '2019',
-  Year2020: '2020',
-  Year2021: '2021',
-  Year2022: '2022',
-  Year2023: '2023',
-} as const;
-type ReportingPeriodMock = (typeof ReportingPeriodMock)[keyof typeof ReportingPeriodMock];
+const nonSourceabilityRequest = computed(() => ({ companyIds: [props.companyId] }));
+const { data: nonSourceableDimensions } = useSearchNonSourceableDimensionsQuery(nonSourceabilityRequest);
 
-// TODO: remove this mock interface once the backend endpoint / NonSourceabilityInfo.ts util is available
-interface NonSourceabilityTriple {
-  companyId: string;
-  dataType: DataTypeEnum;
-  reportingPeriod: ReportingPeriodMock;
-}
-
-// TODO: remove this mocked array once the backend endpoint / NonSourceabilityInfo.ts util is available
-const mockNonSourceableTriples: NonSourceabilityTriple[] = [
-  { companyId: 'TestCompany', dataType: 'sfdr' as DataTypeEnum, reportingPeriod: ReportingPeriodMock.Year2021 },
-  { companyId: 'TestCompany', dataType: 'sfdr' as DataTypeEnum, reportingPeriod: ReportingPeriodMock.Year2022 },
-  {
-    companyId: 'TestCompany',
-    dataType: 'eutaxonomy-financials' as DataTypeEnum,
-    reportingPeriod: ReportingPeriodMock.Year2019,
-  },
-  {
-    companyId: 'TestCompany',
-    dataType: 'eutaxonomy-financials' as DataTypeEnum,
-    reportingPeriod: ReportingPeriodMock.Year2020,
-  },
-  {
-    companyId: 'TestCompany',
-    dataType: 'eutaxonomy-financials' as DataTypeEnum,
-    reportingPeriod: ReportingPeriodMock.Year2021,
-  },
-  {
-    companyId: 'TestCompany',
-    dataType: 'eutaxonomy-financials' as DataTypeEnum,
-    reportingPeriod: ReportingPeriodMock.Year2022,
-  },
-  {
-    companyId: 'TestCompany',
-    dataType: 'eutaxonomy-financials' as DataTypeEnum,
-    reportingPeriod: ReportingPeriodMock.Year2023,
-  },
-];
-
-// TODO: remove this computed helper once the backend field / util is available
 const nonSourceablePeriodsByFramework = computed<Partial<Record<DataTypeEnum, string[]>>>(() => {
   const grouped: Partial<Record<DataTypeEnum, string[]>> = {};
-  for (const triple of mockNonSourceableTriples) {
-    (grouped[triple.dataType] ??= []).push(triple.reportingPeriod);
+  for (const dim of nonSourceableDimensions.value ?? []) {
+    (grouped[dim.dataType as DataTypeEnum] ??= []).push(dim.reportingPeriod);
+  }
+  for (const key of Object.keys(grouped) as DataTypeEnum[]) {
+    grouped[key]?.sort();
   }
   return grouped;
 });

--- a/dataland-frontend/src/components/resources/companyCockpit/CompanyDatasetsPane.vue
+++ b/dataland-frontend/src/components/resources/companyCockpit/CompanyDatasetsPane.vue
@@ -122,7 +122,9 @@ const { data: nonSourceableDimensions } = useSearchNonSourceableDimensionsQuery(
 const nonSourceablePeriodsByFramework = computed<Partial<Record<DataTypeEnum, string[]>>>(() => {
   const grouped: Partial<Record<DataTypeEnum, string[]>> = {};
   for (const dim of nonSourceableDimensions.value ?? []) {
-    (grouped[dim.dataType as DataTypeEnum] ??= []).push(dim.reportingPeriod);
+    const dataType = dim.dataType as DataTypeEnum;
+    grouped[dataType] ??= [];
+    grouped[dataType]!.push(dim.reportingPeriod);
   }
   for (const key of Object.keys(grouped) as DataTypeEnum[]) {
     grouped[key]?.sort();

--- a/dataland-frontend/src/components/resources/companyCockpit/FrameworkSummaryPanel.vue
+++ b/dataland-frontend/src/components/resources/companyCockpit/FrameworkSummaryPanel.vue
@@ -43,6 +43,25 @@
           <template v-else> Reporting Periods</template>
         </span>
       </div>
+      <div
+        v-if="(numberOfNonSourceableReportingPeriods ?? 0) > 0"
+        class="summary-panel__data summary-panel__non-sourceable"
+      >
+        <span class="summary-panel__value" :data-test="`${framework}-panel-non-sourceable-value`">
+          {{ numberOfNonSourceableReportingPeriods }}
+        </span>
+        <template v-if="numberOfNonSourceableReportingPeriods === 1"> non-sourceable Period</template>
+        <template v-else> non-sourceable Periods</template>
+        <em
+          class="material-icons info-icon"
+          aria-hidden="true"
+          :data-test="`${framework}-non-sourceable-info-icon`"
+          v-tooltip.top="{ value: nonSourceableInfoTooltipText }"
+          @click.stop
+        >
+          info
+        </em>
+      </div>
     </template>
     <template #footer>
       <div class="stacked-buttons">
@@ -75,11 +94,16 @@ import { getFrameworkSubtitle, getFrameworkTitle } from '@/utils/StringFormatter
 import { FRAMEWORKS_WITH_UPLOAD_FORM, FRAMEWORKS_WITH_VIEW_PAGE } from '@/utils/Constants';
 import Card from 'primevue/card';
 import Button from 'primevue/button';
+import Tooltip from 'primevue/tooltip';
+
+const vTooltip = Tooltip;
 
 const props = defineProps<{
   companyId: string;
   framework: DataTypeEnum;
   numberOfProvidedReportingPeriods?: number | null;
+  numberOfNonSourceableReportingPeriods?: number | null;
+  nonSourceableReportingPeriods?: string[] | null;
   isUserAllowedToUpload?: boolean;
 }>();
 
@@ -100,6 +124,12 @@ const showProvideDataButton = computed(
 );
 
 const showViewDataButton = computed(() => hasAccessibleViewPage.value);
+
+const nonSourceableInfoTooltipText = computed(() => {
+  const years = props.nonSourceableReportingPeriods ?? [];
+  if (years.length === 0) return '';
+  return `The following years are non-sourceable:\n${years.join(', ')}`;
+});
 
 /**
  * Handles the panel click event. Navigates to the framework page if
@@ -216,5 +246,13 @@ function onCursorLeaveProvideButton(): void {
   &__value {
     font-weight: 600;
   }
+}
+
+.info-icon {
+  cursor: help;
+  font-size: 16px;
+  margin-left: 4px;
+  vertical-align: middle;
+  color: var(--text-color-secondary);
 }
 </style>

--- a/dataland-frontend/src/components/resources/portfolio/PortfolioDetailsBase.vue
+++ b/dataland-frontend/src/components/resources/portfolio/PortfolioDetailsBase.vue
@@ -119,21 +119,11 @@
           :showFilterMatchModes="false"
         >
           <template #body="portfolioEntry">
-            <Button
-              v-if="portfolioEntry.data.frameworkHyphenatedNamesToDataRef.get(framework)"
-              :label="getAvailableReportingPeriods(portfolioEntry.data, framework)"
-              variant="link"
-              @click="router.push(portfolioEntry.data.frameworkHyphenatedNamesToDataRef.get(framework))"
-              :pt="{
-                label: {
-                  style: 'font-weight: normal; text-align: left;',
-                },
-                root: {
-                  style: 'padding-left: 0;',
-                },
-              }"
+            <PortfolioReportingPeriodsCell
+              :periods="getReportingPeriodEntries(portfolioEntry.data, framework)"
+              :clickable="hasClickableLink(portfolioEntry.data, framework)"
+              @navigate="router.push(portfolioEntry.data.frameworkHyphenatedNamesToDataRef.get(framework)!)"
             />
-            <span v-else>{{ getAvailableReportingPeriods(portfolioEntry.data, framework) }}</span>
           </template>
           <template #filter="{ filterModel, filterCallback }">
             <div :data-test="getFrameworkFieldKey(framework) + 'AvailableReportingPeriodsFilterOverlay'">
@@ -188,6 +178,36 @@ import type { AxiosError, AxiosRequestConfig } from 'axios';
 import { forceFileDownload, groupAllReportingPeriodsByFrameworkForPortfolio } from '@/utils/FileDownloadUtils.ts';
 import router from '@/router';
 import { pollExportJobStatus, prepareDownloadFile } from '@/utils/ExportUtils.ts';
+import PortfolioReportingPeriodsCell, {
+  type ReportingPeriodEntry,
+} from '@/components/resources/portfolio/PortfolioReportingPeriodsCell.vue';
+
+// TODO: remove this mock data once EnrichedPortfolioEntry provides non-sourceable reporting periods per
+// framework from the backend (computed in PortfolioEnrichmentService via a batched findActiveForCompanies lookup)
+const MOCKED_NON_SOURCEABLE_PERIODS_BY_FRAMEWORK: Partial<Record<string, string[]>> = {
+  [DataTypeEnum.Sfdr]: ['2019', '2027'],
+  [DataTypeEnum.EutaxonomyFinancials]: ['2025'],
+};
+
+/**
+ * Merges the (comma-separated) string of real, available reporting periods for a framework with the mocked
+ * non-sourceable reporting periods for that same framework, and returns a single, ascendingly sorted list where
+ * each entry is marked whether it is non-sourceable.
+ * TODO: replace the non-sourceable-periods argument with real data once the backend provides it.
+ * @param availableReportingPeriodsCsv the comma-separated string of real, available reporting periods
+ * @param framework the hyphenated framework name the reporting periods belong to
+ */
+function mergeReportingPeriods(
+  availableReportingPeriodsCsv: string | undefined,
+  framework: string
+): ReportingPeriodEntry[] {
+  const realYears = availableReportingPeriodsCsv ? availableReportingPeriodsCsv.split(', ') : [];
+  const nonSourceableYears = MOCKED_NON_SOURCEABLE_PERIODS_BY_FRAMEWORK[framework] ?? [];
+  const allYears = new Set([...realYears, ...nonSourceableYears]);
+  return Array.from(allYears)
+    .sort()
+    .map((year) => ({ year, nonSourceable: !realYears.includes(year) }));
+}
 
 /**
  * This class prepares raw `EnrichedPortfolioEntry` data for use in UI components
@@ -206,6 +226,11 @@ class PortfolioEntryPrepared {
   readonly eutaxonomyNonFinancialsAvailableReportingPeriods: string | undefined;
   readonly eutaxonomyNonFinancials202673AvailableReportingPeriods: string | undefined;
   readonly nuclearAndGasAvailableReportingPeriods: string | undefined;
+  readonly sfdrReportingPeriodEntries: ReportingPeriodEntry[];
+  readonly eutaxonomyFinancialsReportingPeriodEntries: ReportingPeriodEntry[];
+  readonly eutaxonomyNonFinancialsReportingPeriodEntries: ReportingPeriodEntry[];
+  readonly eutaxonomyNonFinancials202673ReportingPeriodEntries: ReportingPeriodEntry[];
+  readonly nuclearAndGasReportingPeriodEntries: ReportingPeriodEntry[];
 
   constructor(portfolioEntry: EnrichedPortfolioEntry) {
     this.companyId = portfolioEntry.companyId;
@@ -235,6 +260,27 @@ class PortfolioEntryPrepared {
       portfolioEntry.availableReportingPeriods[DataTypeEnum.EutaxonomyNonFinancials202673] || 'No data available';
     this.nuclearAndGasAvailableReportingPeriods =
       portfolioEntry.availableReportingPeriods[DataTypeEnum.NuclearAndGas] || 'No data available';
+
+    this.sfdrReportingPeriodEntries = mergeReportingPeriods(
+      portfolioEntry.availableReportingPeriods[DataTypeEnum.Sfdr],
+      DataTypeEnum.Sfdr
+    );
+    this.eutaxonomyFinancialsReportingPeriodEntries = mergeReportingPeriods(
+      portfolioEntry.availableReportingPeriods[DataTypeEnum.EutaxonomyFinancials],
+      DataTypeEnum.EutaxonomyFinancials
+    );
+    this.eutaxonomyNonFinancialsReportingPeriodEntries = mergeReportingPeriods(
+      portfolioEntry.availableReportingPeriods[DataTypeEnum.EutaxonomyNonFinancials],
+      DataTypeEnum.EutaxonomyNonFinancials
+    );
+    this.eutaxonomyNonFinancials202673ReportingPeriodEntries = mergeReportingPeriods(
+      portfolioEntry.availableReportingPeriods[DataTypeEnum.EutaxonomyNonFinancials202673],
+      DataTypeEnum.EutaxonomyNonFinancials202673
+    );
+    this.nuclearAndGasReportingPeriodEntries = mergeReportingPeriods(
+      portfolioEntry.availableReportingPeriods[DataTypeEnum.NuclearAndGas],
+      DataTypeEnum.NuclearAndGas
+    );
   }
 }
 
@@ -367,6 +413,42 @@ function getAvailableReportingPeriods(
     default:
       return undefined;
   }
+}
+
+/**
+ * For a given prepared portfolio entry and (hyphenated) framework name, return the merged list of
+ * available and non-sourceable reporting periods.
+ * @param portfolioEntryPrepared
+ * @param frameworkName
+ */
+function getReportingPeriodEntries(
+  portfolioEntryPrepared: PortfolioEntryPrepared,
+  frameworkName: string
+): ReportingPeriodEntry[] {
+  switch (frameworkName) {
+    case DataTypeEnum.Sfdr:
+      return portfolioEntryPrepared.sfdrReportingPeriodEntries;
+    case DataTypeEnum.EutaxonomyFinancials:
+      return portfolioEntryPrepared.eutaxonomyFinancialsReportingPeriodEntries;
+    case DataTypeEnum.EutaxonomyNonFinancials:
+      return portfolioEntryPrepared.eutaxonomyNonFinancialsReportingPeriodEntries;
+    case DataTypeEnum.EutaxonomyNonFinancials202673:
+      return portfolioEntryPrepared.eutaxonomyNonFinancials202673ReportingPeriodEntries;
+    case DataTypeEnum.NuclearAndGas:
+      return portfolioEntryPrepared.nuclearAndGasReportingPeriodEntries;
+    default:
+      return [];
+  }
+}
+
+/**
+ * Determines whether the reporting-periods cell for the given framework should be rendered as a clickable
+ * link, i.e. whether at least one real (non-strikethrough) reporting period exists.
+ * @param portfolioEntryPrepared
+ * @param frameworkName
+ */
+function hasClickableLink(portfolioEntryPrepared: PortfolioEntryPrepared, frameworkName: string): boolean {
+  return Boolean(portfolioEntryPrepared.frameworkHyphenatedNamesToDataRef.get(frameworkName));
 }
 
 /**

--- a/dataland-frontend/src/components/resources/portfolio/PortfolioDetailsBase.vue
+++ b/dataland-frontend/src/components/resources/portfolio/PortfolioDetailsBase.vue
@@ -181,28 +181,22 @@ import { pollExportJobStatus, prepareDownloadFile } from '@/utils/ExportUtils.ts
 import PortfolioReportingPeriodsCell, {
   type ReportingPeriodEntry,
 } from '@/components/resources/portfolio/PortfolioReportingPeriodsCell.vue';
-
-// TODO: remove this mock data once EnrichedPortfolioEntry provides non-sourceable reporting periods per
-// framework from the backend (computed in PortfolioEnrichmentService via a batched findActiveForCompanies lookup)
-const MOCKED_NON_SOURCEABLE_PERIODS_BY_FRAMEWORK: Partial<Record<string, string[]>> = {
-  [DataTypeEnum.Sfdr]: ['2019', '2027'],
-  [DataTypeEnum.EutaxonomyFinancials]: ['2025'],
-};
+import type { BasicDataDimensions } from '@clients/backend';
+import { useSearchNonSourceableDimensionsGroupedByCompanyAndFrameworkQuery } from '@/api-queries/backend/non-sourceability/useSearchNonSourceabilityDimensionsGroupedByCompanyAndFrameworkQuery.ts';
 
 /**
- * Merges the (comma-separated) string of real, available reporting periods for a framework with the mocked
- * non-sourceable reporting periods for that same framework, and returns a single, ascendingly sorted list where
- * each entry is marked whether it is non-sourceable.
- * TODO: replace the non-sourceable-periods argument with real data once the backend provides it.
+ * Merges the (comma-separated) string of real, available reporting periods for a framework with the real
+ * non-sourceable reporting periods for that same framework (from the backend), and returns a single,
+ * ascendingly sorted list where each entry is marked whether it is non-sourceable.
  * @param availableReportingPeriodsCsv the comma-separated string of real, available reporting periods
- * @param framework the hyphenated framework name the reporting periods belong to
+ * @param nonSourceableDimensionsForFramework the set of non-sourceable data dimensions for this company/framework
  */
 function mergeReportingPeriods(
   availableReportingPeriodsCsv: string | undefined,
-  framework: string
+  nonSourceableDimensionsForFramework: Set<BasicDataDimensions> | undefined
 ): ReportingPeriodEntry[] {
   const realYears = availableReportingPeriodsCsv ? availableReportingPeriodsCsv.split(', ') : [];
-  const nonSourceableYears = MOCKED_NON_SOURCEABLE_PERIODS_BY_FRAMEWORK[framework] ?? [];
+  const nonSourceableYears = Array.from(nonSourceableDimensionsForFramework ?? []).map((dim) => dim.reportingPeriod);
   const allYears = new Set([...realYears, ...nonSourceableYears]);
   return Array.from(allYears)
     .sort()
@@ -226,11 +220,6 @@ class PortfolioEntryPrepared {
   readonly eutaxonomyNonFinancialsAvailableReportingPeriods: string | undefined;
   readonly eutaxonomyNonFinancials202673AvailableReportingPeriods: string | undefined;
   readonly nuclearAndGasAvailableReportingPeriods: string | undefined;
-  readonly sfdrReportingPeriodEntries: ReportingPeriodEntry[];
-  readonly eutaxonomyFinancialsReportingPeriodEntries: ReportingPeriodEntry[];
-  readonly eutaxonomyNonFinancialsReportingPeriodEntries: ReportingPeriodEntry[];
-  readonly eutaxonomyNonFinancials202673ReportingPeriodEntries: ReportingPeriodEntry[];
-  readonly nuclearAndGasReportingPeriodEntries: ReportingPeriodEntry[];
 
   constructor(portfolioEntry: EnrichedPortfolioEntry) {
     this.companyId = portfolioEntry.companyId;
@@ -260,27 +249,6 @@ class PortfolioEntryPrepared {
       portfolioEntry.availableReportingPeriods[DataTypeEnum.EutaxonomyNonFinancials202673] || 'No data available';
     this.nuclearAndGasAvailableReportingPeriods =
       portfolioEntry.availableReportingPeriods[DataTypeEnum.NuclearAndGas] || 'No data available';
-
-    this.sfdrReportingPeriodEntries = mergeReportingPeriods(
-      portfolioEntry.availableReportingPeriods[DataTypeEnum.Sfdr],
-      DataTypeEnum.Sfdr
-    );
-    this.eutaxonomyFinancialsReportingPeriodEntries = mergeReportingPeriods(
-      portfolioEntry.availableReportingPeriods[DataTypeEnum.EutaxonomyFinancials],
-      DataTypeEnum.EutaxonomyFinancials
-    );
-    this.eutaxonomyNonFinancialsReportingPeriodEntries = mergeReportingPeriods(
-      portfolioEntry.availableReportingPeriods[DataTypeEnum.EutaxonomyNonFinancials],
-      DataTypeEnum.EutaxonomyNonFinancials
-    );
-    this.eutaxonomyNonFinancials202673ReportingPeriodEntries = mergeReportingPeriods(
-      portfolioEntry.availableReportingPeriods[DataTypeEnum.EutaxonomyNonFinancials202673],
-      DataTypeEnum.EutaxonomyNonFinancials202673
-    );
-    this.nuclearAndGasReportingPeriodEntries = mergeReportingPeriods(
-      portfolioEntry.availableReportingPeriods[DataTypeEnum.NuclearAndGas],
-      DataTypeEnum.NuclearAndGas
-    );
   }
 }
 
@@ -323,7 +291,29 @@ const portfolioCompanies = ref<CompanyIdAndName[]>([]);
 const isLoading = ref(true);
 const isError = ref(false);
 const isMonitored = ref<boolean>(false);
-
+const portfolioCompanyIds = computed(() => enrichedPortfolio.value?.entries.map((entry) => entry.companyId) ?? []);
+const nonSourceabilityRequest = computed(() => ({ companyIds: portfolioCompanyIds.value }));
+const { data: nonSourceableDimensionsGrouped } = useSearchNonSourceableDimensionsGroupedByCompanyAndFrameworkQuery(
+  nonSourceabilityRequest,
+  { enabled: computed(() => portfolioCompanyIds.value.length > 0) }
+);
+const reportingPeriodEntriesByCompanyAndFramework = computed<
+  Record<string, Partial<Record<string, ReportingPeriodEntry[]>>>
+>(() => {
+  const result: Record<string, Partial<Record<string, ReportingPeriodEntry[]>>> = {};
+  for (const entry of enrichedPortfolio.value?.entries ?? []) {
+    const perFramework: Partial<Record<string, ReportingPeriodEntry[]>> = {};
+    for (const framework of PORTFOLIO_OVERVIEW_FRAMEWORKS) {
+      const nonSourceableForFramework = nonSourceableDimensionsGrouped.value?.[entry.companyId]?.[framework];
+      perFramework[framework] = mergeReportingPeriods(
+        entry.availableReportingPeriods[framework],
+        nonSourceableForFramework
+      );
+    }
+    result[entry.companyId] = perFramework;
+  }
+  return result;
+});
 const monitoredTagAttributes = computed(() => ({
   value: isMonitored.value ? 'Portfolio actively monitored' : 'Portfolio not actively monitored',
   icon: isMonitored.value ? 'pi pi-check-circle' : 'pi pi-times-circle',
@@ -417,7 +407,7 @@ function getAvailableReportingPeriods(
 
 /**
  * For a given prepared portfolio entry and (hyphenated) framework name, return the merged list of
- * available and non-sourceable reporting periods.
+ * available and non-sourceable reporting periods, looked up from the pre-computed, cached map.
  * @param portfolioEntryPrepared
  * @param frameworkName
  */
@@ -425,20 +415,7 @@ function getReportingPeriodEntries(
   portfolioEntryPrepared: PortfolioEntryPrepared,
   frameworkName: string
 ): ReportingPeriodEntry[] {
-  switch (frameworkName) {
-    case DataTypeEnum.Sfdr:
-      return portfolioEntryPrepared.sfdrReportingPeriodEntries;
-    case DataTypeEnum.EutaxonomyFinancials:
-      return portfolioEntryPrepared.eutaxonomyFinancialsReportingPeriodEntries;
-    case DataTypeEnum.EutaxonomyNonFinancials:
-      return portfolioEntryPrepared.eutaxonomyNonFinancialsReportingPeriodEntries;
-    case DataTypeEnum.EutaxonomyNonFinancials202673:
-      return portfolioEntryPrepared.eutaxonomyNonFinancials202673ReportingPeriodEntries;
-    case DataTypeEnum.NuclearAndGas:
-      return portfolioEntryPrepared.nuclearAndGasReportingPeriodEntries;
-    default:
-      return [];
-  }
+  return reportingPeriodEntriesByCompanyAndFramework.value[portfolioEntryPrepared.companyId]?.[frameworkName] ?? [];
 }
 
 /**

--- a/dataland-frontend/src/components/resources/portfolio/PortfolioDetailsBase.vue
+++ b/dataland-frontend/src/components/resources/portfolio/PortfolioDetailsBase.vue
@@ -159,7 +159,7 @@ import { getCountryNameFromCountryCode } from '@/utils/CountryCodeConverter.ts';
 import { humanizeStringOrNumber } from '@/utils/StringFormatter.ts';
 import { assertDefined } from '@/utils/TypeScriptUtils.ts';
 import type { EnrichedPortfolio, EnrichedPortfolioEntry } from '@clients/userservice';
-import { type CompanyIdAndName, DataTypeEnum, ExportFileType } from '@clients/backend';
+import { type BasicDataDimensions, type CompanyIdAndName, DataTypeEnum, ExportFileType } from '@clients/backend';
 import { FilterMatchMode } from '@primevue/core/api';
 import type Keycloak from 'keycloak-js';
 import Button from 'primevue/button';
@@ -181,7 +181,6 @@ import { pollExportJobStatus, prepareDownloadFile } from '@/utils/ExportUtils.ts
 import PortfolioReportingPeriodsCell, {
   type ReportingPeriodEntry,
 } from '@/components/resources/portfolio/PortfolioReportingPeriodsCell.vue';
-import type { BasicDataDimensions } from '@clients/backend';
 import { useSearchNonSourceableDimensionsGroupedByCompanyAndFrameworkQuery } from '@/api-queries/backend/non-sourceability/useSearchNonSourceabilityDimensionsGroupedByCompanyAndFrameworkQuery.ts';
 
 /**

--- a/dataland-frontend/src/components/resources/portfolio/PortfolioReportingPeriodsCell.vue
+++ b/dataland-frontend/src/components/resources/portfolio/PortfolioReportingPeriodsCell.vue
@@ -1,0 +1,66 @@
+<template>
+  <Button v-if="clickable" variant="link" @click="$emit('navigate')" :pt="buttonPt">
+    <span v-tooltip.top="tooltipOptions">
+      <template v-for="(period, index) in periods" :key="period.year">
+        <span :class="{ 'non-sourceable-year': period.nonSourceable }">{{ period.year }}</span
+        ><template v-if="index < periods.length - 1">, </template>
+      </template>
+    </span>
+  </Button>
+  <span v-else v-tooltip.top="tooltipOptions">
+    <template v-if="periods.length === 0">No data available</template>
+    <template v-else>
+      <template v-for="(period, index) in periods" :key="period.year">
+        <span :class="{ 'non-sourceable-year': period.nonSourceable }">{{ period.year }}</span
+        ><template v-if="index < periods.length - 1">, </template>
+      </template>
+    </template>
+  </span>
+</template>
+
+<script setup lang="ts">
+import Button from 'primevue/button';
+import Tooltip from 'primevue/tooltip';
+import { computed } from 'vue';
+
+const vTooltip = Tooltip;
+
+/**
+ * A single reporting period, potentially marked as non-sourceable (i.e. it will be displayed struck through).
+ */
+export interface ReportingPeriodEntry {
+  year: string;
+  nonSourceable: boolean;
+}
+
+const NON_SOURCEABLE_TOOLTIP_TEXT = 'If a year number is strikethrough, the report of this year is non-sourceable';
+
+const props = defineProps<{
+  periods: ReportingPeriodEntry[];
+  clickable: boolean;
+}>();
+
+defineEmits<{
+  navigate: [];
+}>();
+
+const buttonPt = {
+  label: {
+    style: 'font-weight: normal; text-align: left;',
+  },
+  root: {
+    style: 'padding-left: 0;',
+  },
+};
+
+const tooltipOptions = computed(() =>
+  props.periods.some((period) => period.nonSourceable) ? { value: NON_SOURCEABLE_TOOLTIP_TEXT } : undefined
+);
+</script>
+
+<style scoped>
+.non-sourceable-year {
+  text-decoration: line-through;
+  text-decoration-thickness: 2px;
+}
+</style>

--- a/dataland-frontend/src/components/resources/portfolio/PortfolioReportingPeriodsCell.vue
+++ b/dataland-frontend/src/components/resources/portfolio/PortfolioReportingPeriodsCell.vue
@@ -33,7 +33,7 @@ export interface ReportingPeriodEntry {
   nonSourceable: boolean;
 }
 
-const NON_SOURCEABLE_TOOLTIP_TEXT = 'If a year number is strikethrough, the report of this year is non-sourceable';
+const NON_SOURCEABLE_TOOLTIP_TEXT = 'A struck-through year indicates that the report for this year is non-sourceable';
 
 const props = defineProps<{
   periods: ReportingPeriodEntry[];

--- a/dataland-frontend/src/services/ApiClients.ts
+++ b/dataland-frontend/src/services/ApiClients.ts
@@ -30,6 +30,7 @@ interface ApiBackendClients {
   dataAvailabilityController: backendApis.DataAvailabilityControllerApiInterface;
   metaDataController: backendApis.MetaDataControllerApiInterface;
   userUploadsController: backendApis.UserUploadsControllerApiInterface;
+  nonSourceabilityController: backendApis.NonSourceabilityControllerApiInterface;
 }
 
 interface ApiClients {
@@ -99,6 +100,7 @@ export class ApiClientProvider {
       dataAvailabilityController: backendClientFactory(backendApis.DataAvailabilityControllerApi),
       metaDataController: backendClientFactory(backendApis.MetaDataControllerApi),
       userUploadsController: backendClientFactory(backendApis.UserUploadsControllerApi),
+      nonSourceabilityController: backendClientFactory(backendApis.NonSourceabilityControllerApi),
     };
   }
 

--- a/dataland-frontend/tests/component/components/pages/ViewMultipleDatasetsDisplayBase.cy.ts
+++ b/dataland-frontend/tests/component/components/pages/ViewMultipleDatasetsDisplayBase.cy.ts
@@ -36,7 +36,12 @@ describe('Component test for the view multiple dataset display base component', 
     });
   });
 
-  it('Check if the toggle of hidden fields works for empty and conditional fields', () => {
+  /**
+   * Mounts the component with the standard set of intercepts (company info, LkSG data, viewable dimensions),
+   * plus a configurable mocked response for the non-sourceable dimensions search.
+   * @param nonSourceableSearchResponse the mocked response for POST /api/non-sourceable/search
+   */
+  function mountComponentWithMocks(nonSourceableSearchResponse: object[]): void {
     const mockDataAndMetaInfo: DataAndMetaInformation<LksgData> = buildDataAndMetaInformationMock(
       lksgMetaInfo,
       preparedFixtureLksgData
@@ -60,6 +65,8 @@ describe('Component test for the view multiple dataset display base component', 
         data: mockDataAndMetaInfo.data,
       }
     ).as('getLkSGData');
+    cy.intercept('POST', '/api/non-sourceable/search', nonSourceableSearchResponse).as('postNonSourceableSearch');
+
     //@ts-ignore
     cy.mountWithPlugins(ViewMultipleDatasetsDisplayBase, {
       keycloak: minimalKeycloakMock({}),
@@ -72,11 +79,34 @@ describe('Component test for the view multiple dataset display base component', 
 
     cy.wait('@postViewableDimensionsSearch');
     cy.wait('@getLkSGData');
+    cy.wait('@postNonSourceableSearch');
+  }
+
+  it('Check if the toggle of hidden fields works for empty and conditional fields', () => {
+    mountComponentWithMocks([]);
 
     checkToggleEmptyFieldsSwitch('Number of Employees');
     cy.get('tr[data-section-label="Social"]');
     cy.get('tr[data-section-label="Child labor"]');
     cy.get('td[data-cell-label="Employee(s) Under 15"]').should('not.exist');
+  });
+
+  it('Shows the non-sourceability info text when non-sourceable periods are returned', () => {
+    mountComponentWithMocks([
+      { companyId: 'mock-company-id', dataType: DataTypeEnum.Lksg, reportingPeriod: '2023' },
+      { companyId: 'mock-company-id', dataType: DataTypeEnum.Lksg, reportingPeriod: '2022' },
+    ]);
+
+    cy.get('[data-test="nonSourceabilityReportingYearInfo"]').should(
+      'have.text',
+      'For the following periods the data is non-sourceable: 2022, 2023'
+    );
+  });
+
+  it('Does not show a non-sourceability info text when no periods are non-sourceable', () => {
+    mountComponentWithMocks([]);
+
+    cy.get('[data-test="nonSourceabilityReportingYearInfo"]').should('not.exist');
   });
 });
 

--- a/dataland-frontend/tests/component/components/resources/companyCockpit/CompanyDatasetsPane.cy.ts
+++ b/dataland-frontend/tests/component/components/resources/companyCockpit/CompanyDatasetsPane.cy.ts
@@ -1,0 +1,48 @@
+import CompanyDatasetsPane from '@/components/resources/companyCockpit/CompanyDatasetsPane.vue';
+import { minimalKeycloakMock } from '@ct/testUtils/Keycloak';
+import { DataTypeEnum } from '@clients/backend';
+
+describe('Component test for the company datasets pane (non-sourceability)', () => {
+  // Valid UUID format required by isCompanyIdValid, used e.g. by the company-ownership check.
+  const companyId = 'ad50bc6e-eb04-4bf6-9e70-a4b1c1c8e161';
+
+  /**
+   * Mounts CompanyDatasetsPane with the standard set of intercepts needed for it to mount cleanly,
+   * plus a configurable mocked response for the non-sourceable dimensions search.
+   * @param nonSourceableSearchResponse the mocked response for POST /api/non-sourceable/search
+   */
+  function mountComponentWithMocks(nonSourceableSearchResponse: object[]): void {
+    cy.intercept('GET', `/api/companies/${companyId}/aggregated-framework-data-summary`, {}).as('getAggregatedSummary');
+    cy.intercept('HEAD', `/community/company-ownership/${companyId}`, { statusCode: 200, body: {} }).as(
+      'getCompanyOwnership'
+    );
+    cy.intercept('GET', '/documents/*', []).as('searchDocuments');
+    cy.intercept('POST', '/api/non-sourceable/search', nonSourceableSearchResponse).as('postNonSourceableSearch');
+
+    //@ts-ignore
+    cy.mountWithPlugins(CompanyDatasetsPane, {
+      keycloak: minimalKeycloakMock({}),
+      props: { companyId },
+    });
+
+    cy.wait('@getAggregatedSummary');
+    cy.wait('@getCompanyOwnership');
+    cy.wait('@postNonSourceableSearch');
+  }
+
+  it('Shows the correct non-sourceable count on the correct framework tile, grouped separately per framework', () => {
+    mountComponentWithMocks([
+      { companyId, dataType: DataTypeEnum.Sfdr, reportingPeriod: '2023' },
+      { companyId, dataType: DataTypeEnum.Sfdr, reportingPeriod: '2022' },
+      { companyId, dataType: DataTypeEnum.NuclearAndGas, reportingPeriod: '2023' },
+    ]);
+    cy.get(`[data-test="${DataTypeEnum.Sfdr}-panel-non-sourceable-value"]`).should('have.text', '2');
+    cy.get(`[data-test="${DataTypeEnum.NuclearAndGas}-panel-non-sourceable-value"]`).should('have.text', '1');
+  });
+
+  it('Does not show a non-sourceable hint on any tile when the response is empty', () => {
+    mountComponentWithMocks([]);
+
+    cy.get('[data-test="summaryPanels"]').find('.summary-panel__non-sourceable').should('not.exist');
+  });
+});

--- a/dataland-frontend/tests/component/components/resources/companyCockpit/FrameworkSummaryPanel.cy.ts
+++ b/dataland-frontend/tests/component/components/resources/companyCockpit/FrameworkSummaryPanel.cy.ts
@@ -1,0 +1,70 @@
+import FrameworkSummaryPanel from '@/components/resources/companyCockpit/FrameworkSummaryPanel.vue';
+import { DataTypeEnum } from '@clients/backend';
+
+describe('Component test for the framework summary panel (non-sourceability)', () => {
+  const companyId = 'ad50bc6e-eb04-4bf6-9e70-a4b1c1c8e161';
+  const framework = DataTypeEnum.Sfdr;
+
+  /**
+   * Mounts the FrameworkSummaryPanel component with standard companyId/framework props, plus the
+   * given non-sourceability related props.
+   * @param props the non-sourceability related props to mount the component with
+   */
+  function mountComponent(props: {
+    numberOfNonSourceableReportingPeriods?: number | null;
+    nonSourceableReportingPeriods?: string[] | null;
+  }): void {
+    //@ts-ignore
+    cy.mountWithPlugins(FrameworkSummaryPanel, {
+      props: {
+        companyId,
+        framework,
+        ...props,
+      },
+    });
+  }
+
+  it('Does not show a non-sourceable info block when there are no non-sourceable periods', () => {
+    mountComponent({ numberOfNonSourceableReportingPeriods: 0 });
+
+    cy.get(`[data-test="${framework}-panel-non-sourceable-value"]`).should('not.exist');
+  });
+
+  it('Shows singular wording for exactly one non-sourceable period', () => {
+    mountComponent({
+      numberOfNonSourceableReportingPeriods: 1,
+      nonSourceableReportingPeriods: ['2023'],
+    });
+
+    cy.get(`[data-test="${framework}-panel-non-sourceable-value"]`).should('have.text', '1');
+    cy.get(`[data-test="${framework}-panel-non-sourceable-value"]`)
+      .parent()
+      .should('contain.text', 'non-sourceable Period')
+      .and('not.contain.text', 'non-sourceable Periods');
+  });
+
+  it('Shows plural wording for multiple non-sourceable periods', () => {
+    mountComponent({
+      numberOfNonSourceableReportingPeriods: 3,
+      nonSourceableReportingPeriods: ['2021', '2022', '2023'],
+    });
+
+    cy.get(`[data-test="${framework}-panel-non-sourceable-value"]`).should('have.text', '3');
+    cy.get(`[data-test="${framework}-panel-non-sourceable-value"]`)
+      .parent()
+      .should('contain.text', 'non-sourceable Periods');
+  });
+
+  it('Shows the correct tooltip content when hovering over the info icon', () => {
+    mountComponent({
+      numberOfNonSourceableReportingPeriods: 2,
+      nonSourceableReportingPeriods: ['2022', '2023'],
+    });
+
+    cy.get(`[data-test="${framework}-non-sourceable-info-icon"]`).trigger('mouseenter', 'center');
+    cy.get('.p-tooltip')
+      .should('be.visible')
+      .should('contain.text', 'The following years are non-sourceable:')
+      .and('contain.text', '2022, 2023');
+  });
+});

--- a/dataland-frontend/tests/component/components/resources/portfolio/PortfolioDetailsBase.cy.ts
+++ b/dataland-frontend/tests/component/components/resources/portfolio/PortfolioDetailsBase.cy.ts
@@ -1,0 +1,48 @@
+import PortfolioDetailsBase from '@/components/resources/portfolio/PortfolioDetailsBase.vue';
+import { type EnrichedPortfolio } from '@clients/userservice';
+import { minimalKeycloakMock } from '@ct/testUtils/Keycloak';
+import { DataTypeEnum } from '@clients/backend';
+
+describe('Component test for the portfolio details base component (non-sourceability)', () => {
+  let portfolioFixture: EnrichedPortfolio;
+
+  before(function () {
+    cy.fixture('enrichedPortfolio.json').then(function (jsonContent) {
+      portfolioFixture = {
+        ...(jsonContent as EnrichedPortfolio),
+        sharedUserIds: [] as unknown as Set<string>,
+      } as EnrichedPortfolio;
+    });
+  });
+
+  it('Merges non-sourceable periods into the correct cell (struck through, sorted) while leaving other cells unaffected', () => {
+    const apricotCompanyId = '55211efc-5502-430e-89b5-afed16a44407';
+
+    cy.intercept('**/users/portfolios/*/enriched-portfolio', portfolioFixture).as('getEnrichedPortfolio');
+    cy.intercept('POST', '/api/non-sourceable/search/grouped', {
+      [apricotCompanyId]: {
+        [DataTypeEnum.Sfdr]: [{ companyId: apricotCompanyId, dataType: DataTypeEnum.Sfdr, reportingPeriod: '2022' }],
+      },
+    }).as('postNonSourceableSearchGrouped');
+
+    //@ts-ignore
+    cy.mountWithPlugins(PortfolioDetailsBase, {
+      keycloak: minimalKeycloakMock({}),
+      props: { portfolioId: portfolioFixture.portfolioId },
+    });
+
+    cy.wait('@getEnrichedPortfolio');
+    cy.wait('@postNonSourceableSearchGrouped');
+
+    // Apricot Inc. (row 1) / SFDR (column 4): real period 2024 merged with non-sourceable 2022, sorted ascending.
+    const apricotSfdrCell = 'table tr:first-child td:nth-child(4)';
+    cy.get(apricotSfdrCell).should('contain.text', '2022, 2024');
+    cy.get(apricotSfdrCell).find('.non-sourceable-year').should('have.length', 1).and('have.text', '2022');
+
+    // Banana LLC (row 2) / EU Taxonomy Financials (column 5): no non-sourceable data mocked for it,
+    // so it must show its real period without any strikethrough.
+    const bananaEutaxonomyFinancialsCell = 'table tr:nth-child(2) td:nth-child(5)';
+    cy.get(bananaEutaxonomyFinancialsCell).should('contain.text', '2023');
+    cy.get(bananaEutaxonomyFinancialsCell).find('.non-sourceable-year').should('not.exist');
+  });
+});

--- a/dataland-frontend/tests/component/components/resources/portfolio/PortfolioReportingPeriodsCell.cy.ts
+++ b/dataland-frontend/tests/component/components/resources/portfolio/PortfolioReportingPeriodsCell.cy.ts
@@ -1,0 +1,75 @@
+import PortfolioReportingPeriodsCell, {
+  type ReportingPeriodEntry,
+} from '@/components/resources/portfolio/PortfolioReportingPeriodsCell.vue';
+
+describe('Component test for the portfolio reporting periods cell (non-sourceability)', () => {
+  /**
+   * Mounts the PortfolioReportingPeriodsCell component with the given periods and clickable flag.
+   * @param periods the reporting periods to display
+   * @param clickable whether the cell should be rendered as a clickable button
+   */
+  function mountComponent(
+    periods: ReportingPeriodEntry[],
+    clickable: boolean
+  ): Cypress.Chainable<{ wrapper: { emitted: () => Record<string, unknown[]> } }> {
+    //@ts-ignore
+    return cy.mountWithPlugins(PortfolioReportingPeriodsCell, {
+      props: { periods, clickable },
+    });
+  }
+
+  it('Shows "No data available" when there are no periods (non-clickable)', () => {
+    mountComponent([], false);
+
+    cy.contains('No data available').should('exist');
+    cy.get('.non-sourceable-year').should('not.exist');
+  });
+
+  it('Shows periods comma-separated without strikethrough when none are non-sourceable', () => {
+    mountComponent(
+      [
+        { year: '2022', nonSourceable: false },
+        { year: '2023', nonSourceable: false },
+      ],
+      false
+    );
+
+    cy.get('span').should('contain.text', '2022, 2023');
+    cy.get('.non-sourceable-year').should('not.exist');
+  });
+
+  it('Shows non-sourceable periods struck through and with a tooltip', () => {
+    mountComponent(
+      [
+        { year: '2022', nonSourceable: true },
+        { year: '2023', nonSourceable: false },
+      ],
+      false
+    );
+
+    cy.get('.non-sourceable-year').should('have.length', 1).and('have.text', '2022');
+    cy.get('span').first().trigger('mouseenter', 'center');
+    cy.get('.p-tooltip')
+      .should('be.visible')
+      .and('contain.text', 'If a year number is strikethrough, the report of this year is non-sourceable');
+  });
+
+  it('Renders as a clickable button, still shows strikethrough/tooltip, and emits navigate on click', () => {
+    mountComponent(
+      [
+        { year: '2022', nonSourceable: true },
+        { year: '2023', nonSourceable: false },
+      ],
+      true
+    ).then(({ wrapper }) => {
+      cy.get('button').should('exist');
+      cy.get('.non-sourceable-year').should('have.length', 1).and('have.text', '2022');
+
+      cy.get('button')
+        .click()
+        .then(() => {
+          cy.wrap(wrapper.emitted()).should('have.property', 'navigate');
+        });
+    });
+  });
+});

--- a/dataland-frontend/tests/component/components/resources/portfolio/PortfolioReportingPeriodsCell.cy.ts
+++ b/dataland-frontend/tests/component/components/resources/portfolio/PortfolioReportingPeriodsCell.cy.ts
@@ -51,7 +51,7 @@ describe('Component test for the portfolio reporting periods cell (non-sourceabi
     cy.get('span').first().trigger('mouseenter', 'center');
     cy.get('.p-tooltip')
       .should('be.visible')
-      .and('contain.text', 'If a year number is strikethrough, the report of this year is non-sourceable');
+      .and('contain.text', 'A struck-through year indicates that the report for this year is non-sourceable');
   });
 
   it('Renders as a clickable button, still shows strikethrough/tooltip, and emits navigate on click', () => {

--- a/dataland-frontend/tests/component/testUtils/Mount.ts
+++ b/dataland-frontend/tests/component/testUtils/Mount.ts
@@ -12,6 +12,7 @@ import { assertDefined } from '@/utils/TypeScriptUtils';
 import { defaultConfig, plugin } from '@formkit/vue';
 import { computed, defineComponent, h } from 'vue';
 import DynamicDialog from 'primevue/dynamicdialog';
+import { QueryClient, VueQueryPlugin } from '@tanstack/vue-query';
 
 interface DatalandMountOptions {
   /**
@@ -62,7 +63,8 @@ export function getMountingFunction(additionalOptions: DatalandMountOptions = {}
           },
         },
       ],
-      DialogService
+      DialogService,
+      [VueQueryPlugin, { queryClient: new QueryClient() }]
     );
     options.global.provide = options.global.provide ?? {};
 
@@ -89,13 +91,12 @@ export function getMountingFunction(additionalOptions: DatalandMountOptions = {}
     }
 
     if (additionalOptions.keycloak) {
-      options.global.provide.apiClientProvider = computed(
-        () => new ApiClientProvider(Promise.resolve(options.keycloak))
-      );
+      const keycloak = additionalOptions.keycloak;
+      options.global.provide.apiClientProvider = computed(() => new ApiClientProvider(Promise.resolve(keycloak)));
       options.global.provide.getKeycloakPromise = (): Promise<Keycloak | undefined> => {
-        return Promise.resolve(additionalOptions.keycloak);
+        return Promise.resolve(keycloak);
       };
-      options.global.provide.authenticated = additionalOptions.keycloak.authenticated;
+      options.global.provide.authenticated = keycloak.authenticated;
     }
 
     options.global.plugins.push(

--- a/dataland-frontend/tests/component/testUtils/Mount.ts
+++ b/dataland-frontend/tests/component/testUtils/Mount.ts
@@ -10,7 +10,7 @@ import { routes } from '@/router';
 import { ApiClientProvider } from '@/services/ApiClients';
 import { assertDefined } from '@/utils/TypeScriptUtils';
 import { defaultConfig, plugin } from '@formkit/vue';
-import { defineComponent, h } from 'vue';
+import { computed, defineComponent, h } from 'vue';
 import DynamicDialog from 'primevue/dynamicdialog';
 
 interface DatalandMountOptions {
@@ -89,7 +89,9 @@ export function getMountingFunction(additionalOptions: DatalandMountOptions = {}
     }
 
     if (additionalOptions.keycloak) {
-      options.global.provide.apiClientProvider = new ApiClientProvider(Promise.resolve(options.keycloak));
+      options.global.provide.apiClientProvider = computed(
+        () => new ApiClientProvider(Promise.resolve(options.keycloak))
+      );
       options.global.provide.getKeycloakPromise = (): Promise<Keycloak | undefined> => {
         return Promise.resolve(additionalOptions.keycloak);
       };

--- a/dataland-frontend/tests/component/testUtils/MountWithPlugins.ts
+++ b/dataland-frontend/tests/component/testUtils/MountWithPlugins.ts
@@ -12,6 +12,7 @@ import type Keycloak from 'keycloak-js';
 import { assertDefined } from '@/utils/TypeScriptUtils';
 import DynamicDialog from 'primevue/dynamicdialog';
 import { ApiClientProvider } from '@/services/ApiClients';
+import { QueryClient, VueQueryPlugin } from '@tanstack/vue-query';
 
 /*
   This file defines a alternative mounting function that also includes many creature comforts
@@ -92,7 +93,8 @@ function mountWithPlugins<T extends DefineComponent<any, any, any, any, any>>(
         },
       },
     ],
-    DialogService
+    DialogService,
+    [VueQueryPlugin, { queryClient: new QueryClient() }]
   );
   options.global.provide = options.global.provide ?? {};
 
@@ -102,11 +104,12 @@ function mountWithPlugins<T extends DefineComponent<any, any, any, any, any>>(
   });
 
   if (options.keycloak) {
-    options.global.provide.apiClientProvider = computed(() => new ApiClientProvider(Promise.resolve(options.keycloak)));
+    const keycloak = options.keycloak;
+    options.global.provide.apiClientProvider = computed(() => new ApiClientProvider(Promise.resolve(keycloak)));
     options.global.provide.getKeycloakPromise = (): Promise<Keycloak> => {
-      return Promise.resolve(options.keycloak as Keycloak);
+      return Promise.resolve(keycloak);
     };
-    options.global.provide.authenticated = options.keycloak.authenticated;
+    options.global.provide.authenticated = keycloak.authenticated;
   }
 
   options.global.plugins.push(

--- a/dataland-frontend/tests/component/testUtils/MountWithPlugins.ts
+++ b/dataland-frontend/tests/component/testUtils/MountWithPlugins.ts
@@ -7,7 +7,7 @@ import { plugin, defaultConfig } from '@formkit/vue';
 import { createMemoryHistory, createRouter, type Router } from 'vue-router';
 import { mount } from 'cypress/vue';
 import { type VueWrapper } from '@vue/test-utils';
-import { type DefineComponent, defineComponent, h } from 'vue';
+import { computed, type DefineComponent, defineComponent, h } from 'vue';
 import type Keycloak from 'keycloak-js';
 import { assertDefined } from '@/utils/TypeScriptUtils';
 import DynamicDialog from 'primevue/dynamicdialog';
@@ -102,7 +102,7 @@ function mountWithPlugins<T extends DefineComponent<any, any, any, any, any>>(
   });
 
   if (options.keycloak) {
-    options.global.provide.apiClientProvider = new ApiClientProvider(Promise.resolve(options.keycloak));
+    options.global.provide.apiClientProvider = computed(() => new ApiClientProvider(Promise.resolve(options.keycloak)));
     options.global.provide.getKeycloakPromise = (): Promise<Keycloak> => {
       return Promise.resolve(options.keycloak as Keycloak);
     };


### PR DESCRIPTION
… with mocked data. The mocked data has to be replaced with the backend call, after the implementation in the backend is ready.

# Pull Request \<Title>
`<Description here>`
## Things to do during Peer Review
Please check all boxes before the Pull Request is merged. In case you skip a box, describe in the PRs description (that means: here) why the check is skipped.
- [x] The GitHub Actions for the CI are green. This is enforced by GitHub. 
- [x] The PR has been peer-reviewed
  - [x] The code has been manually inspected by someone who did not implement the feature
  - [x] The changes have been inspected for possible breaking API changes (changed data models, endpoints, response codes, exception handling, ...). If there are any discuss them with the team.
  - [x] If this PR includes work on the frontend, at least one `@ts-nocheck` is removed. Additionally, there should not be any `@ts-nocheck` in files modified by this PR. If no `@ts-nocheck` are left: Celebrate :tada: :confetti_ball: type-safety and remove this entry. 
- [x] The PR actually implements what is described in the JIRA-Issue
- [x] Make sure you understand the entire workflow from the user’s perspective, and test/review it accordingly. If anything is unclear, please reach out to the dev team.
- [x] At least one test exists testing the new feature
  - [x] Make sure all newly added functionality (especially user facing) is tested
  - [x] Make sure that new test files are included in a test container and actually run in the CI
- [x] At least 3 consecutive CI runs are successfully executed to ensure that there are no flaky tests.
- [x] Documentation is updated as required. If unsure whether or what to update, ask a fellow developer.
- [x] If there was a database entity class added, there must also be a migration script for creating the corresponding database if flyway is already used by the service
- [ ] IF there are changes done to the framework data models or to a database entity class, the following steps were completed in order
  - [ ] A fresh clone of dataland.com is generated (see Wiki page on "OTC" for details)
  - [ ] The feature branch is deployed to clone with `Reset non-user related Docker Volumes & Re-populate` turned off
  - [ ] It's verified that the CD run is green
  - [ ] The new feature is manually used/tested/observed on the clone server. Testing of the new feature should (also) be done by a second, independent reviewer from the dev team
  - [ ] The feature branch is deployed to one of the dev servers with `Reset non-user related Docker Volumes & Re-populate` turned on, and it's verified that the CD run is green
- [x] ELSE, the new version is deployed to one of the dev servers using this branch
  - [x] Run with setting `Reset non-user related Docker Volumes & Re-populate` turned on 
  - [x] It's verified that this version actually is the one deployed (check gitinfo for branch name and commit id!)
  - [x] It's verified that the CD run is green
  - [x] The new feature is manually used/tested/observed on dev server. Testing of the new feature should (also) be done by a second, independent reviewer from the dev team
- [x] Confirm that the latest version (use the /gitinfo endpoint) of the feature branch is deployed to one of the dev servers (no longer enforced by GitHub)
- [ ] Ensure that the release notes are written in a way that is understandable to a non-technical audience.
